### PR TITLE
fix: downgrade goreleaser version to 1.26.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0
         with:
-          version: latest
+          version: 1.26.2
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
#### What does this PR do?
Goreleaser action updated to v2 introducing some breaking changes, this PR sets it to the latest version before 2.0