### PR TITLE
feat: add billing attribute validation

### DIFF
--- a/internal/validators/billing.go
+++ b/internal/validators/billing.go
@@ -1,0 +1,100 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	BillingHourly  = "hourly"
+	BillingMonthly = "monthly"
+	BillingYearly  = "yearly"
+)
+
+var validBillingValues = []string{BillingHourly, BillingMonthly, BillingYearly}
+
+var billingHierarchy = map[string]int{
+	BillingHourly:  0,
+	BillingMonthly: 1,
+	BillingYearly:  2,
+}
+
+// Billing returns validators that enforce valid billing values:
+// - must be one of: hourly, monthly, yearly
+func Billing() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf(validBillingValues...),
+	}
+}
+
+// ValidateBilling runs the Billing validators against the given string
+func ValidateBilling(s string) error {
+	ctx := context.Background()
+
+	req := validator.StringRequest{
+		Path:        path.Root("billing"),
+		ConfigValue: types.StringValue(s),
+	}
+	var resp validator.StringResponse
+
+	for _, v := range Billing() {
+		v.ValidateString(ctx, req, &resp)
+	}
+
+	if resp.Diagnostics.HasError() {
+		d := resp.Diagnostics[0]
+		return fmt.Errorf("%s: %s", d.Summary(), d.Detail())
+	}
+
+	return nil
+}
+
+// ValidateBillingChange validates if a billing change is allowed.
+// Only allows upgrades: hourly -> monthly -> yearly
+// Blocks all downgrades: yearly -> monthly, yearly -> hourly, monthly -> hourly
+func ValidateBillingChange(current, newBilling string) error {
+	current = strings.ToLower(strings.TrimSpace(current))
+	newBilling = strings.ToLower(strings.TrimSpace(newBilling))
+
+	// Validate new billing value
+	if err := ValidateBilling(newBilling); err != nil {
+		return err
+	}
+
+	// If no current value, allow any valid billing value
+	if current == "" {
+		return nil
+	}
+
+	// Validate current billing value
+	currentLevel, currentOk := billingHierarchy[current]
+	if !currentOk {
+		return fmt.Errorf("invalid current billing value: %s", current)
+	}
+
+	// Same value, no change needed
+	if current == newBilling {
+		return nil
+	}
+
+	// Check if change is allowed
+	newLevel, newOk := billingHierarchy[newBilling]
+	if !newOk {
+		return fmt.Errorf("invalid billing value: %s", newBilling)
+	}
+
+	if newLevel <= currentLevel {
+		return fmt.Errorf(
+			"cannot change billing from '%s' to '%s'. The API only allows billing upgrades (hourly -> monthly -> yearly). Downgrades are not permitted",
+			current, newBilling,
+		)
+	}
+
+	return nil
+}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -151,6 +151,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: "The server billing type (hourly, monthly, yearly). Defaults to monthly.",
 				Optional:            true,
 				Computed:            true,
+				Validators:          validators.Billing(),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -244,11 +245,30 @@ func (r *ServerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	var cfg, plan ServerResourceModel
+	var cfg, plan, state ServerResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if !req.State.Raw.IsNull() {
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	}
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Validate billing change during plan phase
+	if !req.State.Raw.IsNull() && !plan.Billing.IsNull() && !plan.Billing.IsUnknown() {
+		if !state.Billing.IsNull() && !state.Billing.IsUnknown() {
+			currentBilling := state.Billing.ValueString()
+			newBilling := plan.Billing.ValueString()
+			
+			// Only validate if billing is actually changing
+			if currentBilling != newBilling {
+				if err := validators.ValidateBillingChange(currentBilling, newBilling); err != nil {
+					resp.Diagnostics.AddError("Billing Change Validation Error", err.Error())
+					return
+				}
+			}
+		}
 	}
 
 	if !cfg.Project.IsNull() && !cfg.Project.IsUnknown() && cfg.Project.ValueString() != "" {
@@ -816,6 +836,16 @@ func (r *ServerResource) updateServerInPlace(ctx context.Context, data *ServerRe
 
 	if !data.Billing.IsNull() && (currentData == nil || data.Billing.ValueString() != currentData.Billing.ValueString()) {
 		billingValue := data.Billing.ValueString()
+		
+		// Validate billing change if we have current billing data
+		if currentData != nil && !currentData.Billing.IsNull() && !currentData.Billing.IsUnknown() {
+			currentBilling := currentData.Billing.ValueString()
+			if err := validators.ValidateBillingChange(currentBilling, billingValue); err != nil {
+				diags.AddError("Billing Change Validation Error", err.Error())
+				return false, "", fmt.Errorf("billing change validation failed: %w", err)
+			}
+		}
+		
 		billing := operations.UpdateServerServersBilling(billingValue)
 		attrs.Billing = &billing
 	}


### PR DESCRIPTION
- Implement validation for valid billing values (hourly, monthly, yearly)
- Implement validation for billing changes (only upgrades allowed)
- Add validation in ModifyPlan to detect errors during terraform plan
- Add unit tests for billing validation and billing changes
- Integrate validator in server resource schema

Resolves: PD-4665