### PR TITLE
fix(virtual_network): retry on 406 deletion restriction and wait for assignment removal to avoid destroy race

### DIFF
--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -473,7 +473,8 @@ func (r *VirtualNetworkResource) Delete(ctx context.Context, req resource.Delete
 		maxBackoff     = 30 * time.Second
 	)
 
-	deadline := time.Now().Add(retryDeadline)
+	start := time.Now()
+	deadline := start.Add(retryDeadline)
 	backoff := initialBackoff
 
 	for {

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -466,17 +467,64 @@ func (r *VirtualNetworkResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	// Attempt to delete using the virtual network ID directly
-	_, err := r.client.VirtualNetworks.Delete(ctx, vlanID)
-	if err != nil {
-		// If we get a 404, the resource was already deleted
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not_found") {
+	const (
+		retryDeadline  = 5 * time.Minute
+		initialBackoff = 5 * time.Second
+		maxBackoff     = 30 * time.Second
+	)
+
+	deadline := time.Now().Add(retryDeadline)
+	backoff := initialBackoff
+
+	for {
+		_, err := r.client.VirtualNetworks.Delete(ctx, vlanID)
+		if err == nil {
+			return
+		}
+
+		errStr := err.Error()
+		if strings.Contains(errStr, "404") || strings.Contains(errStr, "not_found") {
 			resp.Diagnostics.AddWarning("Virtual Network Already Deleted", "Virtual network was already deleted")
 			return
 		}
-		resp.Diagnostics.AddError("Client Error", "Unable to delete virtual network, got error: "+err.Error())
-		return
+
+		if !isDeletionRestrictionError(errStr) {
+			resp.Diagnostics.AddError("Client Error", "Unable to delete virtual network, got error: "+err.Error())
+			return
+		}
+
+		if !time.Now().Add(backoff).Before(deadline) {
+			resp.Diagnostics.AddError(
+				"Client Error",
+				fmt.Sprintf(
+					"Unable to delete virtual network after waiting %s for assignments to drain. Last error: %s",
+					retryDeadline, err.Error(),
+				),
+			)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError(
+				"Context Cancelled",
+				"Virtual network delete was cancelled while waiting for assignments to drain",
+			)
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
+}
+
+func isDeletionRestrictionError(errStr string) bool {
+	return strings.Contains(errStr, "VIRTUAL_NETWORK_DELETION_ERROR") ||
+		strings.Contains(errStr, "Virtual Network Deletion Restriction") ||
+		strings.Contains(errStr, "remove all assignments")
 }
 
 func (r *VirtualNetworkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -499,7 +499,7 @@ func (r *VirtualNetworkResource) Delete(ctx context.Context, req resource.Delete
 				"Client Error",
 				fmt.Sprintf(
 					"Unable to delete virtual network after waiting %s for assignments to drain. Last error: %s",
-					retryDeadline, err.Error(),
+					time.Since(start).Round(time.Second), err.Error(),
 				),
 			)
 			return

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -214,6 +214,45 @@ func (r *VlanAssignmentResource) Delete(ctx context.Context, req resource.Delete
 			return
 		}
 	}
+
+	r.waitForAssignmentRemoval(ctx, id)
+}
+
+func (r *VlanAssignmentResource) waitForAssignmentRemoval(ctx context.Context, id string) {
+	const (
+		waitDeadline = 2 * time.Minute
+		pollInterval = 3 * time.Second
+	)
+	deadline := time.Now().Add(waitDeadline)
+
+	for time.Now().Before(deadline) {
+		response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})
+		if err != nil {
+			// Transient list failures shouldn't fail the destroy; let the
+			// parent vnet delete handle any remaining lag.
+			return
+		}
+		if response.VirtualNetworkAssignments == nil || response.VirtualNetworkAssignments.Data == nil {
+			return
+		}
+
+		stillPresent := false
+		for _, a := range response.VirtualNetworkAssignments.Data {
+			if a.ID != nil && *a.ID == id {
+				stillPresent = true
+				break
+			}
+		}
+		if !stillPresent {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+		}
+	}
 }
 
 func (r *VlanAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -215,10 +215,16 @@ func (r *VlanAssignmentResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	r.waitForAssignmentRemoval(ctx, id)
+	r.waitForAssignmentRemoval(ctx, id, data.VirtualNetworkID.ValueString(), data.ServerID.ValueString())
 }
 
-func (r *VlanAssignmentResource) waitForAssignmentRemoval(ctx context.Context, id string) {
+// waitForAssignmentRemoval polls ListAssignments filtered by both the vnet and
+// the server IDs — the tuple is unique in interface_tagged_vlans, so the
+// response holds at most one entry and fits on the first page regardless of
+// account size. Without the filters, `ListAssignments` returns page 1 of all
+// assignments in the account (page size default 20) and the lookup silently
+// no-ops when the target lives on page 2+.
+func (r *VlanAssignmentResource) waitForAssignmentRemoval(ctx context.Context, id, vnetID, serverID string) {
 	const (
 		waitDeadline = 2 * time.Minute
 		pollInterval = 3 * time.Second
@@ -226,7 +232,10 @@ func (r *VlanAssignmentResource) waitForAssignmentRemoval(ctx context.Context, i
 	deadline := time.Now().Add(waitDeadline)
 
 	for time.Now().Before(deadline) {
-		response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{})
+		response, err := r.client.PrivateNetworks.ListAssignments(ctx, operations.GetVirtualNetworksAssignmentsRequest{
+			FilterVirtualNetworkID: &vnetID,
+			FilterServer:           &serverID,
+		})
 		if err != nil {
 			// Transient list failures shouldn't fail the destroy; let the
 			// parent vnet delete handle any remaining lag.


### PR DESCRIPTION
latitudesh/resource_virtual_network.go - Delete now loops with bounded backoff (5s -> 30s, 5 min deadline) when the API returns a VIRTUAL_NETWORK_DELETION_ERROR. 404 still short-circuits as "already deleted"; every other error still fails immediately. New isDeletionRestrictionError helper matches on the unique error code with two fallback substrings in case the SDK surfaces a different layer of the envelope.

latitudesh/resource_vlan_assignment.go - after a successful DeleteAssignment, Delete polls ListAssignments every 3s for up to 2 min until the assignment is gone. The wait is best-effort: SDK errors and timeouts return silently because the parent vnet's retry is the actual safety net.

The two layers compose: the assignment-side wait closes the common-case race so destroys stay fast, and the vnet-side retry covers the long-tail case (slow backend, assignments created outside Terraform, etc.).


Context: Potential fix for the following error

```
╷
│ Error: Client Error
│
│ Unable to delete virtual network, got error: API error occurred: Status 406
│ {"errors":[{"code":"VIRTUAL_NETWORK_DELETION_ERROR","status":"not_acceptable","title":"Virtual Network Deletion Restriction","detail":"Please remove all assignments from this virtual network before deleting
│ it","meta":{}}]}
╵
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Terraform destroy race where deleting a virtual network with still-active VLAN assignments returns HTTP 406. It introduces two composable layers: a bounded retry loop in `VirtualNetworkResource.Delete` (5 s → 30 s backoff, 5-minute deadline) and a best-effort post-delete polling wait in `VlanAssignmentResource.Delete` that blocks until the API confirms the assignment is gone.

- **`resource_virtual_network.go`**: The `Delete` method now loops on `isDeletionRestrictionError` (matching the `VIRTUAL_NETWORK_DELETION_ERROR` code with two string fallbacks), surfaces the actual elapsed time in the timeout message, and exits immediately on context cancellation, 404, or any non-406 error.
- **`resource_vlan_assignment.go`**: A new `waitForAssignmentRemoval` helper polls `ListAssignments` filtered by both `vnetID` and `serverID` — the dual filter keeps the result set to ≤1 item so pagination is not a concern — and returns silently on errors or timeout, deferring to the vnet retry as the authoritative safety net.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both the retry loop and the polling wait are correctly bounded, context-cancellation is handled, and the previously flagged pagination and elapsed-time issues are fully addressed.

The vnet retry loop exits correctly on success, 404, non-406 errors, context cancellation, and deadline expiry with no infinite-loop risk. The vlan assignment wait now filters by both vnet ID and server ID, eliminating the single-page blind spot from the earlier review. Error messages report actual elapsed time via time.Since(start). No incorrect behavior was found in either path.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(vlan\_assignment): filter ListAssignm..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/f59ad2ad929f1ffdc52d6bf196158b0cfd4a5ab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32241713)</sub>

<!-- /greptile_comment -->