### PR TITLE
fix(plan): handle unknown project references in ModifyPlan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: go get .
       -
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag|TestAccRegion"
+        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag|TestAccRegion|TestAccVirtualNetwork|TestAccFirewall"
         env:
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/latitudesh/resource_firewall.go
+++ b/latitudesh/resource_firewall.go
@@ -137,6 +137,10 @@ func (r *FirewallResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 
+	if cfgProject.IsUnknown() {
+		return
+	}
+
 	// Resolve: resource > provider > erro
 	var resolved types.String
 	if !cfgProject.IsNull() && !cfgProject.IsUnknown() && cfgProject.ValueString() != "" {

--- a/latitudesh/resource_firewall_test.go
+++ b/latitudesh/resource_firewall_test.go
@@ -123,3 +123,35 @@ resource "latitudesh_firewall" "test" {
 }
 `, projectID)
 }
+
+func TestAccFirewall_UnknownProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccTokenCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config: `
+provider "latitudesh" {}
+
+resource "latitudesh_project" "test" {
+  name        = "tf-acc-unknown-project-fw"
+  environment = "Development"
+}
+
+resource "latitudesh_firewall" "test" {
+  name    = "test-firewall-unknown"
+  project = latitudesh_project.test.id
+  rules {
+    from     = "ANY"
+    to       = "ANY"
+    port     = "22"
+    protocol = "TCP"
+  }
+}
+`,
+			},
+		},
+	})
+}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -357,6 +357,10 @@ func (r *ServerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		}
 	}
 
+	if cfg.Project.IsUnknown() {
+		return
+	}
+
 	if !cfg.Project.IsNull() && !cfg.Project.IsUnknown() && cfg.Project.ValueString() != "" {
 		plan.Project = cfg.Project
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -775,3 +775,33 @@ resource "latitudesh_server" "test_item" {
 		testServerOperatingSystem,
 	)
 }
+
+func TestAccServer_UnknownProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccTokenCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config: `
+provider "latitudesh" {}
+
+resource "latitudesh_project" "test" {
+  name        = "tf-acc-unknown-project-srv"
+  environment = "Development"
+}
+
+resource "latitudesh_server" "test_item" {
+  project          = latitudesh_project.test.id
+  hostname         = "tf-acc-unknown.latitude.sh"
+  plan             = "c2-small-x86"
+  site             = "NYC"
+  operating_system = "ubuntu_24_04_x64_lts"
+  billing          = "hourly"
+}
+`,
+			},
+		},
+	})
+}

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -147,6 +147,10 @@ func (r *VirtualNetworkResource) ModifyPlan(ctx context.Context, req resource.Mo
 		}
 	}
 
+	if cfg.Project.IsUnknown() {
+		return
+	}
+
 	if !cfg.Project.IsNull() && !cfg.Project.IsUnknown() && cfg.Project.ValueString() != "" {
 		plan.Project = cfg.Project
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -8,10 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 )
@@ -21,37 +19,15 @@ const (
 	testVNSite = "SAO2"
 )
 
-// Provider factories (ProtoV6 + framework)
-var testAccProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"latitudesh": providerserver.NewProtocol6WithError(New("test")()),
-}
-
-func testAccPreCheck(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Fatalf("TF_ACC must be set for acceptance tests")
-	}
-	if os.Getenv("LATITUDESH_AUTH_TOKEN") == "" {
-		t.Fatalf("LATITUDESH_AUTH_TOKEN must be set for acceptance tests")
-	}
-	if os.Getenv("LATITUDESH_TEST_PROJECT") == "" {
-		t.Fatalf("LATITUDESH_TEST_PROJECT must be set (project id/slug used in provider block)")
-	}
-}
-
-func newSDKClientFromEnv() (*latitudeshgosdk.Latitudesh, error) {
-	token := os.Getenv("LATITUDESH_AUTH_TOKEN")
-	if token == "" {
-		return nil, fmt.Errorf("LATITUDESH_AUTH_TOKEN not set")
-	}
-	return latitudeshgosdk.New(latitudeshgosdk.WithSecurity(token)), nil
-}
-
 func TestAccVirtualNetwork_Basic(t *testing.T) {
 	resourceName := "latitudesh_virtual_network.test_item"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProviderFactories,
+		PreCheck: func() {
+			testAccTokenCheck(t)
+			testAccProjectCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		CheckDestroy:             testAccCheckVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -91,47 +67,35 @@ func testAccCheckVirtualNetworkDestroy(s *terraform.State) error {
 
 		resp, err := client.PrivateNetworks.Get(ctx, id)
 		if err == nil && resp != nil && resp.Object != nil && resp.Object.Data != nil &&
-			resp.Object.Data.ID != nil && *resp.Object.Data.ID == id {
+			resp.Object.Data.Data != nil && resp.Object.Data.Data.ID != nil && *resp.Object.Data.Data.ID == id {
 			return fmt.Errorf("virtual network still exists: %s", id)
 		}
 	}
 	return nil
 }
 
-func testAccCheckVirtualNetworkExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
-		}
-
-		client := testAccProvider.Meta().(*latitudeshgosdk.Latitudesh)
-		ctx := context.Background()
-
-		response, err := client.PrivateNetworks.Get(ctx, rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if response.Object == nil || response.Object.Data == nil {
-			return fmt.Errorf("virtual network not found")
-		}
-
-		vnet := response.Object.Data
-		vnData := vnet.GetData()
-
-		if vnData == nil || vnData.GetID() == nil || *vnData.GetID() != rs.Primary.ID {
-			return fmt.Errorf("Record not found: %v", rs.Primary.ID)
-		}
-
-		return nil
+func newSDKClientFromEnv() (*latitudeshgosdk.Latitudesh, error) {
+	token := os.Getenv("LATITUDESH_AUTH_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("LATITUDESH_AUTH_TOKEN not set")
 	}
+	return latitudeshgosdk.New(latitudeshgosdk.WithSecurity(token)), nil
 }
 
-func testAccCheckVirtualNetworkBasic() string {
+func testAccConfigVirtualNetworkWithProviderProject(project, desc, site string) string {
+	return fmt.Sprintf(`
+provider "latitudesh" {
+  project = "%s"
+}
+
+resource "latitudesh_virtual_network" "test_item" {
+  description = "%s"
+  site        = "%s"
+}
+`, project, desc, site)
+}
+
+func testAccCheckVirtualNetworkBasic(project, desc, site string) string {
 	return fmt.Sprintf(`
 terraform {
   required_providers {
@@ -150,4 +114,31 @@ resource "latitudesh_virtual_network" "test_item" {
   site        = "%s"
 }
 `, project, desc, site)
+}
+
+func TestAccVirtualNetwork_UnknownProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccTokenCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config: `
+provider "latitudesh" {}
+
+resource "latitudesh_project" "test" {
+  name        = "tf-acc-unknown-project-vn"
+  environment = "Development"
+}
+
+resource "latitudesh_virtual_network" "test_item" {
+  description = "tf-acc-unknown-project"
+  site        = "SAO2"
+  project     = latitudesh_project.test.id
+}
+`,
+			},
+		},
+	})
 }

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -1,5 +1,3 @@
-//go:build tfplugintesting
-
 package latitudesh
 
 import (


### PR DESCRIPTION
## Problem

When a `latitudesh_project` is created in the same apply as resources that reference its `.id` (virtual_network, server, firewall), the plan phase fails with "Missing project" because the project ID is unknown (not yet created). The ModifyPlan logic treats unknown values the same as absent, erroring out if no default project is configured.

The fix adds an early return in each resource's ModifyPlan when the project value is unknown, letting Terraform show `project = (known after apply)` and resolve it at apply time.

## Pre-landing review

No issues found.

## Test plan

- [x] Manual end-to-end test: `terraform plan` + `terraform apply` with all 4 resources created and destroyed successfully
- [x] `go vet` and `go build` pass
- [x] CI passes

Refs: https://github.com/latitudesh/terraform-provider-latitudesh/issues/171