### PR TITLE
feat(server)!: make reinstall opt-in (allow_reinstall default false) + hostname trigger (PD-6009)

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -9,6 +9,12 @@ description: |-
 
 The `latitudesh_server` resource allows you to deploy and manage bare metal servers on [Latitude.sh](https://metal.new) via Terraform.
 
+> **Reinstall behavior (v3.0+)**
+>
+> Server reinstalls now require explicit opt-in. The `allow_reinstall` attribute defaults to `false`. With the default, changing `hostname` is applied in-place via PATCH; changing `operating_system`, `ssh_keys`, `user_data`, `raid`, or `ipxe` fails the plan with an error pointing at the field. Set `allow_reinstall = true` on the resource to perform reinstalls (which destroy data on disk).
+>
+> Migrating from earlier versions: if you previously relied on the default `true` (e.g., to apply OS changes), set `allow_reinstall = true` explicitly on those resources.
+
 ## Example usage
 
 ```hcl
@@ -44,27 +50,27 @@ output "server" {
   - Allowed characters: letters (a–z, A–Z), digits (0–9), dots (.), and hyphens (-);
   - Must not begin or end with a dot or hyphen;
   - Underscores (_) are not allowed;
-  - Updating hostname triggers a reinstall when `allow_reinstall` is `true` (default). Set `allow_reinstall = false` to perform an in-place update instead.
-- `operating_system` (String) The server OS slug. Updating OS will trigger a reinstall. Examples: `ubuntu_24_04_x64_lts`, `ubuntu_22_04_x64_lts`, `debian_12`, `rockylinux_8`, `windows_2022_std`. For a complete list of available operating systems and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-plans-operating-system).
+  - Updating hostname is applied in-place via PATCH by default. Set `allow_reinstall = true` on the resource to make hostname changes trigger a server reinstall instead.
+- `operating_system` (String) The server OS slug. Updating the OS requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error. Examples: `ubuntu_24_04_x64_lts`, `ubuntu_22_04_x64_lts`, `debian_12`, `rockylinux_8`, `windows_2022_std`. For a complete list of available operating systems and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-plans-operating-system).
 - `plan` (String) The server plan slug. Examples: `m4-metal-medium`, `c3-large-x86`, `f4-metal-medium`, `rs4-metal-large`, `g4-rtx6kpro-large`. For a complete list of available plans and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-plans).
 - `project` (String) The id or slug of the project.
 - `site` (String) The server site slug. Examples: `AMS`, `ASH`, `BGT`, `BUE`, `CHI`, `FRA`, `TYO4`. For a complete list of available regions and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-regions).
 
 ### Optional
 
-- `allow_reinstall` (Boolean) Allow server reinstallation when `operating_system`, `hostname`, `ssh_keys`, `user_data`, `raid`, or `ipxe` changes. Defaults to `true`. When `false`, only in-place updates are performed and reinstall-triggering changes are reflected in state without affecting the server.
+- `allow_reinstall` (Boolean) Allow server reinstallation when `operating_system`, `hostname`, `ssh_keys`, `user_data`, `raid`, or `ipxe` changes. **Defaults to `false`.** When `false`, `hostname` changes are applied in-place via PATCH and any other reinstall-only field change fails the plan with an explicit error; set this to `true` on resources where you want reinstalls to happen automatically.
 - `billing` (String) The server billing type.
     Accepts hourly and monthly for on demand projects and yearly for reserved projects.
 - `ipxe` (String) Url for the iPXE script that will be used. 
-    Updating ipxe will trigger a reinstall.
+    Updating ipxe requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error.
 - `locked` (Boolean) Lock/unlock the server. A locked server cannot be deleted or updated.
-- `raid` (String) RAID mode for the server. Updating raid will trigger a reinstall.
+- `raid` (String) RAID mode for the server. Updating raid requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error.
 - `ssh_keys` (List of String) List of server SSH key ids.
-    Any change to `ssh_keys` will force a resource replacement.
+    Updating ssh_keys requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error.
 - `tags` (List of String) List of server tags
 - `timeouts` (Block, Optional) Configurable timeouts for server operations. (see [nested schema below](#nestedblock--timeouts))
 - `user_data` (String) The id of user data to set on the server.
-    Updating user_data will trigger a reinstall.
+    Updating user_data requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error.
 
 ### Nested Schema for `timeouts`
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -44,6 +44,7 @@ output "server" {
   - Allowed characters: letters (a–z, A–Z), digits (0–9), dots (.), and hyphens (-);
   - Must not begin or end with a dot or hyphen;
   - Underscores (_) are not allowed;
+  - Updating hostname triggers a reinstall when `allow_reinstall` is `true` (default). Set `allow_reinstall = false` to perform an in-place update instead.
 - `operating_system` (String) The server OS slug. Updating OS will trigger a reinstall. Examples: `ubuntu_24_04_x64_lts`, `ubuntu_22_04_x64_lts`, `debian_12`, `rockylinux_8`, `windows_2022_std`. For a complete list of available operating systems and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-plans-operating-system).
 - `plan` (String) The server plan slug. Examples: `m4-metal-medium`, `c3-large-x86`, `f4-metal-medium`, `rs4-metal-large`, `g4-rtx6kpro-large`. For a complete list of available plans and their slugs, see the [API reference](https://www.latitude.sh/docs/api-reference/get-plans).
 - `project` (String) The id or slug of the project.
@@ -51,6 +52,7 @@ output "server" {
 
 ### Optional
 
+- `allow_reinstall` (Boolean) Allow server reinstallation when `operating_system`, `hostname`, `ssh_keys`, `user_data`, `raid`, or `ipxe` changes. Defaults to `true`. When `false`, only in-place updates are performed and reinstall-triggering changes are reflected in state without affecting the server.
 - `billing` (String) The server billing type.
     Accepts hourly and monthly for on demand projects and yearly for reserved projects.
 - `ipxe` (String) Url for the iPXE script that will be used. 

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -164,9 +165,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: "Allow server reinstallation when operating_system, hostname, ssh_keys, user_data, raid, or ipxe changes. Defaults to false. When false, hostname changes are applied in-place via PATCH and any other reinstall-only field change fails the plan with an explicit error.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Default:             booldefault.StaticBool(false),
 			},
 			"primary_ipv4": schema.StringAttribute{
 				MarkdownDescription: "Primary IPv4 address of the server",
@@ -683,11 +682,6 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Ensure allow_reinstall has a known value (default to false if not set)
-	if data.AllowReinstall.IsNull() || data.AllowReinstall.IsUnknown() {
-		data.AllowReinstall = types.BoolValue(false)
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -1200,11 +1194,6 @@ func (r *ServerResource) readServer(ctx context.Context, data *ServerResourceMod
 
 	// Tags are handled separately - preserve existing tags if not returned by API
 	// The server API doesn't return tags in the get response, so we don't overwrite them
-
-	// Set default value for allow_reinstall if not set
-	if data.AllowReinstall.IsNull() {
-		data.AllowReinstall = types.BoolValue(false)
-	}
 
 	// Ensure billing is set to a known value to prevent "unknown value after apply" errors
 	if data.Billing.IsUnknown() {

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -161,7 +161,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional:            true,
 			},
 			"allow_reinstall": schema.BoolAttribute{
-				MarkdownDescription: "Allow server reinstallation when operating_system, hostname, ssh_keys, user_data, raid, or ipxe changes. If false, only in-place updates are allowed.",
+				MarkdownDescription: "Allow server reinstallation when operating_system, hostname, ssh_keys, user_data, raid, or ipxe changes. Defaults to false. When false, hostname changes are applied in-place via PATCH and any other reinstall-only field change fails the plan with an explicit error.",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Bool{
@@ -262,77 +262,61 @@ func (r *ServerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 
-	// Centralize reinstall warnings here (only during plan, not during apply)
-	// This avoids duplicate warnings that appeared in Plan Modifiers
+	// Centralize reinstall diagnostics here (only during plan, not during apply)
 	if !req.State.Raw.IsNull() && !isApplyPhase {
-		// Check if allow_reinstall is enabled
-		allowReinstall := true // default
-		if !cfg.AllowReinstall.IsNull() && !cfg.AllowReinstall.IsUnknown() {
-			allowReinstall = cfg.AllowReinstall.ValueBool()
+		// Resolve effective allow_reinstall from the planned value (UseStateForUnknown
+		// already collapsed cfg/state). Default is false.
+		allowReinstall := false
+		if !plan.AllowReinstall.IsNull() && !plan.AllowReinstall.IsUnknown() {
+			allowReinstall = plan.AllowReinstall.ValueBool()
 		}
 
-		if allowReinstall {
-			// Collect all changes that require reinstall
-			var reinstallReasons []string
+		// Reinstall-only triggers: API has no in-place path for these.
+		var reinstallOnlyReasons []string
 
-			// Check operating_system
-			if !state.OperatingSystem.IsNull() && !plan.OperatingSystem.IsNull() {
-				if state.OperatingSystem.ValueString() != plan.OperatingSystem.ValueString() {
-					reinstallReasons = append(reinstallReasons, "operating_system")
-				}
+		if !state.OperatingSystem.IsNull() && !plan.OperatingSystem.IsNull() {
+			if state.OperatingSystem.ValueString() != plan.OperatingSystem.ValueString() {
+				reinstallOnlyReasons = append(reinstallOnlyReasons, "operating_system")
 			}
+		}
+		if !state.UserData.Equal(plan.UserData) && (!state.UserData.IsNull() || !plan.UserData.IsNull()) {
+			reinstallOnlyReasons = append(reinstallOnlyReasons, "user_data")
+		}
+		if !state.Raid.Equal(plan.Raid) && (!state.Raid.IsNull() || !plan.Raid.IsNull()) {
+			reinstallOnlyReasons = append(reinstallOnlyReasons, "raid")
+		}
+		if !state.Ipxe.Equal(plan.Ipxe) && (!state.Ipxe.IsNull() || !plan.Ipxe.IsNull()) {
+			reinstallOnlyReasons = append(reinstallOnlyReasons, "ipxe")
+		}
+		if !state.SSHKeys.Equal(plan.SSHKeys) && (!state.SSHKeys.IsNull() || !plan.SSHKeys.IsNull()) {
+			reinstallOnlyReasons = append(reinstallOnlyReasons, "ssh_keys")
+		}
 
-			// Check hostname (only triggers reinstall when allow_reinstall=true)
-			if !state.Hostname.IsNull() && !plan.Hostname.IsNull() && !plan.Hostname.IsUnknown() {
-				if state.Hostname.ValueString() != plan.Hostname.ValueString() {
-					reinstallReasons = append(reinstallReasons, "hostname")
-				}
+		// Hostname is reinstall-trigger only when allow_reinstall=true; otherwise in-place PATCH.
+		hostnameChanged := !state.Hostname.IsNull() && !plan.Hostname.IsNull() && !plan.Hostname.IsUnknown() &&
+			state.Hostname.ValueString() != plan.Hostname.ValueString()
+
+		switch {
+		case allowReinstall:
+			reasons := append([]string{}, reinstallOnlyReasons...)
+			if hostnameChanged {
+				reasons = append(reasons, "hostname")
 			}
-
-			// Check user_data
-			if !state.UserData.Equal(plan.UserData) {
-				if !state.UserData.IsNull() || !plan.UserData.IsNull() {
-					reinstallReasons = append(reinstallReasons, "user_data")
-				}
-			}
-
-			// Check raid
-			if !state.Raid.Equal(plan.Raid) {
-				if !state.Raid.IsNull() || !plan.Raid.IsNull() {
-					reinstallReasons = append(reinstallReasons, "raid")
-				}
-			}
-
-			// Check ipxe
-			if !state.Ipxe.Equal(plan.Ipxe) {
-				if !state.Ipxe.IsNull() || !plan.Ipxe.IsNull() {
-					reinstallReasons = append(reinstallReasons, "ipxe")
-				}
-			}
-
-			// Check ssh_keys
-			if !state.SSHKeys.Equal(plan.SSHKeys) {
-				stateHasKeys := !state.SSHKeys.IsNull() && !state.SSHKeys.IsUnknown()
-				planHasKeys := !plan.SSHKeys.IsNull() && !plan.SSHKeys.IsUnknown()
-
-				if stateHasKeys && !planHasKeys {
-					resp.Diagnostics.AddWarning(
-						"SSH Keys Removal",
-						"SSH keys will be removed from the server. This will trigger a server reinstall. All data on the server will be lost unless backed up.",
-					)
-				} else if !state.SSHKeys.Equal(plan.SSHKeys) {
-					reinstallReasons = append(reinstallReasons, "ssh_keys")
-				}
-			}
-
-			// Emit consolidated warning if there are changes
-			if len(reinstallReasons) > 0 {
+			if len(reasons) > 0 {
 				resp.Diagnostics.AddWarning(
 					"Server Reinstall Required",
 					fmt.Sprintf("%s changes will trigger a server reinstall. All data on the server will be lost unless backed up.",
-						strings.Join(reinstallReasons, ", ")),
+						strings.Join(reasons, ", ")),
 				)
 			}
+		case len(reinstallOnlyReasons) > 0:
+			resp.Diagnostics.AddError(
+				"Server Reinstall Required",
+				fmt.Sprintf("%s changes require a server reinstall, but allow_reinstall is false. "+
+					"Set allow_reinstall = true on this resource to allow the reinstall, or revert the change.",
+					strings.Join(reinstallOnlyReasons, ", ")),
+			)
+			return
 		}
 	}
 
@@ -699,9 +683,9 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Ensure allow_reinstall has a known value (default to true if not set)
+	// Ensure allow_reinstall has a known value (default to false if not set)
 	if data.AllowReinstall.IsNull() || data.AllowReinstall.IsUnknown() {
-		data.AllowReinstall = types.BoolValue(true)
+		data.AllowReinstall = types.BoolValue(false)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -751,47 +735,16 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		allowReinstall = data.AllowReinstall.ValueBool()
 	}
 
-	// Determine what changed to decide between reinstall vs in-place update
-	// Compare planned config vs current state
-	needsReinstall, reason := r.needsReinstall(ctx, &data, &currentData, allowReinstall, &resp.Diagnostics)
+	// Determine what changed to decide between reinstall vs in-place update.
+	// ModifyPlan rejects reinstall-only triggers when allow_reinstall=false,
+	// so reaching the reinstall branch implies allow_reinstall=true (hostname
+	// is the one trigger that depends on the flag here).
+	needsReinstall, _ := r.needsReinstall(ctx, &data, &currentData, allowReinstall, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	if needsReinstall {
-		if !allowReinstall {
-			// When reinstall is not allowed, just update the state
-			resp.Diagnostics.AddWarning(
-				"State Updated Without Server Changes",
-				fmt.Sprintf("Changes detected (%s) would normally trigger a server reinstall, but allow_reinstall is set to false. "+
-					"The Terraform state has been updated to match your configuration, but no actual server changes were made. "+
-					"Set allow_reinstall=true to perform the actual reinstall.", reason),
-			)
-
-			err := r.updateDeployConfig(ctx, &data, &resp.Diagnostics)
-			if err != nil {
-				resp.Diagnostics.AddError("Deploy Config Update Error", "Unable to update deploy config: "+err.Error())
-				return
-			}
-
-			// Read current server state
-			r.readServer(ctx, &data, &resp.Diagnostics)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			// Skip reinstall - just update state
-
-			r.applyEndOfUpdateLock(ctx, lockAction, &data, &resp.Diagnostics)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			return
-		}
-
-		// Perform reinstall for OS, SSH keys, user data, raid, or ipxe changes
 		err := r.reinstallServer(ctx, &data, &resp.Diagnostics)
 		if err != nil {
 			resp.Diagnostics.AddError("Reinstall Error", "Unable to reinstall server: "+err.Error())
@@ -1250,7 +1203,7 @@ func (r *ServerResource) readServer(ctx context.Context, data *ServerResourceMod
 
 	// Set default value for allow_reinstall if not set
 	if data.AllowReinstall.IsNull() {
-		data.AllowReinstall = types.BoolValue(true)
+		data.AllowReinstall = types.BoolValue(false)
 	}
 
 	// Ensure billing is set to a known value to prevent "unknown value after apply" errors
@@ -1351,10 +1304,5 @@ func (r *ServerResource) updateServerTags(ctx context.Context, serverID string, 
 		}
 	}
 
-	return nil
-}
-
-func (r *ServerResource) updateDeployConfig(ctx context.Context, data *ServerResourceModel, diags *diag.Diagnostics) error {
-	// Just return success so state can be updated with planned values
 	return nil
 }

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -108,7 +108,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"hostname": schema.StringAttribute{
-				MarkdownDescription: "The server hostname",
+				MarkdownDescription: "The server hostname. Changing this value triggers a server reinstall when `allow_reinstall` is `true` (default); set `allow_reinstall = false` to perform an in-place update instead.",
 				Optional:            true,
 				Computed:            true,
 				Validators:          validators.Hostname(),
@@ -161,7 +161,7 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional:            true,
 			},
 			"allow_reinstall": schema.BoolAttribute{
-				MarkdownDescription: "Allow server reinstallation when operating_system, ssh_keys, user_data, raid, or ipxe changes. If false, only in-place updates are allowed.",
+				MarkdownDescription: "Allow server reinstallation when operating_system, hostname, ssh_keys, user_data, raid, or ipxe changes. If false, only in-place updates are allowed.",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Bool{
@@ -279,6 +279,13 @@ func (r *ServerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 			if !state.OperatingSystem.IsNull() && !plan.OperatingSystem.IsNull() {
 				if state.OperatingSystem.ValueString() != plan.OperatingSystem.ValueString() {
 					reinstallReasons = append(reinstallReasons, "operating_system")
+				}
+			}
+
+			// Check hostname (only triggers reinstall when allow_reinstall=true)
+			if !state.Hostname.IsNull() && !plan.Hostname.IsNull() && !plan.Hostname.IsUnknown() {
+				if state.Hostname.ValueString() != plan.Hostname.ValueString() {
+					reinstallReasons = append(reinstallReasons, "hostname")
 				}
 			}
 
@@ -739,20 +746,19 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
+	allowReinstall := true // Default to true for backward compatibility
+	if !data.AllowReinstall.IsNull() && !data.AllowReinstall.IsUnknown() {
+		allowReinstall = data.AllowReinstall.ValueBool()
+	}
+
 	// Determine what changed to decide between reinstall vs in-place update
 	// Compare planned config vs current state
-	needsReinstall, reason := r.needsReinstall(ctx, &data, &currentData, &resp.Diagnostics)
+	needsReinstall, reason := r.needsReinstall(ctx, &data, &currentData, allowReinstall, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	if needsReinstall {
-		// Check if reinstall is allowed
-		allowReinstall := true // Default to true for backward compatibility
-		if !data.AllowReinstall.IsNull() && !data.AllowReinstall.IsUnknown() {
-			allowReinstall = data.AllowReinstall.ValueBool()
-		}
-
 		if !allowReinstall {
 			// When reinstall is not allowed, just update the state
 			resp.Diagnostics.AddWarning(
@@ -883,12 +889,18 @@ func (r *ServerResource) applyEndOfUpdateLock(ctx context.Context, action string
 	}
 }
 
-// needsReinstall determines if server needs reinstall based on changed fields
-func (r *ServerResource) needsReinstall(ctx context.Context, planned *ServerResourceModel, current *ServerResourceModel, diags *diag.Diagnostics) (bool, string) {
+// needsReinstall determines if server needs reinstall based on changed fields.
+// hostname only triggers reinstall when allowReinstall is true; otherwise it
+// stays on the in-place PATCH path.
+func (r *ServerResource) needsReinstall(ctx context.Context, planned *ServerResourceModel, current *ServerResourceModel, allowReinstall bool, diags *diag.Diagnostics) (bool, string) {
 	var reasons []string
 
 	if !planned.OperatingSystem.Equal(current.OperatingSystem) {
 		reasons = append(reasons, "operating_system")
+	}
+
+	if allowReinstall && !planned.Hostname.Equal(current.Hostname) {
+		reasons = append(reasons, "hostname")
 	}
 
 	// Compare SSH keys with proper handling of null vs empty lists

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -196,6 +197,70 @@ func TestLockActionFor(t *testing.T) {
 			got := lockActionFor(tc.planned, tc.current)
 			if got != tc.want {
 				t.Fatalf("lockActionFor(%v, %v) = %q, want %q", tc.planned, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNeedsReinstall(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		planned        ServerResourceModel
+		current        ServerResourceModel
+		allowReinstall bool
+		want           bool
+	}{
+		{
+			name:           "no diff",
+			planned:        ServerResourceModel{Hostname: types.StringValue("h"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			current:        ServerResourceModel{Hostname: types.StringValue("h"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			allowReinstall: true,
+			want:           false,
+		},
+		{
+			name:           "hostname change with allow_reinstall=true triggers reinstall",
+			planned:        ServerResourceModel{Hostname: types.StringValue("new"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			current:        ServerResourceModel{Hostname: types.StringValue("old"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			allowReinstall: true,
+			want:           true,
+		},
+		{
+			name:           "hostname change with allow_reinstall=false stays in-place",
+			planned:        ServerResourceModel{Hostname: types.StringValue("new"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			current:        ServerResourceModel{Hostname: types.StringValue("old"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			allowReinstall: false,
+			want:           false,
+		},
+		{
+			name:           "OS change always triggers reinstall regardless of allow_reinstall",
+			planned:        ServerResourceModel{Hostname: types.StringValue("h"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			current:        ServerResourceModel{Hostname: types.StringValue("h"), OperatingSystem: types.StringValue("ubuntu_22_04_x64_lts")},
+			allowReinstall: false,
+			want:           true,
+		},
+		{
+			name:           "hostname + OS with allow_reinstall=true",
+			planned:        ServerResourceModel{Hostname: types.StringValue("new"), OperatingSystem: types.StringValue("ubuntu_24_04_x64_lts")},
+			current:        ServerResourceModel{Hostname: types.StringValue("old"), OperatingSystem: types.StringValue("ubuntu_22_04_x64_lts")},
+			allowReinstall: true,
+			want:           true,
+		},
+	}
+
+	r := &ServerResource{}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var diags diag.Diagnostics
+			got, _ := r.needsReinstall(context.Background(), &tc.planned, &tc.current, tc.allowReinstall, &diags)
+			if got != tc.want {
+				t.Fatalf("needsReinstall(allowReinstall=%v) = %v, want %v", tc.allowReinstall, got, tc.want)
+			}
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
 			}
 		})
 	}
@@ -797,6 +862,7 @@ resource "latitudesh_server" "test_item" {
 	plan     = "%s"
 	site     = "%s"
 	operating_system = "%s"
+	allow_reinstall = false
 }
 `,
 		os.Getenv("LATITUDESH_TEST_PROJECT"),


### PR DESCRIPTION
## Summary

Make destructive server reinstalls explicit:

- **Flip `allow_reinstall` default from `true` to `false`.** Reinstalls only happen when explicitly opted in.
- **Add `hostname` to the reinstall-trigger list**, gated by `allow_reinstall`.
- **Replace the dishonest `false` path** (state-only update with warning) with a hard plan-time error.

| Trigger | `allow_reinstall = true` | `allow_reinstall = false` (new default) |
|---|---|---|
| `hostname` change | reinstall (`POST /servers/{id}/reinstall`) | in-place PATCH |
| `operating_system` / `ssh_keys` / `user_data` / `raid` / `ipxe` change | reinstall | **plan error**: "Field X change requires a server reinstall, set allow_reinstall = true to proceed" |
| `billing` / `tags` / `project` | unchanged (in-place PATCH) | unchanged (in-place PATCH) |

> [!warning]
> **Breaking change** — likely justifies a v3.0.0 release.
>
> Existing users who relied on the default `true` (e.g., to apply OS changes) must set `allow_reinstall = true` explicitly on those resources after upgrading. Migration note added to `docs/resources/server.md`.

The `updateDeployConfig` no-op and the "State Updated Without Server Changes" warning path are removed; with the plan-time error, `Update` only sees combinations the API can actually fulfill.

Out of scope (separate ticket): apply `billing` / `tags` / `project` in the same apply as a reinstall — pre-existing limitation.

Refs: [PD-6009](https://latitude.atlassian.net/browse/PD-6009)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./latitudesh -run TestNeedsReinstall|TestLockActionFor -v` — all pass
- [x] E2E (first iteration): imported a real server with `allow_reinstall=true`, changed hostname, confirmed plan shows `Server Reinstall Required` warning + `~ hostname` (no replacement)
- [x] E2E (this iteration): with default `allow_reinstall=false`, change `operating_system` and confirm plan fails with "Server Reinstall Required" error pointing at the field
- [x] E2E (this iteration): with default `allow_reinstall=false`, change `hostname` and confirm in-place PATCH (no reinstall)

[PD-6009]: https://latitude.atlassian.net/browse/PD-6009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ