### PR TITLE
docs(server): document combo apply behavior (PD-6011)

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -9,11 +9,13 @@ description: |-
 
 The `latitudesh_server` resource allows you to deploy and manage bare metal servers on [Latitude.sh](https://metal.new) via Terraform.
 
-> **Reinstall behavior (v3.0+)**
+> **Reinstall behavior**
 >
-> Server reinstalls now require explicit opt-in. The `allow_reinstall` attribute defaults to `false`. With the default, changing `hostname` is applied in-place via PATCH; changing `operating_system`, `ssh_keys`, `user_data`, `raid`, or `ipxe` fails the plan with an error pointing at the field. Set `allow_reinstall = true` on the resource to perform reinstalls (which destroy data on disk).
+> Server reinstalls require explicit opt-in. The `allow_reinstall` attribute defaults to `false`. With the default, changing `hostname` is applied in-place via PATCH; changing `operating_system`, `ssh_keys`, `user_data`, `raid`, or `ipxe` fails the plan with an error pointing at the field. Set `allow_reinstall = true` on the resource to perform reinstalls (which destroy data on disk).
 >
-> Migrating from earlier versions: if you previously relied on the default `true` (e.g., to apply OS changes), set `allow_reinstall = true` explicitly on those resources.
+> When a reinstall-trigger field changes alongside `billing`, `tags`, or `project` in the same plan, the provider runs the reinstall first and follows up with an in-place PATCH so all changes are applied in a single apply.
+>
+> Migrating from earlier versions (pre-v3.0): if you previously relied on the default `true` (e.g., to apply OS changes), set `allow_reinstall = true` explicitly on those resources.
 
 ## Example usage
 


### PR DESCRIPTION
## Summary

Updates the `latitudesh_server` resource doc to reflect the combo behavior shipped in v3.0.1 (PD-6011): reinstall-trigger changes can now coexist with `billing`/`tags`/`project` changes in a single apply, with the reinstall running first and a follow-up in-place PATCH applying the rest.

Also drops the `(v3.0+)` version tag from the "Reinstall behavior" callout (now stable, pre-v3.0 reference moved into the migration paragraph).

## Diff (single file)

`docs/resources/server.md` — three small changes inside the existing callout box:

1. Title: `Reinstall behavior (v3.0+)` → `Reinstall behavior`.
2. Removed `now` from the first sentence.
3. Inserted a new paragraph between the opt-in description and the migration note explaining the combo apply.
4. Migration paragraph reworded to keep the version reference: `(pre-v3.0)`.

No code changes.

Refs: [PD-6011](https://latitude.atlassian.net/browse/PD-6011)

[PD-6011]: https://latitude.atlassian.net/browse/PD-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ