### PR TITLE
fix(server): wait for server ready after in-place update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: go get .
       -
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag"
+        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag|TestAccRegion"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -794,7 +794,22 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 
-		// For in-place updates, only read server info
+		// Extract configured timeout with default of 30 minutes
+		updateTimeout, diags := data.Timeouts.Update(ctx, 30*time.Minute)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Wait for server to be ready after in-place update
+		// The API may trigger a redeployment for certain changes, so we need
+		// to wait for the server to reach "on" status before reading state
+		r.waitForServerReady(ctx, data.ID.ValueString(), &resp.Diagnostics, "update", updateTimeout)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Read server to get updated values after update
 		r.readServer(ctx, &data, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return

--- a/latitudesh/resource_server_userdata_test.go
+++ b/latitudesh/resource_server_userdata_test.go
@@ -7,33 +7,35 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
 
 func TestAccServer_WithUserData(t *testing.T) {
-	recorder, teardown := createTestRecorder(t)
-	defer teardown()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccTokenCheck(t)
-			testAccProjectCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVCR(recorder),
-		CheckDestroy:             testAccCheckServerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckServerWithUserData(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerExists("latitudesh_server.test_item"),
-					resource.TestCheckResourceAttr(
-						"latitudesh_server.test_item", "hostname", testServerHostname),
-					resource.TestCheckResourceAttr(
-						"latitudesh_server.test_item", "user_data", "ud_R82A0y9L06mMY"),
-					resource.TestCheckResourceAttrSet(
-						"latitudesh_server.test_item", "primary_ipv4"),
-				),
+	runTestWithSiteFallback(t, func(site string, rec *recorder.Recorder) resource.TestCase {
+		return resource.TestCase{
+			PreCheck: func() {
+				testAccTokenCheck(t)
+				testAccProjectCheck(t)
 			},
-		},
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVCR(rec),
+			CheckDestroy:             testAccCheckServerDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccCheckServerWithUserData(site),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckServerExists("latitudesh_server.test_item"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "hostname", testServerHostname),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "user_data", "ud_R82A0y9L06mMY"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "site", site),
+						resource.TestCheckResourceAttrSet(
+							"latitudesh_server.test_item", "primary_ipv4"),
+					),
+				},
+			},
+		}
 	})
 }
 
@@ -110,7 +112,7 @@ func pointersEqual(a, b *string) bool {
 	return *a == *b
 }
 
-func testAccCheckServerWithUserData() string {
+func testAccCheckServerWithUserData(site string) string {
 	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
@@ -126,7 +128,7 @@ resource "latitudesh_server" "test_item" {
 		os.Getenv("LATITUDESH_TEST_PROJECT"),
 		testServerHostname,
 		testServerPlan,
-		testServerSite,
+		site,
 		testServerOperatingSystem,
 	)
 }

--- a/latitudesh/test_utils_server.go
+++ b/latitudesh/test_utils_server.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Lista de sites para fallback (em ordem)
-var testServerSiteFallbackOrder = []string{"SAN3", "BGT", "SAO2", "AMS", "ASH"}
+var testServerSiteFallbackOrder = []string{"SAN3", "BGT", "SAO2", "AMS", "ASH", "DAL", "FRA", "CHI", "LON2"}
 
 // isServersOutOfStockError detecta erro 422 com código SERVERS_OUT_OF_STOCK
 func isServersOutOfStockError(err error) bool {


### PR DESCRIPTION
## Problem

The provider returns inconsistent results after applying in-place server updates. When the API triggers a redeployment, the server status changes from `"on"` to `"deploying"` and the hostname may temporarily change, causing Terraform to report a provider bug ("Provider produced inconsistent result after apply").

The fix adds a `waitForServerReady` call after in-place updates, ensuring the server reaches `"on"` status before reading the final state back into Terraform.

## Test plan

- [x] Apply a server update that triggers redeployment and verify no inconsistent result error
- [x] CI passes

Refs: [PD-5697](https://latitude.atlassian.net/browse/PD-5697)

[PD-5697]: https://latitude.atlassian.net/browse/PD-5697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ