### PR TITLE
feat(server): apply billing/tags/project in the same apply as a reinstall (PD-6011)

### DIFF
--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -758,10 +758,35 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 
-		// Read server to get updated values after reinstall
+		// The reinstall API doesn't accept billing, tags or project. If those
+		// changed in the same plan, follow up with an in-place PATCH so the
+		// state matches reality after this apply (PD-6011).
+		var changedProj bool
+		var newProj string
+		if inPlaceFieldsChanged(&data, &currentData) {
+			var err error
+			changedProj, newProj, err = r.updateServerInPlace(ctx, &data, &currentData, &resp.Diagnostics)
+			if err != nil {
+				resp.Diagnostics.AddError("Update Error", "Unable to update server: "+err.Error())
+				return
+			}
+
+			r.waitForServerReady(ctx, data.ID.ValueString(), &resp.Diagnostics, "post-reinstall update", updateTimeout)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		}
+
+		// Read server to get updated values after reinstall (and follow-up update, if any)
 		r.readServer(ctx, &data, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+
+		// readServer only writes project when state was null/unknown, so reinstate
+		// the changed project explicitly (mirrors the in-place-only branch below).
+		if changedProj && newProj != "" {
+			data.Project = types.StringValue(newProj)
 		}
 	} else {
 		// Performing in-place update
@@ -805,6 +830,23 @@ func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// inPlaceFieldsChanged reports whether billing, tags or project differ between
+// the planned and current models. These are the fields that the reinstall API
+// does not accept; when any of them changed in a reinstall apply, a follow-up
+// PATCH is required to keep state in sync with reality.
+func inPlaceFieldsChanged(planned, current *ServerResourceModel) bool {
+	if !planned.Billing.IsNull() && !planned.Billing.IsUnknown() && !planned.Billing.Equal(current.Billing) {
+		return true
+	}
+	if !planned.Project.IsNull() && !planned.Project.IsUnknown() && !planned.Project.Equal(current.Project) {
+		return true
+	}
+	if !planned.Tags.Equal(current.Tags) {
+		return true
+	}
+	return false
 }
 
 func lockActionFor(planned, current types.Bool) string {

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -266,6 +266,74 @@ func TestNeedsReinstall(t *testing.T) {
 	}
 }
 
+func TestInPlaceFieldsChanged(t *testing.T) {
+	t.Parallel()
+
+	tagsA, diagsA := types.ListValueFrom(context.Background(), types.StringType, []string{"tag-1"})
+	if diagsA.HasError() {
+		t.Fatalf("setup tagsA: %v", diagsA)
+	}
+	tagsB, diagsB := types.ListValueFrom(context.Background(), types.StringType, []string{"tag-2"})
+	if diagsB.HasError() {
+		t.Fatalf("setup tagsB: %v", diagsB)
+	}
+
+	cases := []struct {
+		name    string
+		planned ServerResourceModel
+		current ServerResourceModel
+		want    bool
+	}{
+		{
+			name:    "no diff",
+			planned: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			current: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    false,
+		},
+		{
+			name:    "billing changed",
+			planned: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			current: ServerResourceModel{Billing: types.StringValue("hourly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    true,
+		},
+		{
+			name:    "project changed",
+			planned: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_b"), Tags: tagsA},
+			current: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    true,
+		},
+		{
+			name:    "tags changed",
+			planned: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsB},
+			current: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    true,
+		},
+		{
+			name:    "planned billing unknown is ignored",
+			planned: ServerResourceModel{Billing: types.StringUnknown(), Project: types.StringValue("proj_a"), Tags: tagsA},
+			current: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    false,
+		},
+		{
+			name:    "planned project null is ignored",
+			planned: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringNull(), Tags: tagsA},
+			current: ServerResourceModel{Billing: types.StringValue("monthly"), Project: types.StringValue("proj_a"), Tags: tagsA},
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := inPlaceFieldsChanged(&tc.planned, &tc.current)
+			if got != tc.want {
+				t.Fatalf("inPlaceFieldsChanged = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAccServer_Basic(t *testing.T) {
 	runTestWithSiteFallback(t, func(site string, recorder *recorder.Recorder) resource.TestCase {
 		return resource.TestCase{


### PR DESCRIPTION
## Summary

Closes the pre-existing gap where `billing` / `tags` / `project` changes were silently dropped when they shared an apply with a reinstall trigger. After v3.0.0 (PD-6009) added `hostname` to the trigger list, this combo became more likely to be hit, motivating the fix.

The reinstall API does not accept `billing`, `tags` or `project`. Before this PR, `Update` was "A xor B" — either `reinstallServer` or `updateServerInPlace`, never both — so:

- `billing`: API kept the old value, `readServer` reverted it on state, the diff resurfaced on the next plan (visible but required a 2nd apply).
- `tags` / `project`: state adopted the planned value while the API stayed on the old one — silent drift.

## What changed

- `Update`: when the reinstall path runs and `inPlaceFieldsChanged()` reports a delta in `billing`/`tags`/`project`, follow up with `updateServerInPlace` and a second `waitForServerReady("post-reinstall update")` before `readServer`. Project handling mirrors the in-place-only branch.
- New helper `inPlaceFieldsChanged(planned, current)` factored out for testability.
- New unit test `TestInPlaceFieldsChanged` covering: no diff, billing change, project change, tags change, planned-billing-unknown ignored, planned-project-null ignored.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./latitudesh -run 'TestInPlaceFieldsChanged|TestNeedsReinstall|TestLockActionFor'` — all pass
- [x] **E2E**: applied `hostname rt3 → rt4` + `billing monthly → yearly` against a real server with the local provider build. Apply log shows the expected sequence:

  ```
  Server reinstall: status changed from '' to 'deploying' (waiting for 'on')
  Server reinstall: status changed from 'deploying' to 'on' (waiting for 'on')
  Server reinstall completed successfully (status: on)
  Server post-reinstall update: status changed from '' to 'on' (waiting for 'on')
  Server post-reinstall update completed successfully (status: on)
  Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
  ```

  Post-apply, state == API for both `hostname` and `billing`, and a follow-up `terraform plan` returned `No changes` (no drift).

Refs: [PD-6011](https://latitude.atlassian.net/browse/PD-6011)

[PD-6011]: https://latitude.atlassian.net/browse/PD-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ