### PR TITLE
Add server hostname validator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: go get .
       - 
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet|TestAccServer_SSHKeys_NoDrift|TestAccTag|TestAccSSHKey"
+        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet|TestAccServer|TestAccTag|TestAccSSHKey"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "2.4.0"
+      version = ">= 2.4.0"
     }
   }
 }

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -7,15 +7,27 @@ description: |-
 
 # latitudesh_server (Resource)
 
-
+The `latitudesh_server` resource allows you to deploy and manage bare metal servers on [Latitude.sh](https://metal.new) via Terraform.
 
 ## Example usage
 
-```terraform
+```hcl
+terraform {
+  required_providers {
+    latitudesh = {
+      source  = "latitudesh/latitudesh"
+      version = "2.4.0"
+    }
+  }
+}
+
+provider "latitudesh" {}
+
+# Create a server
 resource "latitudesh_server" "server" {
-  hostname         = "terraform.latitude.sh"
-  operating_system = "ubuntu_22_04_x64_lts"
-  plan             = data.latitudesh_plan.plan.slug
+  hostname         = "terraform-latitude-sh"
+  operating_system = "ubuntu_24_04_x64_lts"
+  plan             = "monthly"
   project          = latitudesh_project.project.id      # You can use the project id or slug
   site             = data.latitudesh_region.region.slug # You can use the site id or slug
   ssh_keys         = [latitudesh_ssh_key.ssh_key.id]
@@ -23,13 +35,9 @@ resource "latitudesh_server" "server" {
   ipxe_url         = "" # URL to a boot.ipxe file. e.g. https://boot.netboot.xyz
 }
 
-# Access the server's IP addresses
-output "server_ipv4" {
-  value = latitudesh_server.server.primary_ipv4
-}
-
-output "server_ipv6" {
-  value = latitudesh_server.server.primary_ipv6
+# Access the server's attributes
+output "server" {
+  value = latitudesh_server.server
 }
 ```
 
@@ -38,13 +46,12 @@ output "server_ipv6" {
 
 ### Required
 
-- `hostname` (String) – The server hostname
+- `hostname` (String) The server hostname
   - Maximum length: 32 characters
   - Allowed characters: letters (a–z, A–Z), digits (0–9), dots (.), and hyphens (-)
   - Must not begin or end with a dot or hyphen
   - Underscores (_) are not allowed
-- `operating_system` (String) The server OS. 
-				Updating operating_system will trigger a reinstall if allow_reinstall is set to true.
+- `operating_system` (String) The server OS
 - `plan` (String) The server plan
 - `project` (String) The id or slug of the project
 - `site` (String) The server site
@@ -52,19 +59,19 @@ output "server_ipv6" {
 ### Optional
 
 - `allow_reinstall` (Boolean, Deprecated) Allow server reinstallation when operating_system, ssh_keys, user_data, raid, or ipxe_url changes.
-				WARNING: The reinstall will be triggered even if Terraform reports an in-place update.
-- `billing` (String) The server billing type. 
-				Accepts hourly and monthly for on demand projects and yearly for reserved projects.
-- `ipxe_url` (String) Url for the iPXE script that will be used.	
-				Updating ipxe_url will trigger a reinstall if allow_reinstall is set to true.
+    WARNING: The reinstall will be triggered even if Terraform reports an in-place update.
+- `billing` (String) The server billing type.
+    Accepts hourly and monthly for on demand projects and yearly for reserved projects.
+- `ipxe_url` (String) Url for the iPXE script that will be used. 
+    Updating ipxe_url will trigger a reinstall if allow_reinstall is set to true.
 - `locked` (Boolean) Lock/unlock the server. A locked server cannot be deleted or updated.
-- `raid` (String) RAID mode for the server. 
-				Updating raid will trigger a reinstall if allow_reinstall is set to true.
-- `ssh_keys` (List of String) List of server SSH key ids. 
-				Any change to `ssh_keys` will force a resource replacement.
+- `raid` (String) RAID mode for the server.
+    Updating raid will trigger a reinstall if allow_reinstall is set to true.
+- `ssh_keys` (List of String) List of server SSH key ids.
+    Any change to `ssh_keys` will force a resource replacement.
 - `tags` (List of String) List of server tags
-- `user_data` (String) The id of user data to set on the server. 
-				Updating user_data will trigger a reinstall if allow_reinstall is set to true.
+- `user_data` (String) The id of user data to set on the server.
+    Updating user_data will trigger a reinstall if allow_reinstall is set to true.
 
 ### Read-Only
 
@@ -108,3 +115,4 @@ terraform plan -generate-config-out=generated_server.tf
 This will generate the resource configuration for the imported server resource.
 
 > **Note:** The import block feature is experimental and its syntax or behavior may change in future Terraform versions.
+

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -38,7 +38,11 @@ output "server_ipv6" {
 
 ### Required
 
-- `hostname` (String): The server hostname. **Maximum length: 32 characters.**
+- `hostname` (String) – The server hostname
+  - Maximum length: 32 characters
+  - Allowed characters: letters (a–z, A–Z), digits (0–9), dots (.), and hyphens (-)
+  - Must not begin or end with a dot or hyphen
+  - Underscores (_) are not allowed
 - `operating_system` (String) The server OS. 
 				Updating operating_system will trigger a reinstall if allow_reinstall is set to true.
 - `plan` (String) The server plan

--- a/internal/validators/hostname.go
+++ b/internal/validators/hostname.go
@@ -1,0 +1,31 @@
+package validators
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+const (
+	MaxHostnameLength = 32
+)
+
+var hostnameRegex = regexp.MustCompile(
+	`^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$`,
+)
+
+// Hostname returns validators that enforce a stricter than RFC1123 allowed hostname:
+// - max 32 characters
+// - must start and end with a letter or digit
+// - may contain letters, digits, hyphens (-) and dots (.)
+// - underscores (_) are not allowed
+func Hostname() []validator.String {
+	return []validator.String{
+		stringvalidator.LengthAtMost(MaxHostnameLength),
+		stringvalidator.RegexMatches(
+			hostnameRegex,
+			"must contain only letters, digits, hyphens (-), and dots (.). Cannot start or end with a hyphen or dot; underscores (_) are not allowed",
+		),
+	}
+}

--- a/internal/validators/hostname.go
+++ b/internal/validators/hostname.go
@@ -1,10 +1,14 @@
 package validators
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const (
@@ -28,4 +32,26 @@ func Hostname() []validator.String {
 			"must contain only letters, digits, hyphens (-), and dots (.). Cannot start or end with a hyphen or dot; underscores (_) are not allowed",
 		),
 	}
+}
+
+// ValidateHostname runs the Hostname validators against the given string
+func ValidateHostname(s string) error {
+	ctx := context.Background()
+
+	req := validator.StringRequest{
+		Path:        path.Root("hostname"),
+		ConfigValue: types.StringValue(s),
+	}
+	var resp validator.StringResponse
+
+	for _, v := range Hostname() {
+		v.ValidateString(ctx, req, &resp)
+	}
+
+	if resp.Diagnostics.HasError() {
+		d := resp.Diagnostics[0]
+		return fmt.Errorf("%s: %s", d.Summary(), d.Detail())
+	}
+
+	return nil
 }

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -108,7 +108,6 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:            true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(maxHostnameLength),
-					// only letters, numbers, dot and hyphen; underscore is not allowed
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$`),
 						"must contain only letters, digits, hyphens (-), and dots (.). Cannot start or end with a hyphen or dot; underscores (_) are not allowed",

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -111,7 +111,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					// only letters, numbers, dot and hyphen; underscore is not allowed
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$`),
-						"must contain only letters, numbers, dots (.) and hyphens (-); underscores (_) are not allowed",
+						"must contain only letters, digits, hyphens (-), and dots (.). Cannot start or end with a hyphen or dot; underscores (_) are not allowed",
 					),
 				},
 				PlanModifiers: []planmodifier.String{

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -58,7 +58,7 @@ func TestAccServer_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerExists("latitudesh_server.test_item"),
 					resource.TestCheckResourceAttr(
-						"latitudesh_server.test_item", "hostname", "test"),
+						"latitudesh_server.test_item", "hostname", testServerHostname),
 					resource.TestCheckResourceAttrSet(
 						"latitudesh_server.test_item", "primary_ipv4"),
 					resource.TestCheckResourceAttrSet(
@@ -140,7 +140,7 @@ func TestAccServer_IPv6Support(t *testing.T) {
 						"latitudesh_server.test_item", "primary_ipv6"),
 					// Verify the field names are correct
 					resource.TestCheckResourceAttr(
-						"latitudesh_server.test_item", "hostname", "test"),
+						"latitudesh_server.test_item", "hostname", testServerHostname),
 				),
 			},
 		},
@@ -244,7 +244,7 @@ func testAccCheckServerExists(n string) resource.TestCheckFunc {
 		}
 
 		// Check if server meets all required conditions
-		if (status == "on" || status == "inventory") &&
+		if (status == "on" || status == "inventory" || status == "deploying") &&
 			serverProjectID == os.Getenv("LATITUDESH_TEST_PROJECT") &&
 			serverOS == testServerOperatingSystem {
 			return nil
@@ -257,6 +257,7 @@ func testAccCheckServerExists(n string) resource.TestCheckFunc {
 func testAccCheckServerBasic() string {
 	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
+	billing = "monthly"
 	project = "%s"
   	hostname = "%s"
 	plan     = "%s"


### PR DESCRIPTION
## What does this PR do?

- Adds hostname validation to `latitudesh_server` with a friendly error
- Ensures billing defaults to `monthly` when is null
- Updated e2e tests

## DX Improvements

- Improved Terraform validation with more detailed errors

## How should this be manually tested?

### 1) Hostname validation

```hcl
resource "latitudesh_server" "server" {
  project          = "proj_XXXX"
  hostname         = "terraform_host" # underscore
  site             = "SAO2"
  plan             = "c2-small-x86"
  operating_system = "ubuntu_24_04_x64_lts"
}

```

Run:

```sh
terraform plan
```

Expected error:

```sh
│ Error: Invalid Attribute Value Match
│
│   with latitudesh_server.node_server,
│   on node.tf line 3, in resource "latitudesh_server" "node_server":
│    3:   hostname         = "terraform_host"
│
│ Attribute hostname must contain only letters, digits, hyphens (-), and dots (.). Cannot start or end with a hyphen or dot;
│ underscores (_) are not allowed, got: terraform_host
```

### 2) Hostname valid

Change to `hostname = "terraform-host"`, then run `terraform plan`

### 3) Billing default

Omit billing and apply on-demand project should use `monthly`

## Background context

Standard hostnames per RFC 952/1123 don’t allow underscores

### Tips

- Clean cache: `rm -rf .terraform terraform.lock.hcl`
- Verbose logs: `export TF_LOG=TRACE terraform plan/apply`