### PR TITLE
Fix: Error when refreshing state

### DIFF
--- a/latitudesh/resource_project.go
+++ b/latitudesh/resource_project.go
@@ -3,6 +3,7 @@ package latitudesh
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -84,8 +85,13 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	projectID := d.Id()
 
-	project, _, err := c.Projects.Get(projectID, nil)
+	project, resp, err := c.Projects.Get(projectID, nil)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -131,8 +132,13 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	serverID := d.Id()
 
-	server, _, err := c.Servers.Get(serverID, nil)
+	server, resp, err := c.Servers.Get(serverID, nil)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/latitudesh/resource_ssh_key.go
+++ b/latitudesh/resource_ssh_key.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -83,8 +84,13 @@ func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	keyID := d.Id()
 
-	key, _, err := c.SSHKeys.Get(keyID, d.Get("project").(string), nil)
+	key, resp, err := c.SSHKeys.Get(keyID, d.Get("project").(string), nil)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/latitudesh/resource_user_data.go
+++ b/latitudesh/resource_user_data.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -83,8 +84,13 @@ func resourceUserDataRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	userDataID := d.Id()
 
-	userData, _, err := c.UserData.Get(userDataID, d.Get("project").(string), nil)
+	userData, resp, err := c.UserData.Get(userDataID, d.Get("project").(string), nil)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -84,8 +85,13 @@ func resourceVirtualNetworkRead(ctx context.Context, d *schema.ResourceData, m i
 
 	virtualNetworkID := d.Id()
 
-	virtualNetwork, _, err := c.VirtualNetworks.Get(virtualNetworkID, nil)
+	virtualNetwork, resp, err := c.VirtualNetworks.Get(virtualNetworkID, nil)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,8 +93,13 @@ func resourceVlanAssignmentRead(ctx context.Context, d *schema.ResourceData, m i
 
 	vlanAssignmentID := d.Id()
 
-	vlanAssignment, _, err := c.VlanAssignments.Get(vlanAssignmentID)
+	vlanAssignment, resp, err := c.VlanAssignments.Get(vlanAssignmentID)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
#### What does this PR do?
When users manually delete resources via our Dashboard, CLI, or by directly calling the API, this causes a mismatch between their Terraform state and the resources they have. To solve this, Terraform has the command `terraform refresh`, which will attempt to sync the Terraform state with the resources.

In order to work properly, terraform refresh needs the resource Read function to detect 404 errors and translate them into deleting the resource from the Terraform state file.

This PR aims to add this 404 error handling to the Read function of all our resources.

#### Description of Task to be completed?
Address 404 erros in all of the provider resources:
- [x] Projects
- [x] Servers
- [x] SSH Keys
- [x]  User Data
- [x]  Virtual Networks
- [x]  Virtual Network Assignments

#### How should this be manually tested?
#### Local installation:
Clone the repository, checkout to this branch before proceeding
- Installation
Before installing you will need to modify the `Makefile` present in the folder with the right information.
Normally you'll only need to modify two fields:
```
VERSION=0.0.1 # Make sure this doesn't interfere with other installations that you might have. I leave it as 0.0.1
OS_ARCH=linux_amd64 # This is your operating system architecture
```
*You can find the full list of supported `OS_ARCH` at `https://github.com/latitudesh/terraform-provider-latitudesh/releases` by expanding Assets.*

Them run `make install` to do a local installation of the provider.

- Setup
Create a new folder with a `main.tf` file:
```
# main.tf
terraform {
  required_providers {
    latitudesh = {
      source  = "latitude.sh/iac/latitudesh"
      version = "~> 0.0.1"
    }
  }
}

# Configure the provider
provider "latitudesh" {
  auth_token = <YOUR_LATITUDESH_TOKEN>
}
```
and run `terraform init`. Now you are ready to start using terraform.

#### Testing:
In order to test this PR you will need to create resources with terraform ([instructions](https://registry.terraform.io/providers/latitudesh/latitudesh/latest/docs)) delete them manually and them run the command
```
terraform refresh
```
this should remove the resource from your `terraform.tfstate` file, you can compare with the `terraform.tfstate.backup` to make sure everything went well.

#### Any background context you want to provide?

#### What are the relevant GitHub issues (if any)?

#### Screenshots (if appropriate):

#### Questions: