### PR TITLE
refactor(provider): centralize SSH key datasource configuration

### DIFF
--- a/latitudesh/datasource_ssh_key.go
+++ b/latitudesh/datasource_ssh_key.go
@@ -16,6 +16,8 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
 )
 
 var (
@@ -49,18 +51,11 @@ func (d *SSHKeyDataSource) Metadata(ctx context.Context, req datasource.Metadata
 }
 
 func (d *SSHKeyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
+	deps := iprovider.ConfigureFromProviderData(req.ProviderData, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	client, ok := req.ProviderData.(*latitudeshgosdk.Latitudesh)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *latitudeshgosdk.Latitudesh, got: %T", req.ProviderData),
-		)
-		return
-	}
-	d.client = client
+	d.client = deps.Client
 }
 
 func (d *SSHKeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {


### PR DESCRIPTION
#### What does this PR do?

Refactors the `SSHKey` data source to use the shared `ConfigureFromProviderData` helper.

#### Description of Task to be completed?

- This PR replaces it with the centralized helper located in `internal/provider`.  
- This change improves consistency and simplifies error handling and client configuration.

#### How should this be manually tested?

Build the provider locally:

```sh
make build
```

Use a Terraform config like this:

```hcl
data "latitudesh_ssh_key" "by_name" {
  name = "example"
}

output "ssh_key_by_name" {
  value = data.latitudesh_ssh_key.by_name
}
```

Run `terraform plan` and confirm you see the output:

```
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ssh_key_by_name = {
      + created_at  = "2025-08-22T13:19:41+00:00"
      + fingerprint = "75:7c..."
      + id          = "ssh_..."
      + name        = "example"
      + public_key  = "ssh-ed25519 AAAA..."
      + updated_at  = "2025-08-22T13:19:41+00:00"
    }
```