### PR TITLE
docs(guides): add Object Storage as Terraform remote state backend guide

### DIFF
--- a/docs/guides/object-storage-backend.md
+++ b/docs/guides/object-storage-backend.md
@@ -128,4 +128,4 @@ The region must match the value used by the storage endpoint shown on the bucket
 
 **`PreconditionFailed` on lock acquisition** — another Terraform process already holds the lock. Wait for it to finish, or run `terraform force-unlock <lock-id>` if you are certain the previous run is dead.
 
-**State writes succeed but locking seems to do nothing** — verify that you are pointing at a High-performance bucket.
+**State writes succeed but locking seems to do nothing** — verify that you are pointing at a High-performance bucket. Standard buckets do not honor `If-None-Match`, so `use_lockfile = true` becomes a silent no-op.

--- a/docs/guides/object-storage-backend.md
+++ b/docs/guides/object-storage-backend.md
@@ -1,0 +1,131 @@
+---
+page_title: "Using Latitude.sh Object Storage as a Terraform Remote State Backend"
+---
+
+# Using Latitude.sh Object Storage as a Terraform Remote State Backend
+
+Latitude.sh Object Storage is S3-compatible and works as a Terraform remote state backend through Terraform's built-in [`s3` backend](https://developer.hashicorp.com/terraform/language/backend/s3). This guide shows the configuration for each bucket tier and the trade-offs between them.
+
+For bucket creation, access keys, and endpoint lookup, see the [Object Storage documentation](https://www.latitude.sh/docs/storage/object-storage).
+
+## Bucket tiers
+
+Two tiers are available, with different state-locking behavior:
+
+| Tier             | Endpoint pattern                 | State locking                  | Recommended for                                       |
+|------------------|----------------------------------|--------------------------------|-------------------------------------------------------|
+| Standard         | `objects.<region>.storage.sh`    | Not available                  | Single-user setups, manually coordinated runs         |
+| High-performance | `objects.<slug>.storage.sh`      | Yes (`use_lockfile = true`)    | CI, teams, anywhere concurrent runs are possible      |
+
+If multiple operators or pipelines may run Terraform against the same state, choose a **High-performance** bucket so state locking is available.
+
+## Prerequisites
+
+- A bucket created in the [Latitude.sh dashboard](https://latitude.sh/dashboard).
+- An access key and secret for that bucket.
+- **Terraform 1.10** or later (required for `use_lockfile`).
+
+## Authentication
+
+Terraform's `s3` backend reads credentials from the standard AWS environment variables:
+
+```sh
+export AWS_ACCESS_KEY_ID=<latitudesh-object-storage-access-key>
+export AWS_SECRET_ACCESS_KEY=<latitudesh-object-storage-secret-key>
+```
+
+The `AWS_*` names come from Terraform's built-in `s3` backend — the credentials themselves are your Latitude.sh Object Storage keys.
+
+## Configuration
+
+### Standard tier (no locking)
+
+```terraform
+terraform {
+  required_version = ">= 1.10"
+
+  backend "s3" {
+    bucket = "your-state-bucket"
+    key    = "infra/terraform.tfstate"
+
+    # Standard buckets use AWS-style region slugs (e.g. us-east-1).
+    region = "us-east-1"
+
+    endpoints = {
+      s3 = "https://objects.us-east-1.storage.sh"
+    }
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+
+    # State locking is not available on Standard buckets.
+    # Use a High-performance bucket if you need locking.
+  }
+}
+```
+
+~> **Warning:** Standard buckets do not currently support state locking. Concurrent `terraform apply` runs against the same state can corrupt it silently. Coordinate runs out-of-band, or use a High-performance bucket.
+
+### High-performance tier (with locking)
+
+```terraform
+terraform {
+  required_version = ">= 1.10"
+
+  backend "s3" {
+    bucket = "your-state-bucket"
+    key    = "infra/terraform.tfstate"
+
+    # High-performance buckets use Latitude.sh location slugs (e.g. nyc).
+    region = "nyc"
+
+    endpoints = {
+      s3 = "https://objects.nyc.storage.sh"
+    }
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+
+    # Native state locking via S3 conditional writes (no DynamoDB required).
+    # Requires Terraform 1.10+.
+    use_lockfile = true
+  }
+}
+```
+
+`use_lockfile = true` enables native S3 state locking using conditional writes. Terraform creates a `<state>.tflock` object during operations and removes it when finished. No DynamoDB table is required.
+
+## Initialize the backend
+
+```sh
+terraform init
+```
+
+If you are migrating from a local backend, use `-migrate-state`:
+
+```sh
+terraform init -migrate-state
+```
+
+## A note on region values
+
+Region naming differs from the rest of the Latitude.sh platform — do not paste a `latitudesh_region.slug` value here.
+
+- **Standard** buckets use AWS-style region slugs (e.g. `us-east-1`).
+- **High-performance** buckets use Latitude.sh location slugs (e.g. `nyc`).
+
+The region must match the value used by the storage endpoint shown on the bucket detail page in the dashboard.
+
+## Troubleshooting
+
+**`SignatureDoesNotMatch`** — the `region` set in the backend block does not match what the endpoint expects. Confirm the region against the bucket detail page.
+
+**`PreconditionFailed` on lock acquisition** — another Terraform process already holds the lock. Wait for it to finish, or run `terraform force-unlock <lock-id>` if you are certain the previous run is dead.
+
+**State writes succeed but locking seems to do nothing** — verify that you are pointing at a High-performance bucket.

--- a/examples/guides/object-storage-backend/backend-high-performance.tf
+++ b/examples/guides/object-storage-backend/backend-high-performance.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.10"
+
+  backend "s3" {
+    bucket = "your-state-bucket"
+    key    = "infra/terraform.tfstate"
+
+    # High-performance buckets use Latitude.sh location slugs (e.g. nyc).
+    region = "nyc"
+
+    endpoints = {
+      s3 = "https://objects.nyc.storage.sh"
+    }
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+
+    # Native state locking via S3 conditional writes (no DynamoDB required).
+    # Requires Terraform 1.10+.
+    use_lockfile = true
+  }
+}

--- a/examples/guides/object-storage-backend/backend-standard.tf
+++ b/examples/guides/object-storage-backend/backend-standard.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.10"
+
+  backend "s3" {
+    bucket = "your-state-bucket"
+    key    = "infra/terraform.tfstate"
+
+    # Standard buckets use AWS-style region slugs (e.g. us-east-1).
+    region = "us-east-1"
+
+    endpoints = {
+      s3 = "https://objects.us-east-1.storage.sh"
+    }
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+
+    # State locking is not available on Standard buckets.
+    # Use a High-performance bucket if you need locking.
+  }
+}

--- a/templates/guides/object-storage-backend.md.tmpl
+++ b/templates/guides/object-storage-backend.md.tmpl
@@ -1,0 +1,80 @@
+---
+page_title: "Using Latitude.sh Object Storage as a Terraform Remote State Backend"
+---
+
+# Using Latitude.sh Object Storage as a Terraform Remote State Backend
+
+Latitude.sh Object Storage is S3-compatible and works as a Terraform remote state backend through Terraform's built-in [`s3` backend](https://developer.hashicorp.com/terraform/language/backend/s3). This guide shows the configuration for each bucket tier and the trade-offs between them.
+
+For bucket creation, access keys, and endpoint lookup, see the [Object Storage documentation](https://www.latitude.sh/docs/storage/object-storage).
+
+## Bucket tiers
+
+Two tiers are available, with different state-locking behavior:
+
+| Tier             | Endpoint pattern                 | State locking                  | Recommended for                                       |
+|------------------|----------------------------------|--------------------------------|-------------------------------------------------------|
+| Standard         | `objects.<region>.storage.sh`    | Not available                  | Single-user setups, manually coordinated runs         |
+| High-performance | `objects.<slug>.storage.sh`      | Yes (`use_lockfile = true`)    | CI, teams, anywhere concurrent runs are possible      |
+
+If multiple operators or pipelines may run Terraform against the same state, choose a **High-performance** bucket so state locking is available.
+
+## Prerequisites
+
+- A bucket created in the [Latitude.sh dashboard](https://latitude.sh/dashboard).
+- An access key and secret for that bucket.
+- **Terraform 1.10** or later (required for `use_lockfile`).
+
+## Authentication
+
+Terraform's `s3` backend reads credentials from the standard AWS environment variables:
+
+```sh
+export AWS_ACCESS_KEY_ID=<latitudesh-object-storage-access-key>
+export AWS_SECRET_ACCESS_KEY=<latitudesh-object-storage-secret-key>
+```
+
+The `AWS_*` names come from Terraform's built-in `s3` backend — the credentials themselves are your Latitude.sh Object Storage keys.
+
+## Configuration
+
+### Standard tier (no locking)
+
+{{ tffile "examples/guides/object-storage-backend/backend-standard.tf" }}
+
+~> **Warning:** Standard buckets do not currently support state locking. Concurrent `terraform apply` runs against the same state can corrupt it silently. Coordinate runs out-of-band, or use a High-performance bucket.
+
+### High-performance tier (with locking)
+
+{{ tffile "examples/guides/object-storage-backend/backend-high-performance.tf" }}
+
+`use_lockfile = true` enables native S3 state locking using conditional writes. Terraform creates a `<state>.tflock` object during operations and removes it when finished. No DynamoDB table is required.
+
+## Initialize the backend
+
+```sh
+terraform init
+```
+
+If you are migrating from a local backend, use `-migrate-state`:
+
+```sh
+terraform init -migrate-state
+```
+
+## A note on region values
+
+Region naming differs from the rest of the Latitude.sh platform — do not paste a `latitudesh_region.slug` value here.
+
+- **Standard** buckets use AWS-style region slugs (e.g. `us-east-1`).
+- **High-performance** buckets use Latitude.sh location slugs (e.g. `nyc`).
+
+The region must match the value used by the storage endpoint shown on the bucket detail page in the dashboard.
+
+## Troubleshooting
+
+**`SignatureDoesNotMatch`** — the `region` set in the backend block does not match what the endpoint expects. Confirm the region against the bucket detail page.
+
+**`PreconditionFailed` on lock acquisition** — another Terraform process already holds the lock. Wait for it to finish, or run `terraform force-unlock <lock-id>` if you are certain the previous run is dead.
+
+**State writes succeed but locking seems to do nothing** — verify that you are pointing at a High-performance bucket. Standard buckets do not honor `If-None-Match`, so `use_lockfile = true` becomes a silent no-op.


### PR DESCRIPTION
## Summary

- Adds a new guide explaining how to use Latitude.sh Object Storage as a Terraform remote state backend via Terraform's built-in `s3` backend.
- Covers both Standard and High-performance bucket tiers, with their endpoint pattern, region naming convention, and locking trade-offs.
- High-performance buckets honor `If-None-Match` conditional writes, so the guide recommends `use_lockfile = true` (Terraform 1.10+) there to get native state locking without DynamoDB.
- Standard buckets do not honor conditional writes; the guide includes an explicit warning against concurrent runs on that tier.
- Adds two example `.tf` files (one per tier) referenced from the guide template via `tffile`, plus the generated `docs/guides/` Markdown.
- Links the user-facing [Object Storage documentation](https://www.latitude.sh/docs/storage/object-storage) for bucket creation, access key, and endpoint lookup.

## Test plan

- [x] `terraform init` + `apply` + `plan` + `destroy` against a Standard bucket (no `use_lockfile`) — clean.
- [x] Same flow against a High-performance bucket with `use_lockfile = true` enabled — clean, state and lockfile object observed in the bucket.
- [x] HTTP probe (raw `PUT` with `If-None-Match: *`) confirmed High-performance returns `412 PreconditionFailed` on conflict; Standard returns `200` (overwrite) — locking recommendation matches observed behavior.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new guide documenting how to use Latitude.sh Object Storage as a Terraform remote state backend via the built-in `s3` backend, covering both Standard and High-performance bucket tiers with their respective locking behavior.

- Adds template (`templates/guides/object-storage-backend.md.tmpl`), two example `.tf` files, and the generated `docs/guides/object-storage-backend.md` — the generated file is missing the final sentence of the last troubleshooting entry present in the template, which explains why `use_lockfile = true` silently does nothing on Standard buckets.
- The Standard tier example sets `required_version = ">= 1.10"` even though `use_lockfile` (the sole reason 1.10 is required per the guide) is not used in that configuration, creating a minor contradiction with the Prerequisites section.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the missing troubleshooting sentence in the generated doc; the template is correct but the generated output is incomplete.

The template correctly documents the `use_lockfile` silent no-op behavior on Standard buckets, but that explanation was dropped from the generated `docs/guides/object-storage-backend.md`. A user hitting this exact scenario — mistakenly pointing `use_lockfile = true` at a Standard bucket — would find the troubleshooting entry unhelpful without that second sentence. The Standard tier example's `required_version` constraint is a secondary inconsistency with the guide's own Prerequisites text.

docs/guides/object-storage-backend.md needs the missing troubleshooting sentence re-added; examples/guides/object-storage-backend/backend-standard.tf has a minor version constraint inconsistency.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Terraform CLI
    participant Backend as S3 Backend
    participant Storage as Latitude.sh Object Storage

    User->>Backend: terraform init
    Backend->>Storage: HEAD bucket (verify access)
    Storage-->>Backend: 200 OK

    User->>Backend: terraform apply
    alt "High-performance bucket (use_lockfile = true)"
        Backend->>Storage: "PUT state.tflock (If-None-Match: *)"
        alt Lock acquired
            Storage-->>Backend: 200 Created
            Backend->>Storage: GET terraform.tfstate
            Storage-->>Backend: current state
            Backend->>Storage: PUT terraform.tfstate
            Storage-->>Backend: 200 OK
            Backend->>Storage: DELETE state.tflock
            Storage-->>Backend: 200 OK
        else Lock already held
            Storage-->>Backend: 412 PreconditionFailed
            Backend-->>User: Error: state locked
        end
    else Standard bucket (no locking)
        Backend->>Storage: GET terraform.tfstate
        Storage-->>Backend: current state
        Backend->>Storage: PUT terraform.tfstate (overwrites)
        Storage-->>Backend: 200 OK
        Note over User,Storage: No locking - concurrent runs risk state corruption
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/guides/object-storage-backend.md:131
The last troubleshooting entry in the generated doc is truncated compared to the template source. The template (`templates/guides/object-storage-backend.md.tmpl`, final line) includes an important second sentence explaining *why* locking silently does nothing: "Standard buckets do not honor `If-None-Match`, so `use_lockfile = true` becomes a silent no-op." Without it, a user who accidentally sets `use_lockfile = true` on a Standard bucket gets no guidance on what went wrong.

```suggestion
**State writes succeed but locking seems to do nothing** — verify that you are pointing at a High-performance bucket. Standard buckets do not honor `If-None-Match`, so `use_lockfile = true` becomes a silent no-op.
```

### Issue 2 of 2
examples/guides/object-storage-backend/backend-standard.tf:1-9
The Standard tier example pins `required_version = ">= 1.10"`, but the guide's Prerequisites section explicitly states 1.10 is required only for `use_lockfile`, which is not used here. Setting this constraint on the Standard config implies users need Terraform 1.10 just to use a Standard bucket, which is misleading and more restrictive than necessary.

```suggestion
terraform {
  required_version = ">= 1.6"

  backend "s3" {
    bucket = "your-state-bucket"
    key    = "infra/terraform.tfstate"

    # Standard buckets use AWS-style region slugs (e.g. us-east-1).
    region = "us-east-1"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(guides): add Object Storage as Terr..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/5e248c853434ad41a1fd3c7ba9ad68baf2a5becb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33821227)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->