### PR TITLE
feat(server): add hostname max length validation (32 chars)

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -38,7 +38,7 @@ output "server_ipv6" {
 
 ### Required
 
-- `hostname` (String) The server hostname
+- `hostname` (String): The server hostname. **Maximum length: 32 characters.**
 - `operating_system` (String) The server OS. 
 				Updating operating_system will trigger a reinstall if allow_reinstall is set to true.
 - `plan` (String) The server plan

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -213,9 +213,8 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	if !data.Hostname.IsNull() {
 		hostname := data.Hostname.ValueString()
-		if len(hostname) > maxHostnameLength {
-			errMsg := fmt.Sprintf("The hostname must not exceed %d characters. Provided hostname has %d characters.", maxHostnameLength, len(hostname))
-			resp.Diagnostics.AddError("Hostname Too Long", errMsg)
+		if err := validateHostnameLength(hostname); err != nil {
+			resp.Diagnostics.AddError("Hostname Too Long", err.Error())
 			return
 		}
 		attrs.Hostname = &hostname
@@ -647,5 +646,12 @@ func (r *ServerResource) updateServerTags(ctx context.Context, serverID string, 
 		}
 	}
 
+	return nil
+}
+
+func validateHostnameLength(hostname string) error {
+	if len(hostname) > maxHostnameLength {
+		return fmt.Errorf("hostname must not exceed %d characters; provided hostname has %d characters", maxHostnameLength, len(hostname))
+	}
 	return nil
 }

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 )
 
+const maxHostnameLength = 32
+
 var _ resource.Resource = &ServerResource{}
 var _ resource.ResourceWithImportState = &ServerResource{}
 
@@ -211,6 +213,11 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	if !data.Hostname.IsNull() {
 		hostname := data.Hostname.ValueString()
+		if len(hostname) > maxHostnameLength {
+			errMsg := fmt.Sprintf("The hostname must not exceed %d characters. Provided hostname has %d characters.", maxHostnameLength, len(hostname))
+			resp.Diagnostics.AddError("Hostname Too Long", errMsg)
+			return
+		}
 		attrs.Hostname = &hostname
 	}
 

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -19,6 +19,28 @@ const (
 	testRetryDelay            = 30 // Delay between retries in seconds
 )
 
+func TestValidateHostnameLength(t *testing.T) {
+	cases := []struct {
+		hostname  string
+		shouldErr bool
+		name      string
+	}{
+		{"short-hostname", false, "shorter than max"},
+		{"abcdefghijklmnopqrstuvwxyzabcdef", false, "exactly max length"}, // 32 chars
+		{"abcdefghijklmnopqrstuvwxyzabcdefg", true, "longer than max"},    // 33 chars
+	}
+
+	for _, tc := range cases {
+		err := validateHostnameLength(tc.hostname)
+		if tc.shouldErr && err == nil {
+			t.Errorf("%s: expected error, got nil", tc.name)
+		}
+		if !tc.shouldErr && err != nil {
+			t.Errorf("%s: expected no error, got %v", tc.name, err)
+		}
+	}
+}
+
 func TestAccServer_Basic(t *testing.T) {
 	recorder, teardown := createTestRecorder(t)
 	defer teardown()


### PR DESCRIPTION
#### What does this PR do?

Adds validation to ensure the hostname attribute in the `latitudesh_server` resource does not exceed **32 characters**, and updates the documentation to mention this limit.

#### Description of Task to be completed?

- Add max hostname length validation (32 chars)
- Update docs

#### How should this be manually tested?

- Create or Update a `latitudesh_server` resource

Run `terraform plan` for:

```sh
resource "latitudesh_project" "project" {
  description            = "Terraform provider project resource"
  environment          = "Development"
  name                      = "Terraform provider"
  provisioning_type = "on_demand"
  billing                     = "monthly"
}

resource "latitudesh_server" "server" {
  hostname         = "long-hostname-for-the-server-resource.latitude.sh"
  operating_system = "ubuntu_22_04_x64_lts"
  site             = "ASH"
  plan             = "m4-metal-large"
  project          = latitudesh_project.project.id
  billing          = "monthly"
}
```

Then `terraform apply`. You'll see a message similar to:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/6d069204-429c-4773-860a-744fbf5994be" />

- Confirm the clearly error message
- Check documentation

#### Any background context you want to provide?

Enforces the limit at the provider level and clarifies it in the docs.