### PR TITLE
Use Server Reinstall over Delete/Recreate when possible

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "1.0.0-rc.1"
+      version = "1.0.0-rc.2"
     }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "1.0.0-rc.1"
+      version = "1.0.0-rc.2"
     }
   }
 }

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -13,7 +13,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "1.0.0-rc.1" // update varible when version updated
+var currentVersion = "1.0.0-rc.2" // update variable when version updated
 
 func Provider() *schema.Provider {
 	return &schema.Provider{


### PR DESCRIPTION
#### What does this PR do?
When any of the following values are updated on a server resource: `operating_system, ssh_keys, user_data, raid or ipxe_url` we can re-install the server with the updated values instead of forcing a delete and recreate. 

#### Description of Task to be completed?
We want to avoid deleting and recreating servers since server resources in a Latitude account might not be available to re-creation after they are deleted. 

#### How should this be manually tested?
I added the following to my `.terraform.rc` file
```
provider_installation {
  dev_overrides {
    "latitudesh/latitudesh" = "<my-local-path>/terraform-provider-latitudesh"
  }
  direct {}
}
```
and run Terraform plans against resources which updated the `user_data` field. It no longer forced replacement as seen in the screen shots section below.

I did not do this but we could add more acceptance testing in `resource_server_test.go`. I held off on this myself as I don't have an API key where I feel comfortable creating/deleting any net new resources. 

#### Any background context you want to provide?
Issue #55 

#### What are the relevant GitHub issues (if any)?
Issue #55 

#### Screenshots (if appropriate):
Before this change:
```
  # module.latitude.latitudesh_server.local_file_server[0] must be replaced
  # (imported from "...")
  # Warning: this will destroy the imported resource
-/+ resource "latitudesh_server" "local_file_server" {
      ~ created          = "2024-02-08T00:00:00+00:00" -> (known after apply)
...
        site             = "NYC"
      + ssh_keys         = []
      + updated          = (known after apply)
      + user_data        = (known after apply) # forces replacement
    }
```


After this change:
```
  # module.latitude-test.latitudesh_server.local_server[0] will be created
  + resource "latitudesh_server" "local_server" {
      + created          = (known after apply)
      + hostname         = (known after apply)
      + id               = (known after apply)
...
      + updated          = (known after apply)
      + user_data        = (known after apply)
    }
```



#### Questions: