### PR TITLE
v3.0.4 hotfix: status inconsistent + 429 retry (PD-6029)

### DIFF
--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -103,7 +103,7 @@ func (p *latitudeshProvider) Configure(ctx context.Context, req provider.Configu
 				Exponent:        1.5,
 				MaxElapsedTime:  300000,
 			},
-			RetryConnectionErrors: true,
+			RetryConnectionErrors: false,
 		}),
 	}
 	if p.httpClient != nil {

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
+	"github.com/latitudesh/latitudesh-go-sdk/retry"
 	iprovider "github.com/latitudesh/terraform-provider-latitudesh/v2/internal/provider"
 )
 
@@ -94,6 +95,16 @@ func (p *latitudeshProvider) Configure(ctx context.Context, req provider.Configu
 
 	sdkOpts := []latitudeshgosdk.SDKOption{
 		latitudeshgosdk.WithSecurity(authToken),
+		latitudeshgosdk.WithRetryConfig(retry.Config{
+			Strategy: "backoff",
+			Backoff: &retry.BackoffStrategy{
+				InitialInterval: 500,
+				MaxInterval:     60000,
+				Exponent:        1.5,
+				MaxElapsedTime:  300000,
+			},
+			RetryConnectionErrors: true,
+		}),
 	}
 	if p.httpClient != nil {
 		sdkOpts = append(sdkOpts, latitudeshgosdk.WithClient(p.httpClient))

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -184,9 +184,6 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"status": schema.StringAttribute{
 				MarkdownDescription: "Server power status",
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"locked": schema.BoolAttribute{
 				MarkdownDescription: "Whether the server is locked",


### PR DESCRIPTION
## Summary

Two fixes targeted for v3.0.4 hotfix, both reported by customers running provider v3.0.3 against large server fleets.

### 1. `Provider produced inconsistent result after apply: .status`
- Removes `UseStateForUnknown` from the `status` attribute on `latitudesh_server` (`resource_server.go:188`).
- The attribute is `Computed` and changes asynchronously after apply (reinstall, lock/unlock cycles transition `on → deploying → on`). Keeping the modifier forced the planned value to match prior state, so the framework's post-apply consistency check failed with `Provider produced inconsistent result after apply: .status: was X, but now Y`.
- Without the modifier, `terraform plan` honestly marks `status` as `(known after apply)` on Update paths and the post-apply value is whatever the API returned.

### 2. `Status 429 RATE_LIMIT_EXCEEDED`
- Wires `WithRetryConfig` on the SDK client (`provider.go:95`) with exponential backoff and Retry-After honoring.
- The provider was creating the SDK client with no retry configuration. The Latitude.sh API rate-limits per token (1000 GET / 60s, 200 WRITE / 60s). Customers running `terraform refresh` against large fleets exceeded the read budget and saw 429 propagate as a hard failure (`Unable to read server, got error: Status 429`).
- Defaults: 500ms initial interval → 60s max, 1.5x exponent, 5min total budget per call. Honors `Retry-After` headers automatically. `RetryConnectionErrors: false` so transport-level failures are not retried (avoids duplicating non-idempotent writes when a request reached the server but the response was lost).

## How to validate (copy-paste)

Both scenarios share a setup. Tooling required: `bash`, `git`, `go ≥ 1.22`, `terraform ≥ 1.5`, `sed`, `curl`. A Latitude.sh project with capacity for one hourly server, plus `LATITUDESH_AUTH_TOKEN`.

### Common setup

1. Clone and build the fix into `/tmp`:

```sh
git clone git@github.com:latitudesh/terraform-provider-latitudesh.git /tmp/tf-pd6029-src
cd /tmp/tf-pd6029-src
git checkout pd-6029/status-use-state-for-unknown
go build -o /tmp/terraform-provider-latitudesh
```

2. Create the test workspace at `/tmp/tf-pd6029-repro` (writes both `main.tf` and the dev-override config; `TF_CLI_CONFIG_FILE` is intentionally **not** exported yet — registry v3.0.3 is used until you opt into the override per scenario):

```sh
mkdir -p /tmp/tf-pd6029-repro && cd /tmp/tf-pd6029-repro

cat > main.tf <<'EOF'
terraform {
  required_providers {
    latitudesh = {
      source  = "latitudesh/latitudesh"
      version = "3.0.3"
    }
  }
}

variable "project" {
  type = string
}

variable "site" {
  type    = string
  default = "ASH"
}

variable "plan" {
  type    = string
  default = "f4-metal-small"
}

resource "latitudesh_server" "repro" {
  hostname         = "tf-pd6029-repro"
  operating_system = "ubuntu_24_04_x64_lts"
  plan             = var.plan
  site             = var.site
  project          = var.project
  billing          = "hourly"
  allow_reinstall  = true
  locked           = true
}
EOF

cat > .terraformrc <<'EOF'
provider_installation {
  dev_overrides {
    "latitudesh/latitudesh" = "/tmp"
  }
  direct {}
}
EOF
```
```sh
unset TF_CLI_CONFIG_FILE   # belt-and-suspenders: registry v3.0.3 will be used for init+apply
export LATITUDESH_AUTH_TOKEN="<paste your token>"
export TF_VAR_project="<paste your project id>"
# Override site/plan if defaults aren't available in your account:
# export TF_VAR_site="NYC"
# export TF_VAR_plan="c2-small-x86"
```

3. Provision the server using v3.0.3 from the registry:

```sh
terraform init
terraform apply -auto-approve
# wait until status stabilizes
```

### Scenario A — `inconsistent result after apply: .status`

**Reproduce against v3.0.3:**

```sh
unset TF_CLI_CONFIG_FILE
sed -i 's/"status": "on"/"status": "deploying"/' terraform.tfstate
sed -i 's/locked           = true/locked           = false/' main.tf
terraform plan -refresh=false -out=/tmp/plan-broken.bin
terraform apply /tmp/plan-broken.bin
```

Expected output:
```
Error: Provider produced inconsistent result after apply
...status: was cty.StringVal("deploying"), but now cty.StringVal("on").
```

**Validate fix with the local build:**

```sh
export TF_CLI_CONFIG_FILE="$PWD/.terraformrc"
sed -i 's/"status": "on"/"status": "deploying"/' terraform.tfstate
sed -i 's/locked           = false/locked           = true/' main.tf
terraform plan -refresh=false -out=/tmp/plan-fixed.bin
terraform apply /tmp/plan-fixed.bin
```

Expected:
- Plan shows two `Provider development overrides are in effect` warnings, then `~ status = "deploying" -> (known after apply)`.
- `Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`

### Scenario B — `Status 429 RATE_LIMIT_EXCEEDED`

Saturates the per-token READ bucket via curl, then runs `terraform refresh` within the throttled window.

**Reproduce against v3.0.3:**

```sh
unset TF_CLI_CONFIG_FILE
SERVER_ID=$(terraform state show latitudesh_server.repro | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/ {print $2; exit}')

# Fill the read bucket: 1100 parallel GETs against the same endpoint
for i in $(seq 1 1100); do
  curl -s -o /dev/null \
    -H "Authorization: Bearer $LATITUDESH_AUTH_TOKEN" \
    "https://api.latitude.sh/servers/$SERVER_ID" &
done
wait

# Immediately, within the 60s throttled window:
terraform refresh
```

Expected output:
```
Error: Client Error
Unable to read server, got error: API error occurred: Status 429
{"errors":[{"code":"RATE_LIMIT_EXCEEDED",...
```

**Validate fix with the local build:**

```sh
export TF_CLI_CONFIG_FILE="$PWD/.terraformrc"
sleep 65   # let the bucket drain from the previous test

for i in $(seq 1 1100); do
  curl -s -o /dev/null \
    -H "Authorization: Bearer $LATITUDESH_AUTH_TOKEN" \
    "https://api.latitude.sh/servers/$SERVER_ID" &
done
wait

time terraform refresh
```

Expected:
- `terraform refresh` completes without error.
- Wall-clock typically 60–120s (one or two Retry-After cycles).

### Cleanup

The test fixture sets `locked = true`; unlock the server before destroying or the API will refuse with `SERVER_LOCKED_ERROR`.

```sh
sed -i 's/locked           = true/locked           = false/' main.tf
terraform apply -auto-approve
terraform destroy -auto-approve
```

## Known caveats (retry config)

- **HTTP status retry covers `429` and `5xx`.** For 429 the rate limiter rejects requests before the controller, so retry is safe. For 5xx the backend may have already processed the request — retrying could rarely duplicate a billable resource. Acceptable for hotfix scope; granular per-method control is a follow-up.
- **Transport errors are NOT retried** (`RetryConnectionErrors: false`). TCP reset, dial timeout, TLS errors, etc. propagate so we never duplicate non-idempotent writes when a request reached the server and the response was lost in flight. Customers hitting transient transport errors should re-run `terraform apply`.
- `MaxElapsedTime` is 5 minutes total per call. Customers sustaining rate-limit pressure beyond that window still see eventual errors and should reduce `-parallelism`.
- Existing handcrafted retry in `resource_server.go:384-523` (post-create polling) and `resource_elastic_ip.go:390-410` is preserved as belt-and-suspenders. Simplifying after this lands is a separate cleanup.

## Test plan
- [x] Reproduced both errors against v3.0.3.
- [x] Both errors gone with the local build.
- [ ] Acceptance tests still pass (`TF_ACC=1 go test ./latitudesh/... -run TestAccServer`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix addresses two customer-reported issues in provider v3.0.3: an `inconsistent result after apply` error on `status` caused by `UseStateForUnknown` fighting the API's asynchronous state machine, and hard 429 failures caused by the absence of retry logic on the SDK client.

- **`resource_server.go`**: Removes `UseStateForUnknown()` from the `status` attribute so the framework no longer pins the post-apply value to prior state; `status` is now correctly marked `(known after apply)` on update paths.
- **`provider.go`**: Wires `WithRetryConfig` at SDK-client construction time with exponential backoff (500 ms → 60 s cap, 1.5×), a 5-minute per-call budget, and `RetryConnectionErrors: false` to avoid retrying non-idempotent writes on transport-level failures.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are minimal, targeted, and directly reproduce the customer-reported failures. The retry config follows the SDK's own README example exactly, and the plan-modifier removal is a straightforward fix for an asynchronous computed attribute.

Two small, isolated changes with well-documented root causes and reproduction steps. The retry config pattern matches the official SDK documentation, the UseStateForUnknown removal is correct for a purely server-driven asynchronous attribute, and the known 5xx-retry/write trade-off is explicitly acknowledged in the PR description.

No files require special attention.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TF as Terraform
    participant P as Provider (Configure)
    participant SDK as latitudesh-go-sdk
    participant API as Latitude.sh API

    TF->>P: Configure()
    P->>SDK: New(WithSecurity, WithRetryConfig)
    Note over SDK: Strategy=backoff<br/>InitialInterval=500ms<br/>MaxInterval=60s<br/>MaxElapsedTime=5min<br/>RetryConnectionErrors=false

    TF->>SDK: Read/Refresh server
    SDK->>API: GET /servers/:id
    API-->>SDK: 429 RATE_LIMIT_EXCEEDED (Retry-After: N)
    Note over SDK: Honor Retry-After header<br/>Apply exponential backoff
    SDK->>API: GET /servers/:id (retry)
    API-->>SDK: 200 OK
    SDK-->>TF: server data

    TF->>SDK: Update server (lock/unlock)
    SDK->>API: PATCH /servers/:id
    API-->>SDK: "200 OK {status: deploying}"
    Note over TF: status = (known after apply)<br/>No UseStateForUnknown constraint
    TF-->>TF: Apply complete (no consistency error)
```

<sub>Reviews (3): Last reviewed commit: ["fix(provider): disable RetryConnectionEr..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/4cd769c96e642e0555aca58fcef97be100622613) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31418823)</sub>

<!-- /greptile_comment -->