### PR TITLE
fix: add type verification to server.Project.ID

### DIFF
--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -140,7 +140,16 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("project", strconv.FormatFloat(server.Project.ID.(float64), 'b', 2, 64)); err != nil {
+	// server.Project.ID is an interface{} type so we should verify before using
+	var serverProjectId string
+	switch server.Project.ID.(type) {
+	case string:
+		serverProjectId = server.Project.ID.(string)
+	case float64:
+		serverProjectId = strconv.FormatFloat(server.Project.ID.(float64), 'b', 2, 64)
+	}
+
+	if err := d.Set("project", serverProjectId); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
#### What does this PR do?
Add explicity type verification to our server.Project.ID 

#### Description of Task to be completed?
Verify if server.Project.ID is returning as string or float64(standard numeric type for enconding/json library)

#### How should this be manually tested?
- Installation
Before installing you will need to modify the `Makefile` present in the folder with the right information.
Normally you'll only need to modify two fields:
```
VERSION=0.0.1 # Make sure this doesn't interfere with other installations that you might have. I leave it as 0.0.1
OS_ARCH=linux_amd64 # This is your operating system architecture
```
*You can find the full list of suported `OS_ARCH` at `https://github.com/latitudesh/terraform-provider-latitudesh/releases` by expanding Assets.*

Them run `make install` to do a local installation of the provider.

- Setup
Create a new folder with a `main.tf` file:
```
# main.tf
terraform {
  required_providers {
    latitudesh = {
      source  = "latitude.sh/iac/latitudesh"
      version = "~> 0.0.1"
    }
  }
}

# Configure the provider
provider "latitudesh" {
  auth_token = <YOUR_LATITUDESH_TOKEN>
}
```
and run `terraform init`. Now you are ready to start using terraform.

#### What are the relevant GitHub issues (if any)?
closes https://github.com/latitudesh/terraform-provider-latitudesh/issues/50