### PR TITLE
fix(resource/import): ensure correct types handling during resource import

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitude.sh/iac/latitudesh"
-      version = "2.1.0"
+      version = "2.1.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "2.1.0"
+      version = "2.1.1"
     }
   }
 }

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -24,7 +24,6 @@ resource "latitudesh_ssh_key" "ssh_key" {
 ### Required
 
 - `name` (String) The SSH key name
-- `project` (String, Deprecated) The id or slug of the project
 - `public_key` (String) The SSH public key
 
 ### Optional
@@ -38,8 +37,8 @@ resource "latitudesh_ssh_key" "ssh_key" {
 - `updated` (String) The timestamp for the last time the SSH key was updated
 
 ## Import
-SshKey can be imported using the sshKeyID along with the projectID that contains the sshKey, e.g.,
+The `latitudesh_ssh_key` resource can now be imported by specifying only the `sshKeyID`, for example:
 
 ```sh
-$ terraform import latitudesh_ssh_key.ssh_key projectID:sshKeyID
+$ terraform import latitudesh_ssh_key.ssh_key sshKeyID
 ```

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "2.1.0"
+      version = "2.1.1"
     }
   }
 }

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -15,7 +15,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "2.1.0"
+var currentVersion = "2.1.1"
 
 // Ensure latitudeshProvider satisfies various provider interfaces
 var _ provider.Provider = &latitudeshProvider{}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -574,6 +574,9 @@ func (r *ServerResource) readServer(ctx context.Context, data *ServerResourceMod
 		if attrs.Region != nil && attrs.Region.Site != nil && attrs.Region.Site.Slug != nil {
 			data.Region = types.StringValue(*attrs.Region.Site.Slug)
 		}
+
+		data.SSHKeys = types.ListNull(types.StringType)
+		data.Tags = types.ListNull(types.StringType)
 	}
 }
 

--- a/latitudesh/resource_ssh_key.go
+++ b/latitudesh/resource_ssh_key.go
@@ -256,6 +256,9 @@ func (r *SSHKeyResource) readSSHKey(ctx context.Context, data *SSHKeyResourceMod
 	}
 
 	sshKey := result.Object.Data
+
+	data.Tags = types.ListNull(types.StringType)
+
 	if sshKey.Attributes != nil {
 		if sshKey.Attributes.Name != nil {
 			data.Name = types.StringValue(*sshKey.Attributes.Name)


### PR DESCRIPTION
#### What does this PR do?

Fixes type handling for list attributes (e.g., `tags`, `ssh_keys`) during resource import for the `server` and `ssh_key` resources, ensuring compatibility with Terraform import and preventing type conversion errors.

#### Description of Task to be completed?

Ensure that list attributes are always set with the correct type (even when empty) in the provider state.

#### How should this be manually tested?

1. Build and install the provider locally
2. Use terraform `import to import` existing `latitudesh_server` and `latitudesh_ssh_key` resources

  - [import latitudesh_server](https://registry.terraform.io/providers/latitudesh/latitudesh/latest/docs/resources/server#import)
    - Server can be imported using the serverID, e.g.:

      ```
       terraform import latitudesh_server.server serverID
       ```
  - [import latitudesh_ssh_key](https://registry.terraform.io/providers/latitudesh/latitudesh/latest/docs/resources/ssh_key)
    - SshKey can be imported using the sshKeyID along with the projectID that contains the sshKey, e.g.:
    
      ```
      terraform import latitudesh_ssh_key.ssh_key projectID:sshKeyID
      ```

5. Confirm that the import completes without type conversion errors and that the state is consistent.

#### What are the relevant GitHub issues (if any)?

- #100 