### PR TITLE
chore(deps): Updates `latitudesh-go` to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
-	github.com/latitudesh/latitudesh-go v0.1.0
+	github.com/latitudesh/latitudesh-go v0.1.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/latitudesh/latitudesh-go v0.1.0 h1:7vQybeaODbNjcECy2e/EX+/lHWvRwiSFjCYfRyxG7lI=
 github.com/latitudesh/latitudesh-go v0.1.0/go.mod h1:yru2V+bWzTIeyAlfD4cZ5S/baus+qdYYjzXIcqyuGF0=
+github.com/latitudesh/latitudesh-go v0.1.2 h1:PVgbt0pvH8d94ABu18cE25vS51GzApHihwtRGr75v5U=
+github.com/latitudesh/latitudesh-go v0.1.2/go.mod h1:yru2V+bWzTIeyAlfD4cZ5S/baus+qdYYjzXIcqyuGF0=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
#### What does this PR do?
Updates `latitudesh-go` to v0.1.2, fixing a bug where updating a project resulted in an error. 

#### Description of Task to be completed?
Major dependency update

#### How should this be manually tested?
Making changes to an existing project from the `latitudesh_project` resource should work.

#### What are the relevant GitHub issues (if any)?
N/A
