### PR TITLE
chore: Throw invalid token error when auth_token is missing

### DIFF
--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -51,6 +51,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 		return c, diags
 	}
+	c := api.NewClientWithAuth("latitudesh", " ", nil)
 
-	return nil, diags
+	return c, diags
 }


### PR DESCRIPTION
#### What does this PR do?
When users forget to set their auth_token, we were returning a nil client, which would break in our resources when casting the interface `c := m.(*api.Client)` .

This PR aims to improve the usability of our provider by returning an error message when this happens.

#### Description of Task to be completed?
Instead of returning a nil value, we should return an `api.Client` object with an invalid token, so when this client is used by the resources, it will throw the invalid token error message. 

#### How should this be manually tested?

- Installation
Before installing you will need to modify the `Makefile` present in the folder with the right information.
Normally you'll only need to modify two fields:
```
VERSION=0.0.1 # Make sure this doesn't interfere with other installations that you might have. I leave it as 0.0.1
OS_ARCH=linux_amd64 # This is your operating system architecture
```
*You can find the full list of suported `OS_ARCH` at `https://github.com/latitudesh/terraform-provider-latitudesh/releases` by expanding Assets.*

Then run `make install` to do a local installation of the provider.

- Setup
Create a new folder with a `main.tf` file without setting the auth_token:

```
# main.tf
terraform {
  required_providers {
    latitudesh = {
      source  = "latitude.sh/iac/latitudesh"
      version = "~> 0.0.1"
    }
  }
}
```
if you have exported the `LATITUDESH_AUTH_TOKEN` env variable, you can unset it by using the following command:

```
unset LATITUDESH_AUTH_TOKEN
```

and run `terraform init`. Now you are ready to start using terraform.

- Testing
In this test you just have to execute any apply or import action and without the token. You should expect an error message just like the following:

```
╷
│ Error: GET https://api.latitude.sh/projects/409: 401
│
│ Invalid Token
│ CODE: INVALID_TOKEN
│ STATUS: unauthorized
│ DETAIL: Invalid Token
│
│
│
╵
```

Setting the `auth_token` will make the provider work as intended.

#### Any background context you want to provide?
https://latitude.atlassian.net/browse/PD-3172

#### What are the relevant GitHub issues (if any)?
resolves https://github.com/latitudesh/terraform-provider-latitudesh/issues/41

#### Screenshots (if appropriate):

#### Questions: