### PR TITLE
fix(virtual-network, vlan-assignment): orphan-prevention, Computed Null fallback, set-aware tag ordering (PD-6028)

### DIFF
--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -194,6 +194,22 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 	// persist in state to avoid flapping of Optional+Computed
 	data.Project = types.StringValue(effectiveProject)
 
+	// Extract and validate tag IDs *before* the Create POST so an invalid tag
+	// can't leave behind an orphan virtual network in the backend.
+	var tagIDs []string
+	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
+		resp.Diagnostics.Append(data.Tags.ElementsAs(ctx, &tagIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if len(tagIDs) > 0 {
+			if err := r.validateTagIDs(ctx, tagIDs); err != nil {
+				resp.Diagnostics.AddError("Tag Validation Error", "Unable to validate tag IDs: "+err.Error())
+				return
+			}
+		}
+	}
+
 	// Prepare attributes for creation
 	attrs := operations.CreateVirtualNetworkPrivateNetworksAttributes{}
 
@@ -256,22 +272,14 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// The Create endpoint does not accept tags; apply them via PATCH so they
-	// land on the resource and don't drift on the next plan.
-	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
-		var tagIDs []string
-		resp.Diagnostics.Append(data.Tags.ElementsAs(ctx, &tagIDs, false)...)
-		if resp.Diagnostics.HasError() {
+	// land on the resource and don't drift on the next plan. If the PATCH
+	// fails, attempt to delete the just-created VNet so we don't leave an
+	// orphan in the backend that blocks downstream destroys.
+	if len(tagIDs) > 0 {
+		if err := r.applyTags(ctx, data.ID.ValueString(), tagIDs, data.Description.ValueString()); err != nil {
+			r.cleanupOrphanVNet(ctx, data.ID.ValueString(), &resp.Diagnostics)
+			resp.Diagnostics.AddError("Tag Update Error", "Unable to apply tags to virtual network: "+err.Error())
 			return
-		}
-		if len(tagIDs) > 0 {
-			if err := r.validateTagIDs(ctx, tagIDs); err != nil {
-				resp.Diagnostics.AddError("Tag Validation Error", "Unable to validate tag IDs: "+err.Error())
-				return
-			}
-			if err := r.applyTags(ctx, data.ID.ValueString(), tagIDs, data.Description.ValueString()); err != nil {
-				resp.Diagnostics.AddError("Tag Update Error", "Unable to apply tags to virtual network: "+err.Error())
-				return
-			}
 		}
 	}
 
@@ -655,23 +663,52 @@ func (r *VirtualNetworkResource) readVirtualNetworkByID(ctx context.Context, dat
 		data.Region = types.StringNull()
 	}
 
+	// Tags need set-equivalence handling: the API treats `tags` as a set
+	// (no order preserved server-side), but the schema is a List. If we
+	// blindly overwrite state.Tags with the API's order, the next plan
+	// shows a phantom diff and the framework rejects "inconsistent result
+	// after apply". When state and API hold the same set of tag IDs, keep
+	// state's order; only adopt the API ordering when an actual drift is
+	// detected (different membership).
 	tags := attrs.GetTags()
-	if len(tags) > 0 {
-		tagIDs := make([]attr.Value, 0, len(tags))
-		for _, tag := range tags {
-			if tag.GetID() != nil {
-				tagIDs = append(tagIDs, types.StringValue(*tag.GetID()))
-			}
+	apiOrder := make([]attr.Value, 0, len(tags))
+	apiSet := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if tag.GetID() != nil {
+			apiOrder = append(apiOrder, types.StringValue(*tag.GetID()))
+			apiSet[*tag.GetID()] = struct{}{}
 		}
-		tagList, diagErr := types.ListValue(types.StringType, tagIDs)
-		if diagErr.HasError() {
-			diags.Append(diagErr...)
-		} else {
-			data.Tags = tagList
-		}
-	} else {
-		data.Tags = types.ListNull(types.StringType)
 	}
+
+	preserveStateOrder := false
+	if !data.Tags.IsNull() && !data.Tags.IsUnknown() && len(data.Tags.Elements()) == len(apiOrder) {
+		var stateIDs []string
+		if !data.Tags.ElementsAs(ctx, &stateIDs, false).HasError() {
+			allMatch := true
+			for _, sid := range stateIDs {
+				if _, ok := apiSet[sid]; !ok {
+					allMatch = false
+					break
+				}
+			}
+			preserveStateOrder = allMatch
+		}
+	}
+
+	if preserveStateOrder {
+		// data.Tags already reflects the same set; keep its ordering.
+		return
+	}
+	if len(apiOrder) == 0 {
+		data.Tags = types.ListNull(types.StringType)
+		return
+	}
+	tagList, diagErr := types.ListValue(types.StringType, apiOrder)
+	if diagErr.HasError() {
+		diags.Append(diagErr...)
+		return
+	}
+	data.Tags = tagList
 }
 
 func (r *VirtualNetworkResource) readVirtualNetwork(ctx context.Context, data *VirtualNetworkResourceModel, diags *diag.Diagnostics) {
@@ -752,6 +789,22 @@ func (r *VirtualNetworkResource) readVirtualNetwork(ctx context.Context, data *V
 		if data.Description.IsUnknown() {
 			data.Description = types.StringNull()
 		}
+	}
+}
+
+// cleanupOrphanVNet best-effort deletes a VNet that was created server-side
+// but couldn't complete its post-create work (e.g., tag PATCH failed). A
+// failure here is logged as a warning rather than promoted to an error so the
+// caller's original failure remains the surfaced one.
+func (r *VirtualNetworkResource) cleanupOrphanVNet(ctx context.Context, vlanID string, diags *diag.Diagnostics) {
+	if vlanID == "" {
+		return
+	}
+	if _, err := r.client.VirtualNetworks.Delete(ctx, vlanID); err != nil {
+		diags.AddWarning(
+			"Orphan Cleanup Failed",
+			fmt.Sprintf("Failed to delete partially-created virtual network %s: %s. Manual cleanup may be required.", vlanID, err.Error()),
+		)
 	}
 }
 

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 )
 
 const (
@@ -191,6 +193,65 @@ func joinComma(s []string) string {
 		out += v
 	}
 	return out
+}
+
+// TestAccVirtualNetwork_InvalidTagFailsBeforePOST verifies that PD-6028's fix
+// validates tag IDs before the Create POST and does not leave an orphan VNet
+// in the backend when validation fails.
+func TestAccVirtualNetwork_InvalidTagFailsBeforePOST(t *testing.T) {
+	project := os.Getenv("LATITUDESH_TEST_PROJECT")
+	if project == "" {
+		t.Skip("LATITUDESH_TEST_PROJECT must be set")
+	}
+
+	desc := "tf-acc-pd6028-orphan-check"
+	bogusTagID := "tag_pd6028_definitely_not_a_real_tag"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccTokenCheck(t)
+			testAccProjectCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccConfigVirtualNetworkWithTags(project, desc, testVNSite, []string{bogusTagID}),
+				ExpectError: regexp.MustCompile(`Tag Validation Error`),
+			},
+		},
+		CheckDestroy: func(s *terraform.State) error {
+			// After the failed apply, the backend must not contain a vnet
+			// with our description — otherwise the orphan-prevention regressed.
+			ctx := context.Background()
+			client, err := newSDKClientFromEnv()
+			if err != nil {
+				return err
+			}
+			resp, err := client.PrivateNetworks.List(ctx, operations.GetVirtualNetworksRequest{
+				FilterProject: &project,
+			})
+			if err != nil {
+				return fmt.Errorf("listing vnets to check for orphan: %w", err)
+			}
+			if resp.VirtualNetworks == nil || resp.VirtualNetworks.Data == nil {
+				return nil
+			}
+			for _, vn := range resp.VirtualNetworks.Data {
+				attrs := vn.GetAttributes()
+				if attrs == nil || attrs.GetDescription() == nil {
+					continue
+				}
+				if *attrs.GetDescription() == desc {
+					id := ""
+					if vn.GetID() != nil {
+						id = *vn.GetID()
+					}
+					return fmt.Errorf("orphan vnet %s left behind with description %q (PD-6028 regression)", id, desc)
+				}
+			}
+			return nil
+		},
+	})
 }
 
 func TestAccVirtualNetwork_UnknownProject(t *testing.T) {

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -204,7 +205,9 @@ func TestAccVirtualNetwork_InvalidTagFailsBeforePOST(t *testing.T) {
 		t.Skip("LATITUDESH_TEST_PROJECT must be set")
 	}
 
-	desc := "tf-acc-pd6028-orphan-check"
+	// Suffix per-run so parallel CI jobs don't false-trigger each other's
+	// orphan check on the shared project.
+	desc := fmt.Sprintf("tf-acc-pd6028-orphan-check-%s", acctest.RandString(6))
 	bogusTagID := "tag_pd6028_definitely_not_a_real_tag"
 
 	resource.Test(t, resource.TestCase{

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -231,60 +231,83 @@ func (r *VlanAssignmentResource) ImportState(ctx context.Context, req resource.I
 func (r *VlanAssignmentResource) readVlanAssignment(ctx context.Context, data *VlanAssignmentResourceModel, diags *diag.Diagnostics) {
 	assignmentID := data.ID.ValueString()
 
-	// Get all virtual network assignments and find ours
-	response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})
-	if err != nil {
-		diags.AddError("Client Error", "Unable to read virtual network assignments, got error: "+err.Error())
-		return
-	}
+	// Initialize Computed attributes to Null. Plugin Framework requires every
+	// Computed attribute to be Known (concrete value or explicit Null) after
+	// Apply; if the API response is missing one of these fields we still want
+	// a concrete Null in state rather than Unknown.
+	data.Vid = types.Int64Null()
+	data.Description = types.StringNull()
+	data.Status = types.StringNull()
 
-	if response.VirtualNetworkAssignments == nil || response.VirtualNetworkAssignments.Data == nil {
-		data.ID = types.StringNull()
-		return
-	}
+	// The API populates `vid` asynchronously when assignments are created in
+	// parallel (NetBox `get_next_vid` allocation). Retry the lookup a few
+	// times so we don't surface Null and trigger a phantom diff on refresh.
+	const vidRetryAttempts = 3
+	for attempt := 0; attempt < vidRetryAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Second)
+		}
 
-	// Find our assignment
-	var assignment *components.VirtualNetworkAssignmentData
-	for _, a := range response.VirtualNetworkAssignments.Data {
-		if a.ID != nil && *a.ID == assignmentID {
-			assignment = &a
-			break
+		response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})
+		if err != nil {
+			diags.AddError("Client Error", "Unable to read virtual network assignments, got error: "+err.Error())
+			return
+		}
+
+		if response.VirtualNetworkAssignments == nil || response.VirtualNetworkAssignments.Data == nil {
+			data.ID = types.StringNull()
+			return
+		}
+
+		var assignment *components.VirtualNetworkAssignmentData
+		for _, a := range response.VirtualNetworkAssignments.Data {
+			if a.ID != nil && *a.ID == assignmentID {
+				assignment = &a
+				break
+			}
+		}
+
+		if assignment == nil {
+			data.ID = types.StringNull()
+			return
+		}
+
+		if assignment.Attributes != nil {
+			attrs := assignment.Attributes
+			if attrs.Server != nil && attrs.Server.ID != nil {
+				data.ServerID = types.StringValue(*attrs.Server.ID)
+			}
+			if attrs.VirtualNetworkID != nil {
+				data.VirtualNetworkID = types.StringValue(*attrs.VirtualNetworkID)
+			}
+			if attrs.Vid != nil {
+				data.Vid = types.Int64Value(*attrs.Vid)
+			}
+			if attrs.Description != nil {
+				data.Description = types.StringValue(*attrs.Description)
+			}
+			if attrs.Status != nil {
+				data.Status = types.StringValue(*attrs.Status)
+			}
+		}
+
+		// If we got the vid, we're done. Otherwise retry.
+		if !data.Vid.IsNull() {
+			return
 		}
 	}
-
-	if assignment == nil {
-		data.ID = types.StringNull()
-		return
-	}
-
-	if assignment.Attributes != nil {
-		attrs := assignment.Attributes
-
-		if attrs.Server != nil && attrs.Server.ID != nil {
-			data.ServerID = types.StringValue(*attrs.Server.ID)
-		}
-
-		if attrs.VirtualNetworkID != nil {
-			data.VirtualNetworkID = types.StringValue(*attrs.VirtualNetworkID)
-		}
-
-		if attrs.Vid != nil {
-			data.Vid = types.Int64Value(*attrs.Vid)
-		}
-
-		if attrs.Description != nil {
-			data.Description = types.StringValue(*attrs.Description)
-		}
-
-		if attrs.Status != nil {
-			data.Status = types.StringValue(*attrs.Status)
-		}
-	}
+	// Exhausted retries — keep whatever Null fallbacks were initialized above.
 }
 
 func (r *VlanAssignmentResource) findAssignmentByServerAndVNet(ctx context.Context, data *VlanAssignmentResourceModel, diags *diag.Diagnostics) {
 	serverID := data.ServerID.ValueString()
 	vnetID := data.VirtualNetworkID.ValueString()
+
+	// Initialize Computed attributes to Null so a partial API response can't
+	// leave them Unknown after Apply.
+	data.Vid = types.Int64Null()
+	data.Description = types.StringNull()
+	data.Status = types.StringNull()
 
 	// Get all virtual network assignments and find ours
 	response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -245,7 +245,11 @@ func (r *VlanAssignmentResource) readVlanAssignment(ctx context.Context, data *V
 	const vidRetryAttempts = 3
 	for attempt := 0; attempt < vidRetryAttempts; attempt++ {
 		if attempt > 0 {
-			time.Sleep(time.Second)
+			select {
+			case <-time.After(time.Second):
+			case <-ctx.Done():
+				return
+			}
 		}
 
 		response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})


### PR DESCRIPTION
## Summary

Three regressions surfaced shortly after v3.0.2 (PD-6027) shipped:

1. **Orphan `latitudesh_virtual_network` on tag validation failure.** Validate tag IDs *before* the Create POST + best-effort cleanup if the post-POST PATCH fails.
2. **`latitudesh_vlan_assignment` left Computed attrs Unknown after Apply.** Initialize `Vid` / `Description` / `Status` to Null and retry on `vid` populating asynchronously.
3. **`latitudesh_virtual_network` tag order swap.** Compare state and API as sets — preserve state's order when membership matches, only adopt API order on actual drift.

## Why each one

### Bug 1 — orphan VNet
PD-6027 (v3.0.2) ran `validateTagIDs` *after* `PrivateNetworks.Create`. An invalid tag ID returned a validation error, but the VNet was already created on the backend and Terraform didn't save state for it. That left an orphan VNet that blocked `terraform destroy` of the parent project with `cannot be deleted because it still has associated vlans`.

**Fix:** move validation to before the POST. Add `cleanupOrphanVNet` that best-effort `VirtualNetworks.Delete`s if any post-POST step fails (cleanup failure is a Warning, not an error).

### Bug 2 — vlan_assignment Computed Unknown
`terraform apply` on `latitudesh_vlan_assignment` (especially `count > 1`) consistently failed with:

> Error: Provider returned invalid result object after apply
> After the apply operation, the provider still indicated an unknown value for ...vid / .description / .status

Plugin Framework requires every Computed attribute to be Known after Apply. The provider only set these when the API returned non-nil values. The backend populates `vid` asynchronously when assignments are created in parallel, and the LIST endpoint can return rows where `vid` / `description` come back nil under contention.

**Fix:** initialize the three Computed attrs to `Null` at the start of `readVlanAssignment` and `findAssignmentByServerAndVNet`. Wrap the list-and-find in a 3× 1s retry loop that breaks as soon as `vid` populates. If the retries exhaust, Null persists and the next refresh reconciles silently (Computed attrs don't trigger plan diffs).

### Bug 3 — tag order swap on read
The API treats VNet `tags` as a set; the schema attribute is a `List`. `readVirtualNetworkByID` overwrote `data.Tags` with API order on every read. Once a refresh ran with 2+ tags, the next apply hit:

> Error: Provider produced inconsistent result after apply
> When applying changes to ..., provider produced an unexpected new value: .tags[0]: was X, but now Y.

Pre-existed in v3.0.2 — only escaped earlier acceptance tests because they used a single tag.

**Fix:** in `readVirtualNetworkByID`, build the API tag set, and if state's tag membership matches, preserve state's order. Only adopt API ordering when membership differs (drift).

## Files

- `latitudesh/resource_virtual_network.go` — pre-POST validation, `cleanupOrphanVNet` helper, set-aware tag merge in `readVirtualNetworkByID`.
- `latitudesh/resource_vlan_assignment.go` — Null-init + retry in `readVlanAssignment` and `findAssignmentByServerAndVNet`.
- `latitudesh/resource_virtual_network_test.go` — `TestAccVirtualNetwork_InvalidTagFailsBeforePOST` (covers Bug 1: errors at validation + zero orphan VNets in the project).

## Validation

- `go build ./...`, `go vet ./...`, full unit test suite — clean.
- End-to-end run against the live API with 3 control-plane + 3 worker servers, VLAN with multiple tags, full `count = 6` `latitudesh_vlan_assignment`, full Talos provider chain (`talos_machine_secrets` → `data.talos_machine_configuration` → `talos_machine_configuration_apply`):
  - All 6 `latitudesh_vlan_assignment` created without "invalid result object" errors (Bug 2 ✓).
  - `latitudesh_virtual_network.this[0].tags` order preserved across plan / apply (Bug 3 ✓).
  - All 6 `talos_machine_configuration_apply.*` succeeded — confirms `latitudesh_server.X.primary_ipv4` and `latitudesh_virtual_network.this[0].vid` populated correctly and flowed into downstream consumers.
  - Bug 1 reproduced manually with an invalid tag ID — apply errors at validation; backend list shows no orphan VNet.
  - `terraform destroy` ran clean end-to-end.

## Out of scope (deferred to a broader provider reliability audit)

- Auditing other resources for the same orphan-on-failure / Computed-Unknown / tag-ordering patterns (`latitudesh_server` likely has the same Read overwrite; `firewall_assignment` likely has the same orphan-on-failure surface).
- Exposing a `Get(assignmentID)` endpoint on the API + SDK so the provider doesn't have to LIST + filter.
- Surfacing async `status` transitions more discoverably to users.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Unit tests pass (excluding pre-existing `TestValidateUserData` failures, unrelated)
- [x] E2E against live API: full lifecycle (apply → idempotent plan → destroy)

## References

- Parent fix: PD-6027 (PR #179, shipped v3.0.2)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three regressions introduced in v3.0.2 (PD-6027): orphan virtual networks left when tag validation failed post-create, `vid`/`description`/`status` Computed attributes remaining Unknown after apply on `vlan_assignment`, and phantom tag-order diffs on `virtual_network` reads caused by the API returning an unordered set.

- **Bug 1 (orphan VNet):** Tag validation is moved before the Create POST, and a `cleanupOrphanVNet` helper best-effort deletes the newly created VNet if the subsequent tag-PATCH fails, preventing the orphan from blocking project destroys.
- **Bug 2 (Computed Unknown):** `vid`, `description`, and `status` are pre-initialized to `types.Null` at the start of `readVlanAssignment` and `findAssignmentByServerAndVNet`, with a 3× 1-second context-aware retry loop in `readVlanAssignment` to catch asynchronous vid allocation.
- **Bug 3 (tag order swap):** `readVirtualNetworkByID` now builds an API-side set and compares membership with state; if identical, state's ordering is preserved and the function returns early without updating `data.Tags`, avoiding the \"inconsistent result after apply\" framework error.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three regressions are correctly addressed without introducing new failure modes.

The three targeted fixes are narrowly scoped and logically sound. Pre-POST validation prevents orphans without affecting the success path; the Null-init + context-aware retry closes the Computed-Unknown window without risk of blocking indefinitely; the set-membership comparison in readVirtualNetworkByID preserves state order only when the membership is identical, correctly falling through to API order on real drift. The acceptance test directly verifies the no-orphan invariant against the live backend rather than relying on state.

No files require special attention.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TF as Terraform Apply
    participant P as Provider (Create)
    participant API as Latitude.sh API

    TF->>P: Create virtual_network (with tags)
    P->>API: validateTagIDs (GET tags list)
    alt Invalid tag ID
        API-->>P: tag not found
        P-->>TF: Error: Tag Validation Error (no VNet created)
    else Tags valid
        P->>API: POST /private-networks (Create VNet)
        API-->>P: VNet created (ID returned)
        P->>API: PATCH /private-networks/:id (apply tags)
        alt PATCH fails
            API-->>P: error
            P->>API: DELETE /private-networks/:id (cleanupOrphanVNet)
            P-->>TF: Error: Tag Update Error + optional warning
        else PATCH succeeds
            P->>API: Read VNet (readVirtualNetworkByID)
            Note over P: Set-aware tag merge
            API-->>P: VNet attributes
            P-->>TF: State saved
        end
    end

    TF->>P: Create vlan_assignment
    P->>API: POST /assign
    API-->>P: Assignment ID
    P->>P: "Initialize vid/description/status = Null"
    loop up to 3 retries (1s apart, ctx-aware)
        P->>API: LIST /assignments
        API-->>P: assignments
        alt vid populated
            P-->>TF: State saved with vid
        else vid still nil
            Note over P: wait 1s, retry
        end
    end
    P-->>TF: "State saved (vid=Null if retries exhausted)"
```

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/ad1380d93cb80a9dddebb1cd448027616e13e9c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31265496)</sub>

<!-- /greptile_comment -->