### PR TITLE
fix: update goreleaser --rm-dist to --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.1.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -56,3 +56,10 @@ resource "latitudesh_server" "server" {
 - `id` (String) The ID of this resource.
 - `primary_ipv4` (String) The server IP address
 - `updated` (String) The timestamp for the last time the server was updated
+
+## Import
+Server can be imported using the serverID, e.g.,
+
+```sh
+$ terraform import latitudesh_server.server serverID
+```


### PR DESCRIPTION
#### What does this PR do?
The`--rm-dist` flag got deprecated, we need to use `--clean` now
Also add the import documentation for server.

#### Any background context you want to provide?
https://goreleaser.com/deprecations/#-rm-dist
