### PR TITLE
fix(server): apply Lock/Unlock during Create and Update (PD-5985)

### DIFF
--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -679,8 +679,7 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Apply lock if requested. Done before the final read so the read reflects
-	// the locked state returned by the API.
+	// Lock before readServer so the read reflects the locked state.
 	if !data.Locked.IsNull() && !data.Locked.IsUnknown() && data.Locked.ValueBool() {
 		if _, err := r.client.Servers.Lock(ctx, data.ID.ValueString()); err != nil {
 			resp.Diagnostics.AddError("Lock Error", "Unable to lock server: "+err.Error())
@@ -732,7 +731,6 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Locked servers reject modifications, so unlock first when transitioning off.
-	// Re-locking happens before each state.Set below.
 	lockAction := lockActionFor(data.Locked, currentData.Locked)
 	if lockAction == "unlock" {
 		if _, err := r.client.Servers.Unlock(ctx, data.ID.ValueString()); err != nil {
@@ -856,10 +854,8 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// lockActionFor returns "lock", "unlock", or "" based on planned vs current locked state.
-// A null or unknown planned value means "no opinion" and produces no action — relevant for
-// imports or computed-only flows where the framework hasn't resolved a concrete bool.
 func lockActionFor(planned, current types.Bool) string {
+	// Null/unknown planned means "no opinion" — never act on it.
 	if planned.IsNull() || planned.IsUnknown() {
 		return ""
 	}
@@ -874,9 +870,6 @@ func lockActionFor(planned, current types.Bool) string {
 	return "unlock"
 }
 
-// applyEndOfUpdateLock issues Lock at the end of Update when transitioning off→on, and
-// reconciles data.Locked with the action taken so the state matches what the API now reports.
-// Unlock is handled at the top of Update so subsequent modifications are allowed.
 func (r *ServerResource) applyEndOfUpdateLock(ctx context.Context, action string, data *ServerResourceModel, diags *diag.Diagnostics) {
 	switch action {
 	case "lock":

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -679,6 +679,15 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Apply lock if requested. Done before the final read so the read reflects
+	// the locked state returned by the API.
+	if !data.Locked.IsNull() && !data.Locked.IsUnknown() && data.Locked.ValueBool() {
+		if _, err := r.client.Servers.Lock(ctx, data.ID.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Lock Error", "Unable to lock server: "+err.Error())
+			return
+		}
+	}
+
 	r.readServer(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -722,6 +731,16 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	// Locked servers reject modifications, so unlock first when transitioning off.
+	// Re-locking happens before each state.Set below.
+	lockAction := lockActionFor(data.Locked, currentData.Locked)
+	if lockAction == "unlock" {
+		if _, err := r.client.Servers.Unlock(ctx, data.ID.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Unlock Error", "Unable to unlock server: "+err.Error())
+			return
+		}
+	}
+
 	// Determine what changed to decide between reinstall vs in-place update
 	// Compare planned config vs current state
 	needsReinstall, reason := r.needsReinstall(ctx, &data, &currentData, &resp.Diagnostics)
@@ -758,6 +777,11 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 			}
 
 			// Skip reinstall - just update state
+
+			r.applyEndOfUpdateLock(ctx, lockAction, &data, &resp.Diagnostics)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 
 			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			return
@@ -824,7 +848,46 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
+	r.applyEndOfUpdateLock(ctx, lockAction, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// lockActionFor returns "lock", "unlock", or "" based on planned vs current locked state.
+// A null or unknown planned value means "no opinion" and produces no action — relevant for
+// imports or computed-only flows where the framework hasn't resolved a concrete bool.
+func lockActionFor(planned, current types.Bool) string {
+	if planned.IsNull() || planned.IsUnknown() {
+		return ""
+	}
+	want := planned.ValueBool()
+	was := !current.IsNull() && !current.IsUnknown() && current.ValueBool()
+	if want == was {
+		return ""
+	}
+	if want {
+		return "lock"
+	}
+	return "unlock"
+}
+
+// applyEndOfUpdateLock issues Lock at the end of Update when transitioning off→on, and
+// reconciles data.Locked with the action taken so the state matches what the API now reports.
+// Unlock is handled at the top of Update so subsequent modifications are allowed.
+func (r *ServerResource) applyEndOfUpdateLock(ctx context.Context, action string, data *ServerResourceModel, diags *diag.Diagnostics) {
+	switch action {
+	case "lock":
+		if _, err := r.client.Servers.Lock(ctx, data.ID.ValueString()); err != nil {
+			diags.AddError("Lock Error", "Unable to lock server: "+err.Error())
+			return
+		}
+		data.Locked = types.BoolValue(true)
+	case "unlock":
+		data.Locked = types.BoolValue(false)
+	}
 }
 
 // needsReinstall determines if server needs reinstall based on changed fields

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/validators"
@@ -168,6 +169,38 @@ func TestValidateBillingChange(t *testing.T) {
 	}
 }
 
+func TestLockActionFor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		planned types.Bool
+		current types.Bool
+		want    string
+	}{
+		{"no change false→false", types.BoolValue(false), types.BoolValue(false), ""},
+		{"no change true→true", types.BoolValue(true), types.BoolValue(true), ""},
+		{"transition false→true", types.BoolValue(true), types.BoolValue(false), "lock"},
+		{"transition true→false", types.BoolValue(false), types.BoolValue(true), "unlock"},
+		{"null planned, locked current → noop (no opinion)", types.BoolNull(), types.BoolValue(true), ""},
+		{"null planned, unlocked current → noop", types.BoolNull(), types.BoolValue(false), ""},
+		{"unknown planned, locked current → noop", types.BoolUnknown(), types.BoolValue(true), ""},
+		{"locked planned, null current → lock", types.BoolValue(true), types.BoolNull(), "lock"},
+		{"both null → noop", types.BoolNull(), types.BoolNull(), ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := lockActionFor(tc.planned, tc.current)
+			if got != tc.want {
+				t.Fatalf("lockActionFor(%v, %v) = %q, want %q", tc.planned, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAccServer_Basic(t *testing.T) {
 	runTestWithSiteFallback(t, func(site string, recorder *recorder.Recorder) resource.TestCase {
 		return resource.TestCase{
@@ -245,6 +278,66 @@ func TestAccServer_Update(t *testing.T) {
 			},
 		}
 	})
+}
+
+func TestAccServer_Locked(t *testing.T) {
+	runTestWithSiteFallback(t, func(site string, recorder *recorder.Recorder) resource.TestCase {
+		return resource.TestCase{
+			PreCheck: func() {
+				testAccTokenCheck(t)
+				testAccProjectCheck(t)
+			},
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVCR(recorder),
+			CheckDestroy:             testAccCheckServerDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccCheckServerLockedWithSite(site, true),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckServerExists("latitudesh_server.test_item"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "locked", "true"),
+					),
+				},
+				{
+					Config: testAccCheckServerLockedWithSite(site, false),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckServerExists("latitudesh_server.test_item"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "locked", "false"),
+					),
+				},
+				{
+					Config: testAccCheckServerLockedWithSite(site, true),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckServerExists("latitudesh_server.test_item"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "locked", "true"),
+					),
+				},
+			},
+		}
+	})
+}
+
+func testAccCheckServerLockedWithSite(site string, locked bool) string {
+	return fmt.Sprintf(`
+resource "latitudesh_server" "test_item" {
+	billing = "hourly"
+	project = "%s"
+	hostname = "%s"
+	plan     = "%s"
+	site     = "%s"
+	operating_system = "%s"
+	locked   = %t
+}
+`,
+		os.Getenv("LATITUDESH_TEST_PROJECT"),
+		testServerHostname,
+		testServerPlan,
+		site,
+		testServerOperatingSystem,
+		locked,
+	)
 }
 
 func TestAccServer_IPv6Support(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire the SDK `Servers.Lock` / `Servers.Unlock` calls into the `latitudesh_server` resource's Create and Update flows. The `locked` attribute was declared in the schema but neither path called the API endpoints, so after a successful apply `readServer` observed `locked=false` while the plan promised `true`, breaking with `Provider produced inconsistent result after apply: .locked: was cty.True, but now cty.False`.
- Lock on Create when `locked=true`. On Update: unlock at the top when transitioning off (the API rejects modifications on locked servers), and lock at the end when transitioning on. Unlock alone is not paired with a re-lock — that auto-unlock-update-relock case is intentionally out of scope here.
- Tests: `TestLockActionFor` covers the pure decision helper across null/unknown edge cases. `TestAccServer_Locked` exercises the full toggle cycle (`true → false → true`) end-to-end via the existing VCR/acceptance harness.

## Customer impact

Affects 2.x provider. Customer's `terraform apply` fails on any server resource with `locked = true`. Workaround prior to this PR was to remove `locked` from config, which leaves the server unlocked.

## Out of scope (intentional)

- Modifying a server while `locked = true` stays `true`. The API rejects this and the user did not ask for auto unlock-update-relock in this fix.
- Auto-unlock on `Delete`. Customer config uses `prevent_destroy = true`; semantics of "locked but Terraform-deletable" deserve a separate discussion.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./latitudesh -run '^TestLockActionFor$' -v` — 9/9 pass
- [x] CI e2e job runs `TestAccServer_Locked` against the real API (via `TF_ACC=1` + secrets) — verify in PR checks
- [x] Reproduce customer scenario manually: `terraform apply` with `locked = true` on a fresh server, expect no inconsistent-state error