### PR TITLE
docs: update import instructions docs

### DIFF
--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -75,8 +75,36 @@ Read-Only:
 - `default` (Boolean) Whether this is a default rule
 
 ## Import
-Firewall can be imported using the firewallID, e.g.,
+
+You can import a Firewall resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_firewall` resource can be imported by specifying the Firewall ID:
 
 ```sh
-$ terraform import latitudesh_firewall.web_firewall firewallID
-``` 
+terraform import latitudesh_firewall.web_firewall <FIREWALL_ID>
+```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_firewall.web_firewall
+  id = "<FIREWALL_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_firewall.tf
+```
+
+This will generate the resource configuration for the imported firewall resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/firewall_assignment.md
+++ b/docs/resources/firewall_assignment.md
@@ -63,32 +63,53 @@ resource "latitudesh_firewall_assignment" "web_assignment" {
 - `id` (String) The ID of this resource.
 
 ## Import
-Firewall assignment can be imported in two ways:
 
-### Option 1: Using just the assignment ID (recommended)
+You can import a Firewall Assignment resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_firewall_assignment` resource can be imported by specifying the [Firewall assignment](https://docs.latitude.sh/reference/get-firewall-assignments) ID:
+
 ```sh
-$ terraform import latitudesh_firewall_assignment.web_assignment fwasg_dmkONWje0jL1b
+terraform import latitudesh_firewall_assignment.web_assignment <FW_ASSIGNMENT_ID>
 ```
 
-Or using Terraform import blocks:
-```terraform
+**Alternative: Composite ID Format**
+
+You can also import using the composite ID format (firewall ID and firewall assignment ID separated by a colon):
+
+```sh
+terraform import latitudesh_firewall_assignment.web_assignment <FIREWALL_ID>:<FW_ASSIGNMENT_ID>
+```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
 import {
   to = latitudesh_firewall_assignment.web_assignment
-  id = "fwasg_dmkONWje0jL1b"
+  id = "<FW_ASSIGNMENT_ID>"
 }
 ```
 
-### Option 2: Using composite ID format
-```sh
-$ terraform import latitudesh_firewall_assignment.web_assignment firewall_abc123:assignment_def456
-```
+Or, using the composite ID format:
 
-Or using Terraform import blocks:
-```terraform
+```hcl
 import {
   to = latitudesh_firewall_assignment.web_assignment
-  id = "firewall_abc123:assignment_def456"
+  id = "<FIREWALL_ID>:<FW_ASSIGNMENT_ID>"
 }
 ```
 
-The single assignment ID method is recommended as it's simpler and automatically finds the associated firewall. 
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_firewall_assignment.tf
+```
+
+This will generate the resource configuration for the imported firewall assignment resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions. 

--- a/docs/resources/member.md
+++ b/docs/resources/member.md
@@ -39,7 +39,36 @@ resource "latitudesh_member" "member" {
 - `mfa_enabled` (String) The member mfa status
 
 ## Import
-Member can be imported using the MemberID, e.g.,
+
+You can import a Member resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_member` resource can be imported by specifying the Member ID:
 
 ```sh
-$ terraform import latitudesh_member.member MemberID
+terraform import latitudesh_member.member <MEMBER_ID>
+```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_member.member
+  id = "<MEMBER_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_member.tf
+```
+
+This will generate the resource configuration for the imported member resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -40,8 +40,9 @@ resource "latitudesh_project" "project" {
 - `updated` (String) The timestamp for the last time the project was updated
 
 ## Import
-Project can be imported using the projectID, e.g.,
 
-```sh
-$ terraform import latitudesh_project.project projectID
+The `latitudesh_project` resource can be imported by specifying its ID:
+
+```bash
+$ terraform import latitudesh_project.my_project <PROJECT_ID>
 ```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -41,8 +41,35 @@ resource "latitudesh_project" "project" {
 
 ## Import
 
-The `latitudesh_project` resource can be imported by specifying its ID:
+You can import a Project resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
 
-```bash
-$ terraform import latitudesh_project.my_project <PROJECT_ID>
+**CLI Import**
+
+The `latitudesh_project` resource can be imported by specifying the Project ID:
+
+```sh
+terraform import latitudesh_project.my_project <PROJECT_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_project.my_project
+  id = "<PROJECT_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_project.tf
+```
+
+This will generate the resource configuration for the imported project resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -71,8 +71,36 @@ output "server_ipv6" {
 - `updated` (String) The timestamp for the last time the server was updated
 
 ## Import
-Server can be imported using the serverID, e.g.,
+
+You can import a Server resource using either the CLI method or the new [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_server` resource can be imported by specifying its ID:
 
 ```sh
-$ terraform import latitudesh_server.server serverID
+terraform import latitudesh_server.my_server <SERVER_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_server.my_server
+  id = "<SERVER_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_server.tf
+```
+
+This will generate the resource configuration for the imported server resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -37,8 +37,36 @@ resource "latitudesh_ssh_key" "ssh_key" {
 - `updated` (String) The timestamp for the last time the SSH key was updated
 
 ## Import
-The `latitudesh_ssh_key` resource can now be imported by specifying only the `sshKeyID`, for example:
+
+You can import an SSH Key resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_ssh_key` resource can be imported by specifying the SSH key ID:
 
 ```sh
-$ terraform import latitudesh_ssh_key.ssh_key sshKeyID
+terraform import latitudesh_ssh_key.ssh_key <SSH_KEY_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_ssh_key.ssh_key
+  id = "<SSH_KEY_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_ssh_key.tf
+```
+
+This will generate the resource configuration for the imported SSH key resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -36,8 +36,36 @@ resource "latitudesh_tag" "tag" {
 - `id` (String) The ID of this resource.
 
 ## Import
-Tag can be imported using the TagID along with the projectID that contains the Tag, e.g.,
+
+You can import a Tag resource using either the CLI method or the [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_tag` resource can be imported by specifying the Tag ID:
 
 ```sh
-$ terraform import latitudesh_tag.tag TagID
+terraform import latitudesh_tag.tag <TAG_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_tag.tag
+  id = "<TAG_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_tag.tf
+```
+
+This will generate the resource configuration for the imported tag resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/user_data.md
+++ b/docs/resources/user_data.md
@@ -41,8 +41,36 @@ resource "latitudesh_user_data" "setup" {
 - `updated` (String) The timestamp for the last time the User Data was updated
 
 ## Import
-UserData can be imported using the userDataID along with the projectID that contains the userData, e.g.,
+
+You can import a User Data resource using either the CLI method or the new [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_user_data` resource can be imported by specifying its ID:
 
 ```sh
-$ terraform import latitudesh_user_data.user_data projectID:userDataID
+$ terraform import latitudesh_user_data.user_data <USER_DATA_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_user_data.user_data
+  id = "<USER_DATA_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_user_data.tf
+```
+
+This will generate the resource configuration for the imported user data resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -39,8 +39,36 @@ resource "latitudesh_virtual_network" "virtual_network" {
 - `vid` (Number) The vlan ID of the virtual network
 
 ## Import
-VirtualNetwork can be imported using the VirtualNetworkID along with the projectID that contains the VirtualNetwork, e.g.,
+
+You can import a Virtual Network resource using either the CLI method or the new [experimental import block](https://developer.hashicorp.com/terraform/language/import).
+
+**CLI Import**
+
+The `latitudesh_virtual_network` resource can be imported by specifying its ID:
 
 ```sh
-$ terraform import latitudesh_virtual_network.virtual_network projectID:VirtualNetworkID
+terraform import latitudesh_virtual_network.virtual_network <VIRTUAL_NETWORK_ID>
 ```
+
+**Import Block (Experimental)**
+
+Terraform v1.5.0 and later supports the experimental import block, which allows you to define imports in your configuration. This feature is experimental and may change in future Terraform releases. See the [Terraform documentation for details](https://developer.hashicorp.com/terraform/language/import).
+
+To use this method, create a file named `import.tf` (or any `.tf` file) with the following content:
+
+```hcl
+import {
+  to = latitudesh_virtual_network.virtual_network
+  id = "<VIRTUAL_NETWORK_ID>"
+}
+```
+
+Then run:
+
+```sh
+terraform plan -generate-config-out=generated_virtual_network.tf
+```
+
+This will generate the resource configuration for the imported virtual network resource.
+
+> **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.

--- a/docs/resources/vlan_assignment.md
+++ b/docs/resources/vlan_assignment.md
@@ -36,8 +36,9 @@ resource "latitudesh_vlan_assignment" "vlan_assignment" {
 - `vid` (Number) The vlan ID of the virtual network
 
 ## Import
-VlanAssignment can be imported using the VlanAssignmentID along with the projectID that contains the VirtualNetwork, e.g.,
+
+The `latitudesh_vlan_assignment` resource can be imported by specifying the project ID and VLAN assignment ID separated by a colon:
 
 ```sh
-$ terraform import latitudesh_vlan_assignment.vlan_assignment projectID:VlanAssignmentID
+terraform import latitudesh_vlan_assignment.vlan_assignment <PROJECT_ID>:<VLAN_ASSIGNMENT_ID>
 ```


### PR DESCRIPTION
#### What does this PR do?

This PR updates the Terraform docs for all resources to standardize the Import section. Updated `docs/resources/*.md` import examples.

#### How should this be manually tested?

Run `terraform import` for each resource using the new examples and confirm `terraform plan` returns no diffs after import.