### PR TITLE
Add validation and acceptance tests for Tag resource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: go get .
       - 
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet|TestAccServer_SSHKeys_NoDrift"
+        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet|TestAccServer_SSHKeys_NoDrift|TestAccTag"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -7,15 +7,16 @@ description: |-
 
 # latitudesh_tag (Resource)
 
-
+Latitude.sh supports resource tagging to help you organize and manage your infrastructure more effectively.
+Tags allow you to categorize resources, making it easier to search, filter, and group them based on your specific needs.
 
 ## Example usage
 
-```terraform
+```hcl
 resource "latitudesh_tag" "tag" {
-  name          = "Tag Name"
-  description   = "Tag Description"
-  color         = "#ff0000"
+  name        = "Tag Name"
+  description = "Tag Description"
+  color       = "#ff0000"
 }
 ```
 
@@ -24,7 +25,7 @@ resource "latitudesh_tag" "tag" {
 
 ### Required
 
-- `color` (String) The tag color
+- `color` (String) The tag color (hex format, **lowercase**, e.g. `#ff0000`)
 - `name` (String) The tag name
 
 ### Optional

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.23.0 // indirect
 	github.com/hashicorp/terraform-json v0.25.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/hashicorp/terraform-plugin-docs v0.21.0 h1:yoyA/Y719z9WdFJAhpUkI1jRbK
 github.com/hashicorp/terraform-plugin-docs v0.21.0/go.mod h1:J4Wott1J2XBKZPp/NkQv7LMShJYOcrqhQ2myXBcu64s=
 github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
 github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=
+github.com/hashicorp/terraform-plugin-framework-validators v0.18.0/go.mod h1:lZvZvagw5hsJwuY7mAY6KUz45/U6fiDR0CzQAwWD0CA=
 github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=
 github.com/hashicorp/terraform-plugin-go v0.27.0/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/modifiers/lowercase_string_modifier.go
+++ b/internal/modifiers/lowercase_string_modifier.go
@@ -1,0 +1,30 @@
+package modifiers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type LowercaseStringModifier struct{}
+
+var _ planmodifier.String = LowercaseStringModifier{}
+
+func (m LowercaseStringModifier) Description(_ context.Context) string {
+	return "Normalizes the string value to lowercase during the plan phase."
+}
+
+func (m LowercaseStringModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m LowercaseStringModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsUnknown() || req.PlanValue.IsNull() {
+		return
+	}
+
+	val := req.PlanValue.ValueString()
+	resp.PlanValue = types.StringValue(strings.ToLower(val))
+}


### PR DESCRIPTION
#### What does this PR do?

This PR introduces enhancements to the `latitudesh_tag` resource, including input validation, normalization, and improved acceptance test coverage.

#### Description of Task to be completed?

- [x] Enforces lowercase hex format for the `color` field using a string validator (e.g. `#rrggbb`)
- [x] Adds a custom plan modifier (`LowercaseStringModifier`) to normalize color input
- [x] Removes the deprecated `normalizeHexColor` function
- [x] Adds new acceptance tests
- [x] Improves documentation with usage example and validation notes
- [x] Adds `TestAccTag` to CI workflow for automated testing

#### How should this be manually tested?

Run the following command:

```sh
LATITUDESH_TEST_SSH_KEY_ID=ssh_... LATITUDESH_TEST_PROJECT=proj_... TF_ACC=1 go test ./latitudesh -v -timeout 10m -run "TestAccTag"
```

Or use GitHub Actions to verify CI passes with the updated workflow.

#### Any background context you want to provide?

Previously, the `color` input lacked validation and normalization, leading to inconsistencies. We also didn't have proper acceptance tests using the public API to validate create/destroy behavior.

#### What are the relevant GitHub issues (if any)?

N/A

#### Screenshots (if appropriate):

N/A