### PR TITLE
chore: fix docs index

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,7 +18,7 @@ All resources require authentication. API keys can be obtained from your Latitud
 
 `variables.tf` example
 
-{{ tffile "examples/variables.tf }}
+{{ tffile "examples/variables.tf" }}
 
 `latitude_server.tf` example
 


### PR DESCRIPTION
#### What does this PR do?
Fixes a typo on `templates/index.md.tmpl`