### PR TITLE
docs(v2): add v2 migration guide links to README and registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Requirements for developing the provider
 -	[Terraform](https://www.terraform.io/downloads.html) >= 1.3.x
 -	[Go](https://golang.org/doc/install) >= 1.23.x (to build the provider plugin)
 
+Migration Guide
+------------
+
+**Upgrading to v2?** Please read the [Migration Guide to v2](https://github.com/latitudesh/terraform-provider-latitudesh/blob/main/MIGRATION_GUIDE_v2.md) for details on breaking changes and how to safely upgrade.
+
+
 Developing the provider locally
 ------------
 
@@ -43,7 +49,14 @@ $ # Move the binary to the appropriate subdirectory within your user plugins dir
 After installing the provider locally, create a Terraform project and on `main.tf` replace source with:
 
 ```sh
-source  = "latitude.sh/iac/latitudesh"
+terraform {
+  required_providers {
+    latitudesh = {
+      source  = "latitude.sh/iac/latitudesh"
+      version = "2.0.0"
+    }
+  }
+}
 ```
 
 Create `variables.tf` and add your Latitude.sh token. Finally, initialize the project with `terraform init`

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ Use the navigation to the left to read about the available resources.
 
 All resources require authentication. API keys can be obtained from your Latitude.sh dashboard.
 
+**Upgrading to v2:** If you're upgrading from version 1.x to 2.x, please read the [migration guide](https://github.com/latitudesh/terraform-provider-latitudesh/blob/main/MIGRATION_GUIDE_v2.md).
+
+
 ## Example usage
 
 `main.tf` example


### PR DESCRIPTION
#### What does this PR do?

Adds a migration guide reference for v2 to both the Terraform Registry documentation and the project's README.

#### Description of Task to be completed?

- Added a link to `MIGRATION_GUIDE_v2.md` in the `README.md` to help users upgrading to v2.
- Added a notice and link in `docs/index.md` of the Terraform Registry docs.