### PR TITLE
test(e2e): configure ci acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,3 @@ jobs:
         run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet"
         env:
           TF_ACC: '1'
-          LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,4 @@ jobs:
         run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet"
         env:
           TF_ACC: '1'
+          LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,6 @@ jobs:
       - 
         name: Run E2E Tests
         run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet"
+        env:
+          TF_ACC: '1'
+          LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,24 @@ jobs:
       - 
         name: Run Unit Tests
         run: go test ./latitudesh -v -timeout 10m -run "TestProvider|TestFrameworkProvider"
+  
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - 
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.23.0'
+      - 
+        name: Install dependencies
+        run: go get .
+      - 
+        name: Run E2E Tests
+        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to terraform-provider-latitudesh
+
+First off, thanks for taking the time to contribute! 🎉
+
+Whether it's reporting a bug, suggesting a feature, improving documentation, or submitting a pull request, every contribution is welcome and appreciated.
+
+---
+
+## 🧩 Ways to Contribute
+
+### 1. Report Bugs
+
+If you find a bug, please [open an issue](https://github.com/latitudesh/terraform-provider-latitudesh/issues) and include:
+
+- A clear description of the problem
+- Steps to reproduce it (ideally with a minimal Terraform config)
+- What you expected to happen
+- What actually happened
+- Your environment (Terraform version, OS, provider version)
+
+### 2. Suggest Features
+
+Have an idea for a new feature or improvement? [Open an issue](https://github.com/latitudesh/terraform-provider-latitudesh/issues/new) and let’s discuss!
+
+### 3. Submit Pull Requests
+
+We ❤️ PRs! Here's how to get started:
+
+---
+
+## 🛠️ Local Development Setup
+
+1. **Fork and Clone the Repo**
+
+```sh
+git clone https://github.com/your-username/terraform-provider-latitudesh.git
+cd terraform-provider-latitudesh
+```
+
+2. **Install Dependencies**
+
+- [Go](https://go.dev/dl/) >= 1.23.x
+- [Terraform](https://developer.hashicorp.com/terraform) >= 1.3.x
+
+3. **Build the Provider**
+
+```sh
+go build -o terraform-provider-latitudesh
+```
+
+# For Apple Silicon (darwin_arm64), build and install the provider locally:
+
+```sh
+GOOS=darwin GOARCH=arm64 go build -o terraform-provider-latitudesh
+mkdir -p ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_arm64
+mv terraform-provider-latitudesh ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_arm64/
+chmod +x ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_arm64/terraform-provider-latitudesh
+```
+
+# For Intel Macs (darwin_amd64), use:
+
+```sh
+GOOS=darwin GOARCH=amd64 go build -o terraform-provider-latitudesh
+mkdir -p ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_amd64
+mv terraform-provider-latitudesh ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_amd64/
+chmod +x ~/.terraform.d/plugins/latitude.sh/iac/latitudesh/0.0.0/darwin_amd64/terraform-provider-latitudesh
+```
+
+# Use the provider in your Terraform project (main.tf):
+
+```hcl
+terraform {
+  required_providers {
+    latitudesh = {
+      source = "latitude.sh/iac/latitudesh"
+    }
+  }
+}
+
+provider "latitudesh" {
+  auth_token = var.LATITUDESH_AUTH_TOKEN
+}
+```
+
+# Remove any `version` line from the required_providers block to force Terraform to use your local build.
+
+# In your test project, run:
+
+```sh
+rm -rf .terraform .terraform.lock.hcl
+terraform init
+```
+
+Terraform will now use your local provider build for development and testing.
+

--- a/latitudesh/provider_test.go
+++ b/latitudesh/provider_test.go
@@ -135,6 +135,15 @@ func TestFrameworkProvider(t *testing.T) {
 	}
 }
 
+func TestAccEnvVarAuthTokenSet(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	if v := os.Getenv("LATITUDESH_AUTH_TOKEN"); v == "" {
+		t.Fatal("LATITUDESH_AUTH_TOKEN must be set for acceptance tests")
+	}
+}
+
 // Helper function to get providers for Framework testing
 func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){


### PR DESCRIPTION
#### What does this PR do?

Configure acceptance tests for the CI pipeline in `.github/workflows/test.yml`. The new `e2e` job test should appear now and check for the environment variable.

#### How should this be manually tested?

In the workflow run logs, confirm that:

- `TF_ACC` is set to `1`.
- `LATITUDESH_AUTH_TOKEN` is read from secrets.
- The test `TestAccEnvVarAuthTokenSet` passes (logs “LATITUDESH_AUTH_TOKEN is set!”).

#### Any background context you want to provide?

We had initially removed the secret temporarily during a major refactor, which caused the acceptance test to be skipped/fail in CI.