### PR TITLE
chore: remove main trigger on CI process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@
 name: release
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 permissions:


### PR DESCRIPTION
#### What does this PR do?

Remove `main` branch trigger on Actions.

#### Description of Task to be completed?

Remove `main` branch on the release process in GA. Just put the tags, like this example below:

```yaml
on:
  push:
    tags:
      - 'v*'
```

#### How should this be manually tested?

No.

#### Any background context you want to provide?

No.

#### What are the relevant GitHub issues (if any)?

No.

#### Screenshots (if appropriate):

#### Questions: