### PR TITLE
fix(module): add v2 suffix to Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/latitudesh/terraform-provider-latitudesh
+module github.com/latitudesh/terraform-provider-latitudesh/v2
 
 go 1.24.0
 

--- a/latitudesh/datasource_plan.go
+++ b/latitudesh/datasource_plan.go
@@ -10,7 +10,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/datasource_region.go
+++ b/latitudesh/datasource_region.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ datasource.DataSource = &RegionDataSource{}

--- a/latitudesh/datasource_role.go
+++ b/latitudesh/datasource_role.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ datasource.DataSource = &RoleDataSource{}

--- a/latitudesh/datasource_ssh_key.go
+++ b/latitudesh/datasource_ssh_key.go
@@ -17,7 +17,7 @@ import (
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var (

--- a/latitudesh/datasource_tag.go
+++ b/latitudesh/datasource_tag.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ datasource.DataSource = &TagDataSource{}

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure latitudeshProvider satisfies various provider interfaces

--- a/latitudesh/resource_firewall.go
+++ b/latitudesh/resource_firewall.go
@@ -16,7 +16,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/resource_firewall_assignment.go
+++ b/latitudesh/resource_firewall_assignment.go
@@ -14,7 +14,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ resource.Resource = &FirewallAssignmentResource{}

--- a/latitudesh/resource_member.go
+++ b/latitudesh/resource_member.go
@@ -13,7 +13,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/resource_project.go
+++ b/latitudesh/resource_project.go
@@ -12,7 +12,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	"github.com/latitudesh/terraform-provider-latitudesh/internal/planmodifiers"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
-	"github.com/latitudesh/terraform-provider-latitudesh/internal/validators"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/planmodifiers"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/validators"
 )
 
 var _ resource.Resource = &ServerResource{}

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/latitudesh/terraform-provider-latitudesh/internal/validators"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/validators"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
 

--- a/latitudesh/resource_ssh_key.go
+++ b/latitudesh/resource_ssh_key.go
@@ -17,7 +17,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/resource_tag.go
+++ b/latitudesh/resource_tag.go
@@ -17,8 +17,8 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	"github.com/latitudesh/terraform-provider-latitudesh/internal/modifiers"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/modifiers"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ resource.Resource = &TagResource{}

--- a/latitudesh/resource_user_data.go
+++ b/latitudesh/resource_user_data.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -15,8 +15,8 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	"github.com/latitudesh/terraform-provider-latitudesh/internal/planmodifiers"
-	providerpkg "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/planmodifiers"
+	providerpkg "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ resource.Resource = &VirtualNetworkResource{}

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -15,7 +15,7 @@ import (
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
-	iprovider "github.com/latitudesh/terraform-provider-latitudesh/internal/provider"
+	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
 var _ resource.Resource = &VlanAssignmentResource{}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	latitude "github.com/latitudesh/terraform-provider-latitudesh/latitudesh"
+	latitude "github.com/latitudesh/terraform-provider-latitudesh/v2/latitudesh"
 )
 
 // version is set via ldflags during build


### PR DESCRIPTION
## Problem

The `go.mod` declares `module github.com/latitudesh/terraform-provider-latitudesh` but the repo has v2.x git tags. Go module versioning rules require v2+ modules to include the major version in the module path (`/v2`). This breaks `go get`, Pulumi bridge consumers, and other Go tooling that expects the v2 suffix.

Updated the module declaration in `go.mod` and all internal import paths across 19 files to include `/v2`.

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `terraform plan` and `terraform apply` work with the built provider
- [x] Server creation verified end-to-end (created `para-terraform` on DAL)
- [x] CI passes

Refs: #169 