### PR TITLE
feat: implement a pooling to check the server creation/reinstall status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: go get .
       - 
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 10m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan"
+        run: go test ./latitudesh -v -timeout 30m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: go get .
       - 
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 30m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan"
+        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -259,6 +260,109 @@ func (r *ServerResource) Configure(ctx context.Context, req resource.ConfigureRe
 	r.defaultProject = deps.DefaultProject
 }
 
+func (r *ServerResource) waitForServerReady(ctx context.Context, serverID string, diags *diag.Diagnostics, operation string) {
+	// Configs
+	timeout := 30 * time.Minute
+	pollInterval := 10 * time.Second
+	maxRetries := 5
+	deadline := time.Now().Add(timeout)
+
+	consecutiveErrors := 0
+
+	for time.Now().Before(deadline) {
+		response, err := r.client.Servers.Get(ctx, serverID, nil)
+		if err != nil {
+			consecutiveErrors++
+
+			// Check if it's a temporary error that we should retry
+			errStr := err.Error()
+			isTemporaryError := strings.Contains(errStr, "502") ||
+				strings.Contains(errStr, "503") ||
+				strings.Contains(errStr, "504") ||
+				strings.Contains(errStr, "429") ||
+				strings.Contains(errStr, "timeout") ||
+				strings.Contains(errStr, "connection reset")
+
+			if isTemporaryError && consecutiveErrors <= maxRetries {
+				// Calculate backoff with exponential delay
+				backoff := time.Duration(consecutiveErrors) * 5 * time.Second
+				if backoff > 30*time.Second {
+					backoff = 30 * time.Second
+				}
+
+				// Wait before retry with backoff
+				select {
+				case <-ctx.Done():
+					diags.AddError("Context Cancelled", fmt.Sprintf("Server %s was cancelled", operation))
+					return
+				case <-time.After(backoff):
+					// Continue to next iteration
+					continue
+				}
+			}
+
+			// If it's not a temporary error or we've exceeded retries, fail
+			if consecutiveErrors > maxRetries {
+				diags.AddError(
+					"Client Error",
+					fmt.Sprintf("Unable to check server status during %s after %d retries. Last error: %s", operation, maxRetries, err.Error()),
+				)
+			} else {
+				diags.AddError(
+					"Client Error",
+					fmt.Sprintf("Unable to check server status during %s: %s", operation, err.Error()),
+				)
+			}
+			return
+		}
+
+		// Reset consecutive errors on success
+		consecutiveErrors = 0
+
+		if response.Server == nil || response.Server.Data == nil || response.Server.Data.Attributes == nil {
+			diags.AddError("API Error", fmt.Sprintf("Invalid server response during %s", operation))
+			return
+		}
+
+		attrs := response.Server.Data.Attributes
+		if attrs.Status == nil {
+			diags.AddError("API Error", fmt.Sprintf("Server status is null during %s", operation))
+			return
+		}
+
+		status := string(*attrs.Status)
+
+		// Check for failure states
+		if status == "failed_disk_erasing" || status == "failed_deployment" {
+			diags.AddError(
+				fmt.Sprintf("Server %s Failed", operation),
+				fmt.Sprintf("Server entered failed state: %s. Please check the server in the Latitude.sh dashboard.", status),
+			)
+			return
+		}
+
+		// Check for success states
+		if status == "on" {
+			return
+		}
+
+		// Wait before next check
+		select {
+		case <-ctx.Done():
+			diags.AddError("Context Cancelled", fmt.Sprintf("Server %s was cancelled", operation))
+			return
+		case <-time.After(pollInterval):
+			// Continue to next iteration
+		}
+	}
+
+	// Timeout reached
+	diags.AddError(
+		fmt.Sprintf("Server %s Timeout", operation),
+		fmt.Sprintf("Server did not reach 'on' state within %v. Check server status in Latitude.sh dashboard.", timeout),
+	)
+}
+
 func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data ServerResourceModel
 
@@ -392,6 +496,11 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 	}
 
+	r.waitForServerReady(ctx, data.ID.ValueString(), &resp.Diagnostics, "creation")
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	r.readServer(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -481,6 +590,12 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		err := r.reinstallServer(ctx, &data, &resp.Diagnostics)
 		if err != nil {
 			resp.Diagnostics.AddError("Reinstall Error", "Unable to reinstall server: "+err.Error())
+			return
+		}
+
+		// Wait for server to be ready after reinstall
+		r.waitForServerReady(ctx, data.ID.ValueString(), &resp.Diagnostics, "reinstall")
+		if resp.Diagnostics.HasError() {
 			return
 		}
 

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -263,8 +263,8 @@ func (r *ServerResource) Configure(ctx context.Context, req resource.ConfigureRe
 
 func (r *ServerResource) waitForServerReady(ctx context.Context, serverID string, diags *diag.Diagnostics, operation string) {
 	// Configs
-	timeout := 15 * time.Minute
-	pollInterval := 10 * time.Second
+	timeout := 30 * time.Minute
+	pollInterval := 30 * time.Second
 	maxRetries := 5
 
 	// Check if we're in test mode with short deadline


### PR DESCRIPTION
#### What does this PR do?

Implements a server readiness waiting mechanism with automatic retry logic for the Terraform provider to ensure that server operations complete successfully before returning the state.

#### Description of Task to be completed?

This PR adds robust server provisioning logic to the latitudesh_server resource:

**Main changes**:

- Added `waitForServerReady()` function that polls server status until it reaches on state
- Implemented exponential backoff retry mechanism for temporary API errors (502, 503, 504, 429, timeouts)
- Integrated waiting logic into both `Create()` and `Update()` (reinstall) operations
- Added proper error detection for failed server states (`failed_disk_erasing`, `failed_deployment`)

**Technical Details:**

- **Timeout**: 30 minutes maximum wait time
- **Poll Interval**: 10 seconds between status checks
- **Retry Logic**: Up to 5 consecutive retries with exponential backoff (5s, 10s, 15s, 20s, 25s, max 30s)
- **Temporary Errors Handled**: 502, 503, 504, 429, timeouts, connection resets

**Benefits**:

- Terraform now waits for servers to be fully provisioned before completing
- Resilient against temporary API instabilities (no more ugly 502 errors)
- Clear error messages when servers fail to provision
- Better user experience with deterministic state management

#### How should this be manually tested?

1. **Test Server Creation**:

Create the resource:

```hcl
terraform {
  required_providers {
    latitudesh = {
      source = "local/iac/latitudesh"
    }
  }
}

provider "latitudesh" {
  auth_token = var.latitude_auth_token
}

resource "latitudesh_server" "this" {
  billing          = "monthly"
  project          = "proj_X6KG5m9Lk5yPB"
  hostname         = "test-issue-server"
  plan             = "c2-small-x86"
  site             = "SAO2"
  operating_system = "ubuntu_24_04_x64_lts"
  ssh_keys         = ["<MY_SSH_KEY>"]
}
```

Apply the resource:
```bash
terraform apply
# Should wait until server status is "on" before completing
```

2. **Test Server Reinstall**:

Change the resource:
```hcl
terraform {
  required_providers {
    latitudesh = {
      source = "local/iac/latitudesh"
    }
  }
}

provider "latitudesh" {
  auth_token = var.latitude_auth_token
}

resource "latitudesh_server" "this" {
  billing          = "monthly"
  project          = "proj_X6KG5m9Lk5yPB"
  hostname         = "test-issue-server"
  plan             = "c2-small-x86"
  site             = "SAO2"
  operating_system = "ubuntu_22_04_x64_lts" # this example
  ssh_keys         = ["<MY_SSH_KEY>"]
}
```

Apply again:
```bash
terraform apply
# Should wait until server status is "on" before completing
```

3. **Test Retry Logic (optional)**:
- Simulate API instability or wait for a natural 502 error
- Verify that the provider retries automatically without failing immediately

4. **Test Timeout Scenario (optional):**
- If a server gets stuck in deploying state for > 30 minutes
- Should receive clear timeout error message

#### Any background context you want to provide?

Previously, the Terraform provider would complete the create or reinstall operation as soon as the API accepted the request, without waiting for the actual server provisioning to complete. This caused several issues:

1. **Race Conditions**: Dependent resources might try to use the server before it is ready
2. **Poor UX**: Users had to manually check when servers were ready
3. **502 Errors**: Temporary API gateway errors would cause Terraform to fail unnecessarily

This implementation follows the pattern used by other cloud providers (AWS, GCP, Azure), where resource creation waits for the resource to be fully available.

#### What are the relevant GitHub issues (if any)?

N/A (internal improvement)

#### Screenshots (if appropriate):

N/A - Backend logic change, no UI changes

#### Questions:

- Should the timeout duration (30 minutes) be configurable via provider settings?
- Should we add more detailed logging/progress indicators during the wait period?
- Are there any other server states we should handle as "success" states besides on?