### PR TITLE
fix: update docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "~> 0.2.6"
+      version = "~> 0.2.8"
     }
   }
 }
@@ -39,7 +39,7 @@ variable "latitudesh_token" {
 
 variable "plan" {
   description = "Latitude.sh server plan"
-  default     = "c2.small.x86"
+  default     = "c2-small-x86"
 }
 
 variable "region" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ variable "latitudesh_token" {
 
 variable "plan" {
   description = "Latitude.sh server plan"
-  default     = "c2-small-x86"
+  default     = "s3-large-x86"
 }
 
 variable "region" {

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -24,12 +24,12 @@ resource "latitudesh_virtual_network" "virtual_network" {
 
 ### Required
 
-- `description` (String) The Virtual Network description
-- `project` (String) The slug of the project
-- `site` (String) The site slug
+- `description` (String) The virtual network description
+- `project` (String) The project id or slug
+- `site` (String) The site id or slug
 
 ### Read-Only
 
 - `assignments_count` (Number) Amount of devices assigned to the virtual network
 - `id` (String) The ID of this resource.
-- `vid` (String) The vlan ID of the virtual network
+- `vid` (Number) The vlan ID of the virtual network

--- a/docs/resources/vlan_assignment.md
+++ b/docs/resources/vlan_assignment.md
@@ -23,14 +23,14 @@ resource "latitudesh_vlan_assignment" "vlan_assignment" {
 
 ### Required
 
-- `server_id` (String) The Assigned server ID
-- `virtual_network_id` (String) The virtual network ID
+- `server_id` (Number) The assignment server ID
+- `virtual_network_id` (Number) The virtual network ID
 
 ### Read-Only
 
 - `description` (String) The Virtual Network description
 - `id` (String) The ID of this resource.
-- `server_hostname` (String) The Assigned server hostname
-- `server_label` (String) The Assigned server label
-- `status` (String) The Assignment status
-- `vid` (String) The vlan ID of the virtual network
+- `server_hostname` (String) The assignment server hostname
+- `server_label` (String) The assignment server label
+- `status` (String) The assignment status
+- `vid` (Number) The vlan ID of the virtual network

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "~> 0.2.7"
+      version = "~> 0.2.8"
     }
   }
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -4,7 +4,7 @@ variable "latitudesh_token" {
 
 variable "plan" {
   description = "Latitude.sh server plan"
-  default     = "c2.small.x86"
+  default     = "c2-small-x86"
 }
 
 variable "region" {

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -4,7 +4,7 @@ variable "latitudesh_token" {
 
 variable "plan" {
   description = "Latitude.sh server plan"
-  default     = "c2-small-x86"
+  default     = "s3-large-x86"
 }
 
 variable "region" {

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -13,7 +13,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "0.2.7" // update varible when version updated
+var currentVersion = "0.2.8" // update varible when version updated
 
 func Provider() *schema.Provider {
 	return &schema.Provider{


### PR DESCRIPTION
#### What does this PR do?
Modify default plan on our docs from `"c2.small.x86"` to `"s3-large-x86"` to align with the format expected by our API
Also do some general updates

This documentation still complies with V2.

#### Description of Task to be completed?
- Update documentation

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant GitHub issues (if any)?
fixes https://github.com/latitudesh/terraform-provider-latitudesh/issues/47

#### Screenshots (if appropriate):

#### Questions: