### PR TITLE
fix: Standardizes `latitudesh` across the provider and changes `project_id` to `project`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,8 +22,8 @@ https://github.com/latitudesh/terraform-provider-latitudesh/discussions
 
 ### Affected Resource(s)
 <!-- Please list the resources, for example:
-- latitude_server
-- latitude_region
+- latitudesh_server
+- latitudesh_region
 
 ### Expected Behavior
 <!-- What should have happened? -->

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mac
 
 ```sh
 $ mkdir -p ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/[VERSION]/darwin_amd64
-$ mv terraform-provider-latitude ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/[VERSION]/darwin_amd64
+$ mv terraform-provider-latitudesh ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/[VERSION]/darwin_amd64
 ```
 
 Linux

--- a/examples/latitude_plan.tf
+++ b/examples/latitude_plan.tf
@@ -1,3 +1,3 @@
-data "latitude_plan" "plan" {
+data "latitudesh_plan" "plan" {
   name = var.plan
 }

--- a/examples/latitude_project.tf
+++ b/examples/latitude_project.tf
@@ -1,5 +1,5 @@
-resource "latitude_project" "project" {
-  name = "foo"
-  description = "bar"
-  environment = "Development"
+resource "latitudesh_project" "project" {
+  name = "Project name"
+  description = "Description of project"
+  environment = "Development" # Development, Production or Staging
 }

--- a/examples/latitude_region.tf
+++ b/examples/latitude_region.tf
@@ -1,3 +1,3 @@
-data "latitude_region" "region" {
+data "latitudesh_region" "region" {
   slug = var.region
 }

--- a/examples/latitude_server.tf
+++ b/examples/latitude_server.tf
@@ -1,8 +1,8 @@
-resource "latitude_server" "server" {
-  hostname = "foo"
-  operating_system = "ubuntu_20_04_x64_lts"
-  plan = data.latitude_plan.plan.slug
-  project_id = latitude_project.project.id
-  site = data.latitude_region.region.slug
-  ssh_keys = [latitude_ssh_key.ssh_key.id]
+resource "latitudesh_server" "server" {
+  hostname         = "terraform.latitude.sh"
+  operating_system = "ubuntu_22_04_x64_lts"
+  plan             = data.latitudesh_plan.plan.slug
+  project          = latitudesh_project.project.id # You can use the project id or slug
+  site             = data.latitudesh_region.region.slug # You can use the site id or slug
+  ssh_keys         = [latitudesh_ssh_key.ssh_key.id]
 }

--- a/examples/latitude_ssh_key.tf
+++ b/examples/latitude_ssh_key.tf
@@ -1,5 +1,5 @@
-resource "latitude_ssh_key" "ssh_key" {
-  project_id = latitude_project.project.id
-  name = "bar"
+resource "latitudesh_ssh_key" "ssh_key" {
+  project    = latitudesh_project.project.id
+  name       = "John's Key"
   public_key = var.ssh_public_key
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
-    latitude = {
+    latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "~> 0.1.2"
+      version = "~> 0.1.4"
     }
   }
 }
 
 # Configure the provider
-provider "latitude" {
-  auth_token = var.latitude_token
+provider "latitudesh" {
+  auth_token = var.latitudesh_token
 }

--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -1,3 +1,3 @@
 output "server-ip" {
-  value = latitude_server.server.primary_ip_v4
+  value = latitudesh_server.server.primary_ip_v4
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,4 +1,4 @@
-variable "latitude_token" {
+variable "latitudesh_token" {
   description = "Latitude.sh API token"
 }
 

--- a/latitudesh/datasource_plan.go
+++ b/latitudesh/datasource_plan.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"

--- a/latitudesh/datasource_plan_test.go
+++ b/latitudesh/datasource_plan_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func TestAccPlan_Basic(t *testing.T) {
 				Config: testAccCheckPlanBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.latitude_plan.test", "name", testPlanName),
+						"data.latitudesh_plan.test", "name", testPlanName),
 				),
 			},
 		},
@@ -27,7 +27,7 @@ func TestAccPlan_Basic(t *testing.T) {
 
 func testAccCheckPlanBasic() string {
 	return fmt.Sprintf(`
-data "latitude_plan" "test" {
+data "latitudesh_plan" "test" {
 	name = "%s"
 }
 `,

--- a/latitudesh/datasource_region.go
+++ b/latitudesh/datasource_region.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"

--- a/latitudesh/datasource_region_test.go
+++ b/latitudesh/datasource_region_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func TestAccRegion_Basic(t *testing.T) {
 				Config: testAccCheckRegionBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.latitude_region.test", "slug", testRegionSlug),
+						"data.latitudesh_region.test", "slug", testRegionSlug),
 				),
 			},
 		},
@@ -27,7 +27,7 @@ func TestAccRegion_Basic(t *testing.T) {
 
 func testAccCheckRegionBasic() string {
 	return fmt.Sprintf(`
-data "latitude_region" "test" {
+data "latitudesh_region" "test" {
 	slug = "%s"
 }
 `,

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"
@@ -14,17 +14,17 @@ func Provider() *schema.Provider {
 			"auth_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("LATITUDE_AUTH_TOKEN", nil),
+				DefaultFunc: schema.EnvDefaultFunc("LATITUDESH_AUTH_TOKEN", nil),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"latitude_project": resourceProject(),
-			"latitude_server":  resourceServer(),
-			"latitude_ssh_key": resourceSSHKey(),
+			"latitudesh_project": resourceProject(),
+			"latitudesh_server":  resourceServer(),
+			"latitudesh_ssh_key": resourceSSHKey(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"latitude_plan":   dataSourcePlan(),
-			"latitude_region": dataSourceRegion(),
+			"latitudesh_plan":   dataSourcePlan(),
+			"latitudesh_region": dataSourceRegion(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}
@@ -36,7 +36,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	var diags diag.Diagnostics
 
 	if authToken != "" {
-		c := api.NewClientWithAuth("latitude", authToken, nil)
+		c := api.NewClientWithAuth("latitudesh", authToken, nil)
 
 		return c, diags
 	}

--- a/latitudesh/provider_test.go
+++ b/latitudesh/provider_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"os"
@@ -13,7 +13,7 @@ var testAccProvider *schema.Provider
 func init() {
 	testAccProvider = Provider()
 	testAccProviders = map[string]*schema.Provider{
-		"latitude": testAccProvider,
+		"latitudesh": testAccProvider,
 	}
 }
 
@@ -28,13 +28,13 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("LATITUDE_AUTH_TOKEN"); v == "" {
-		t.Fatal("LATITUDE_AUTH_TOKEN must be set for acceptance tests")
+	if v := os.Getenv("LATITUDESH_AUTH_TOKEN"); v == "" {
+		t.Fatal("LATITUDESH_AUTH_TOKEN must be set for acceptance tests")
 	}
-	if v := os.Getenv("LATITUDE_TEST_PROJECT_ID"); v == "" {
-		t.Fatal("LATITUDE_TEST_PROJECT_ID must be set for acceptance tests")
+	if v := os.Getenv("LATITUDESH_TEST_PROJECT"); v == "" {
+		t.Fatal("LATITUDESH_TEST_PROJECT must be set for acceptance tests")
 	}
-	if v := os.Getenv("LATITUDE_TEST_SSH_PUBLIC_KEY"); v == "" {
-		t.Fatal("LATITUDE_TEST_SSH_PUBLIC_KEY must be set for acceptance tests")
+	if v := os.Getenv("LATITUDESH_TEST_SSH_PUBLIC_KEY"); v == "" {
+		t.Fatal("LATITUDESH_TEST_SSH_PUBLIC_KEY must be set for acceptance tests")
 	}
 }

--- a/latitudesh/resource_project.go
+++ b/latitudesh/resource_project.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"

--- a/latitudesh/resource_project_test.go
+++ b/latitudesh/resource_project_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"fmt"
@@ -20,11 +20,11 @@ func TestAccProject_Basic(t *testing.T) {
 			{
 				Config: testAccCheckProjectBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("latitude_project.test_item", &project),
+					testAccCheckProjectExists("latitudesh_project.test_item", &project),
 					resource.TestCheckResourceAttr(
-						"latitude_project.test_item", "name", "test"),
+						"latitudesh_project.test_item", "name", "test"),
 					resource.TestCheckResourceAttr(
-						"latitude_project.test_item", "description", "hello"),
+						"latitudesh_project.test_item", "description", "hello"),
 				),
 			},
 		},
@@ -35,7 +35,7 @@ func testAccCheckProjectDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*api.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "latitude_project" {
+		if rs.Type != "latitudesh_project" {
 			continue
 		}
 		if _, _, err := client.Projects.Get(rs.Primary.ID, nil); err == nil {
@@ -75,7 +75,7 @@ func testAccCheckProjectExists(n string, project *api.Project) resource.TestChec
 
 func testAccCheckProjectBasic() string {
 	return `
-resource "latitude_project" "test_item" {
+resource "latitudesh_project" "test_item" {
   name        = "test"
   description = "hello"
 	environment = "Development"

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"
@@ -16,9 +16,9 @@ func resourceServer() *schema.Resource {
 		UpdateContext: resourceServerUpdate,
 		DeleteContext: resourceServerDelete,
 		Schema: map[string]*schema.Schema{
-			"project_id": {
+			"project": {
 				Type:        schema.TypeString,
-				Description: "The id of the project",
+				Description: "The id or slug of the project",
 				Required:    true,
 			},
 			"site": {
@@ -84,7 +84,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		Data: api.ServerCreateData{
 			Type: "servers",
 			Attributes: api.ServerCreateAttributes{
-				Project:         d.Get("project_id").(string),
+				Project:         d.Get("project").(string),
 				Site:            d.Get("site").(string),
 				Plan:            d.Get("plan").(string),
 				OperatingSystem: d.Get("operating_system").(string),

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"fmt"
@@ -28,9 +28,9 @@ func TestAccServer_Basic(t *testing.T) {
 			{
 				Config: testAccCheckServerBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerExists("latitude_server.test_item", &server),
+					testAccCheckServerExists("latitudesh_server.test_item", &server),
 					resource.TestCheckResourceAttr(
-						"latitude_server.test_item", "hostname", "test"),
+						"latitudesh_server.test_item", "hostname", "test"),
 				),
 			},
 		},
@@ -42,7 +42,7 @@ func testAccCheckServerDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*api.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "latitude_server" {
+		if rs.Type != "latitudesh_server" {
 			continue
 		}
 		if _, _, err := client.Servers.Get(rs.Primary.ID, nil); err == nil {
@@ -82,15 +82,15 @@ func testAccCheckServerExists(n string, server *api.Server) resource.TestCheckFu
 
 func testAccCheckServerBasic() string {
 	return fmt.Sprintf(`
-resource "latitude_server" "test_item" {
-	project_id = "%s"
-  hostname = "%s"
+resource "latitudesh_server" "test_item" {
+	project = "%s"
+  	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"
 	operating_system = "%s"
 }
 `,
-		os.Getenv("LATITUDE_TEST_PROJECT_ID"),
+		os.Getenv("LATITUDESH_TEST_PROJECT"),
 		testServerHostname,
 		testServerPlan,
 		testServerSite,

--- a/latitudesh/resource_ssh_key.go
+++ b/latitudesh/resource_ssh_key.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"context"
@@ -16,9 +16,9 @@ func resourceSSHKey() *schema.Resource {
 		UpdateContext: resourceSSHKeyUpdate,
 		DeleteContext: resourceSSHKeyDelete,
 		Schema: map[string]*schema.Schema{
-			"project_id": {
+			"project": {
 				Type:        schema.TypeString,
-				Description: "The id of the project",
+				Description: "The id or slug of the project",
 				Required:    true,
 			},
 			"name": {
@@ -59,7 +59,7 @@ func resourceSSHKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		},
 	}
 
-	key, _, err := c.SSHKeys.Create(d.Get("project_id").(string), createRequest)
+	key, _, err := c.SSHKeys.Create(d.Get("project").(string), createRequest)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -78,7 +78,7 @@ func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	keyID := d.Id()
 
-	key, _, err := c.SSHKeys.Get(keyID, d.Get("project_id").(string), nil)
+	key, _, err := c.SSHKeys.Get(keyID, d.Get("project").(string), nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,7 +104,7 @@ func resourceSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		},
 	}
 
-	_, _, err := c.SSHKeys.Update(keyID, d.Get("project_id").(string), updateRequest)
+	_, _, err := c.SSHKeys.Update(keyID, d.Get("project").(string), updateRequest)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -121,7 +121,7 @@ func resourceSSHKeyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 
 	keyID := d.Id()
 
-	_, err := c.SSHKeys.Delete(keyID, d.Get("project_id").(string))
+	_, err := c.SSHKeys.Delete(keyID, d.Get("project").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/latitudesh/resource_ssh_key_test.go
+++ b/latitudesh/resource_ssh_key_test.go
@@ -1,4 +1,4 @@
-package latitude
+package latitudesh
 
 import (
 	"fmt"
@@ -25,11 +25,11 @@ func TestAccSSHKey_Basic(t *testing.T) {
 			{
 				Config: testAccCheckSSHKeyBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSSHKeyExists("latitude_ssh_key.test_item", &sshKey),
+					testAccCheckSSHKeyExists("latitudesh_ssh_key.test_item", &sshKey),
 					resource.TestCheckResourceAttr(
-						"latitude_ssh_key.test_item", "name", testSSHKeyName),
+						"latitudesh_ssh_key.test_item", "name", testSSHKeyName),
 					resource.TestCheckResourceAttr(
-						"latitude_ssh_key.test_item", "public_key", os.Getenv("LATITUDE_TEST_SSH_PUBLIC_KEY")),
+						"latitudesh_ssh_key.test_item", "public_key", os.Getenv("LATITUDESH_TEST_SSH_PUBLIC_KEY")),
 				),
 			},
 		},
@@ -40,10 +40,10 @@ func testAccCheckSSHKeyDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*api.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "latitude_ssh_key" {
+		if rs.Type != "latitudesh_ssh_key" {
 			continue
 		}
-		if _, _, err := client.SSHKeys.Get(rs.Primary.ID, rs.Primary.Attributes["project_id"], nil); err == nil {
+		if _, _, err := client.SSHKeys.Get(rs.Primary.ID, rs.Primary.Attributes["project"], nil); err == nil {
 			return fmt.Errorf("SSH key still exists")
 		}
 	}
@@ -63,7 +63,7 @@ func testAccCheckSSHKeyExists(n string, sshKey *api.SSHKeyGetResponse) resource.
 
 		client := testAccProvider.Meta().(*api.Client)
 
-		foundSSHKey, _, err := client.SSHKeys.Get(rs.Primary.ID, rs.Primary.Attributes["project_id"], nil)
+		foundSSHKey, _, err := client.SSHKeys.Get(rs.Primary.ID, rs.Primary.Attributes["project"], nil)
 		if err != nil {
 			return err
 		}
@@ -80,14 +80,14 @@ func testAccCheckSSHKeyExists(n string, sshKey *api.SSHKeyGetResponse) resource.
 
 func testAccCheckSSHKeyBasic() string {
 	return fmt.Sprintf(`
-resource "latitude_ssh_key" "test_item" {
-	project_id  = "%s"
-  name        = "%s"
-  public_key  = "%s"
+resource "latitudesh_ssh_key" "test_item" {
+	project  	= "%s"
+  	name        = "%s"
+  	public_key  = "%s"
 }
 `,
-		os.Getenv("LATITUDE_TEST_PROJECT_ID"),
+		os.Getenv("LATITUDESH_TEST_PROJECT"),
 		testSSHKeyName,
-		os.Getenv("LATITUDE_TEST_SSH_PUBLIC_KEY"),
+		os.Getenv("LATITUDESH_TEST_SSH_PUBLIC_KEY"),
 	)
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -20,6 +20,6 @@ All resources require authentication. API keys can be obtained from your Latitud
 
 {{ tffile "examples/variables.tf" }}
 
-`latitude_server.tf` example
+`latitudesh_server.tf` example
 
-{{ tffile "examples/latitude_server.tf" }}
+{{ tffile "examples/latitudesh_server.tf" }}


### PR DESCRIPTION
#### What does this PR do?
* The provider uses `latitude` instead of `latitudesh` in some instances. This changes all references to `latitudesh`.
* Changed `project_id` to `project` as this parameter accepts either project id or project slug
