### PR TITLE
fix(virtual-network): apply tags via PATCH and unblock in-place updates (PD-6027)

### DIFF
--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -40,7 +40,7 @@ resource "latitudesh_virtual_network" "virtual_network" {
 
 ### Optional
 
-- `tags` (List of String) List of virtual network tags
+- `tags` (List of String) List of virtual network tag IDs
 
 ### Read-Only
 

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -82,7 +82,7 @@ func (r *VirtualNetworkResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"tags": schema.ListAttribute{
-				MarkdownDescription: "List of virtual network tags",
+				MarkdownDescription: "List of virtual network tag IDs",
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
@@ -213,8 +213,6 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 		attrs.Description = data.Description.ValueString()
 	}
 
-	// Note: Tags are not supported in the create operation, only in update
-
 	createRequest := operations.CreateVirtualNetworkPrivateNetworksRequestBody{
 		Data: operations.CreateVirtualNetworkPrivateNetworksData{
 			Type:       operations.CreateVirtualNetworkPrivateNetworksTypeVirtualNetwork,
@@ -257,6 +255,26 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 		}
 	}
 
+	// The Create endpoint does not accept tags; apply them via PATCH so they
+	// land on the resource and don't drift on the next plan.
+	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
+		var tagIDs []string
+		resp.Diagnostics.Append(data.Tags.ElementsAs(ctx, &tagIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if len(tagIDs) > 0 {
+			if err := r.validateTagIDs(ctx, tagIDs); err != nil {
+				resp.Diagnostics.AddError("Tag Validation Error", "Unable to validate tag IDs: "+err.Error())
+				return
+			}
+			if err := r.applyTags(ctx, data.ID.ValueString(), tagIDs, data.Description.ValueString()); err != nil {
+				resp.Diagnostics.AddError("Tag Update Error", "Unable to apply tags to virtual network: "+err.Error())
+				return
+			}
+		}
+	}
+
 	// Read the resource to populate all attributes
 	r.readVirtualNetwork(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -284,9 +302,37 @@ func (r *VirtualNetworkResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError("Update Not Supported",
-		"Virtual network updates are not supported due to SDK limitations. "+
-			"Changes to description require resource replacement.")
+	var plan VirtualNetworkResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// description, site, project all have RequiresReplace, so the only
+	// attribute that reaches Update is `tags`.
+	var tagIDs []string
+	if !plan.Tags.IsNull() && !plan.Tags.IsUnknown() {
+		resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tagIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if err := r.validateTagIDs(ctx, tagIDs); err != nil {
+			resp.Diagnostics.AddError("Tag Validation Error", "Unable to validate tag IDs: "+err.Error())
+			return
+		}
+	}
+
+	if err := r.applyTags(ctx, plan.ID.ValueString(), tagIDs, plan.Description.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Tag Update Error", "Unable to update virtual network tags: "+err.Error())
+		return
+	}
+
+	r.readVirtualNetworkByID(ctx, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *VirtualNetworkResource) findVirtualNetworkByProject(ctx context.Context, data *VirtualNetworkResourceModel, diags *diag.Diagnostics) {
@@ -509,13 +555,13 @@ func (r *VirtualNetworkResource) ImportState(ctx context.Context, req resource.I
 
 		tags := attrs.GetTags()
 		if len(tags) > 0 {
-			tagNames := make([]attr.Value, 0, len(tags))
+			tagIDs := make([]attr.Value, 0, len(tags))
 			for _, tag := range tags {
-				if tag.GetName() != nil {
-					tagNames = append(tagNames, types.StringValue(*tag.GetName()))
+				if tag.GetID() != nil {
+					tagIDs = append(tagIDs, types.StringValue(*tag.GetID()))
 				}
 			}
-			tagList, diagErr := types.ListValue(types.StringType, tagNames)
+			tagList, diagErr := types.ListValue(types.StringType, tagIDs)
 			if diagErr.HasError() {
 				resp.Diagnostics.Append(diagErr...)
 			} else {
@@ -611,13 +657,13 @@ func (r *VirtualNetworkResource) readVirtualNetworkByID(ctx context.Context, dat
 
 	tags := attrs.GetTags()
 	if len(tags) > 0 {
-		tagNames := make([]attr.Value, 0, len(tags))
+		tagIDs := make([]attr.Value, 0, len(tags))
 		for _, tag := range tags {
-			if tag.GetName() != nil {
-				tagNames = append(tagNames, types.StringValue(*tag.GetName()))
+			if tag.GetID() != nil {
+				tagIDs = append(tagIDs, types.StringValue(*tag.GetID()))
 			}
 		}
-		tagList, diagErr := types.ListValue(types.StringType, tagNames)
+		tagList, diagErr := types.ListValue(types.StringType, tagIDs)
 		if diagErr.HasError() {
 			diags.Append(diagErr...)
 		} else {
@@ -707,4 +753,70 @@ func (r *VirtualNetworkResource) readVirtualNetwork(ctx context.Context, data *V
 			data.Description = types.StringNull()
 		}
 	}
+}
+
+func (r *VirtualNetworkResource) validateTagIDs(ctx context.Context, tagIDs []string) error {
+	if len(tagIDs) == 0 {
+		return nil
+	}
+
+	response, err := r.client.Tags.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	if response.CustomTags == nil || response.CustomTags.Data == nil {
+		return fmt.Errorf("no tags found")
+	}
+
+	validTagIDs := make(map[string]bool)
+	for _, tag := range response.CustomTags.Data {
+		if tag.ID != nil {
+			validTagIDs[*tag.ID] = true
+		}
+	}
+
+	for _, tagID := range tagIDs {
+		if !validTagIDs[tagID] {
+			return fmt.Errorf("tag ID '%s' not found", tagID)
+		}
+	}
+
+	return nil
+}
+
+// applyTags PATCHes the virtual network with the provided tag IDs. The SDK's
+// Update payload includes a non-omitempty `description` with a default value,
+// so we always echo the planned description back to avoid clobbering it.
+func (r *VirtualNetworkResource) applyTags(ctx context.Context, vlanID string, tagIDs []string, description string) error {
+	if vlanID == "" {
+		return fmt.Errorf("virtual network ID is empty")
+	}
+
+	desc := description
+	attrs := &operations.UpdateVirtualNetworkPrivateNetworksAttributes{
+		Tags:        tagIDs,
+		Description: &desc,
+	}
+
+	body := operations.UpdateVirtualNetworkPrivateNetworksRequestBody{
+		Data: operations.UpdateVirtualNetworkPrivateNetworksData{
+			ID:         vlanID,
+			Type:       operations.UpdateVirtualNetworkPrivateNetworksTypeVirtualNetworks,
+			Attributes: attrs,
+		},
+	}
+
+	result, err := r.client.PrivateNetworks.Update(ctx, vlanID, body)
+	if err != nil {
+		return fmt.Errorf("unable to update virtual network: %w", err)
+	}
+
+	if result != nil && result.HTTPMeta.Response != nil {
+		if status := result.HTTPMeta.Response.StatusCode; status >= 400 {
+			return fmt.Errorf("virtual network update failed with status code: %d", status)
+		}
+	}
+
+	return nil
 }

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -114,6 +114,85 @@ resource "latitudesh_virtual_network" "test_item" {
 `, project, desc, site)
 }
 
+// TestAccVirtualNetwork_WithTags exercises the previously-broken path where
+// a virtual network is created with tags, then re-planned (must be empty),
+// then has its tag set updated in-place. Before the fix in PD-6027, the
+// provider silently dropped tags on Create and hard-coded Update to error.
+//
+// Requires LATITUDESH_TEST_TAG_ID and LATITUDESH_TEST_TAG_ID_ALT to point at
+// two distinct, pre-existing custom tag IDs in the test team.
+func TestAccVirtualNetwork_WithTags(t *testing.T) {
+	tagID := os.Getenv("LATITUDESH_TEST_TAG_ID")
+	altTagID := os.Getenv("LATITUDESH_TEST_TAG_ID_ALT")
+	if tagID == "" || altTagID == "" {
+		t.Skip("LATITUDESH_TEST_TAG_ID and LATITUDESH_TEST_TAG_ID_ALT must be set for this test")
+	}
+
+	resourceName := "latitudesh_virtual_network.test_item"
+	project := os.Getenv("LATITUDESH_TEST_PROJECT")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccTokenCheck(t)
+			testAccProjectCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigVirtualNetworkWithTags(project, testVNDesc, testVNSite, []string{tagID}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", tagID),
+				),
+			},
+			{
+				// Idempotency — same config, plan must be empty.
+				Config:             testAccConfigVirtualNetworkWithTags(project, testVNDesc, testVNSite, []string{tagID}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// In-place tag update must succeed (was the hard-error path).
+				Config: testAccConfigVirtualNetworkWithTags(project, testVNDesc, testVNSite, []string{tagID, altTagID}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigVirtualNetworkWithTags(project, desc, site string, tagIDs []string) string {
+	quoted := make([]string, len(tagIDs))
+	for i, id := range tagIDs {
+		quoted[i] = fmt.Sprintf("%q", id)
+	}
+	return fmt.Sprintf(`
+provider "latitudesh" {
+  project = "%s"
+}
+
+resource "latitudesh_virtual_network" "test_item" {
+  description = "%s"
+  site        = "%s"
+  tags        = [%s]
+}
+`, project, desc, site, joinComma(quoted))
+}
+
+func joinComma(s []string) string {
+	out := ""
+	for i, v := range s {
+		if i > 0 {
+			out += ", "
+		}
+		out += v
+	}
+	return out
+}
+
 func TestAccVirtualNetwork_UnknownProject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccTokenCheck(t) },


### PR DESCRIPTION
## Summary

- `latitudesh_virtual_network` was silently dropping `tags` on Create and hard-coding `Update` to error, locking customers out of running `terraform apply` twice on the same config (Slack: [thread](https://latitude-sh.slack.com/archives/C05ARKE7NDR/p1778162867786829)).
- Create now PATCHes tags onto the resource right after the POST, so they reach the backend instead of being dropped.
- Update is now a real implementation that validates tag IDs and propagates the planned tag set.
- Read paths expose tag IDs (matching the schema and what users write in config) instead of tag names.

## Why two bugs locked the user out

- `Create` skipped tags entirely (`// Tags are not supported in the create operation, only in update` — stale comment; the SDK and API have supported tags on update for a while). State ended up with `tags = null` while config still had tags.
- `Update` was hard-coded to return `Update Not Supported`. Since `description`, `site`, `project` already have `RequiresReplace`, the only attribute reaching `Update` was `tags` — which then always errored. The error message even said "Changes to description require resource replacement", which was misleading.

Together: every second `terraform apply` failed.

## What changed

- `Create`: after the POST, if `tags` is non-null/non-empty, validate IDs via `Tags.List` and PATCH them onto the resource via `PrivateNetworks.Update`. Mirror of `resource_server.go`'s `updateServerTags` / `validateTagIDs`.
- `Update`: extract planned tags, validate, PATCH, re-read state. The PATCH always echoes the planned `description` because the SDK marshals a default value (`"Test virtual network update"`) when `Description` is nil — leaving it nil would clobber the description.
- `readVirtualNetworkByID` and `ImportState`: store `tag.GetID()` (was `tag.GetName()`), so state matches what users write in config.
- Schema docstring + generated docs: `tags` is "List of virtual network tag IDs".

## Example to test

```hcl
terraform {
  required_providers {
    latitudesh = { source = "latitudesh/latitudesh" }
  }
}

provider "latitudesh" {}

resource "latitudesh_tag" "a" {
  name  = "vnet-test-a"
  color = "#ff8800"
}

resource "latitudesh_tag" "b" {
  name  = "vnet-test-b"
  color = "#0088ff"
}

resource "latitudesh_virtual_network" "test" {
  description = "vnet test"
  site        = "ASH"
  project     = "<your-project-id>"
  tags        = [latitudesh_tag.a.id]
}
```

Lifecycle that previously broke at step 2 and step 3:

1. `terraform apply` — creates the vnet with one tag.
2. `terraform plan` — must report `No changes` (was a perpetual `update in-place` diff before).
3. Edit `tags = [latitudesh_tag.a.id, latitudesh_tag.b.id]`, then `terraform apply` — must succeed in-place (was `Error: Update Not Supported`).
4. `terraform plan` — `No changes`.
5. Remove the `tags` line, `terraform apply` — clears tags. `terraform plan` — `No changes`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Existing unit tests pass (excluding pre-existing `TestValidateUserData` failures, unrelated)
- [x] Manual E2E against live API (Lanusse dev project, ASH): create vnet with 1 tag → plan no diff → swap to a different tag → apply succeeds → API GET confirms `tags` populated server-side with `id`/`name`/`description`/`color`
- [x] Acceptance test added: `TestAccVirtualNetwork_WithTags` covers create-with-tags, idempotent plan, and tag mutation. Skipped unless `LATITUDESH_TEST_TAG_ID` and `LATITUDESH_TEST_TAG_ID_ALT` are exported.

## Notes for reviewers

- The customer's `tags = ["latitude-talos", "kubernetes", "talos"]` were strings that look like names — the schema docstring change clarifies that the field expects **tag IDs** (matching `latitudesh_server`). After this PR, an invalid value surfaces as `Tag Validation Error: tag ID '<value>' not found` instead of silently being dropped or failing opaquely.
- The SDK's `UpdateVirtualNetworkPrivateNetworksAttributes.Description` has `default:"Test virtual network update"` without `omitempty` — see `applyTags` for why we always echo the planned description.