### PR TITLE
Fix for "Error: Provider returned invalid result object after apply"

### DIFF
--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -1508,6 +1508,10 @@ func (r *ServerResource) readServer(ctx context.Context, data *ServerResourceMod
 			}
 		}
 	}
+
+	if data.UserDataContentHash.IsUnknown() {
+		data.UserDataContentHash = types.StringNull()
+	}
 }
 
 func (r *ServerResource) readDeployConfig(ctx context.Context, data *ServerResourceModel, diags *diag.Diagnostics) {


### PR DESCRIPTION
This is a fix for these errors that were introduced in v3.1.x somewhere along the way.

```
latitudesh_server.controlplane[1]: Still creating... [03m30s elapsed]
╷
│ Error: Provider returned invalid result object after apply
│
│ After the apply operation, the provider still indicated an unknown value for latitudesh_server.controlplane[0].user_data_content_hash. All values must be known after apply, so this is always a bug in the
│ provider and should be reported in the provider's own repository. Terraform will still save the other known object values in the state.
╵
╷
│ Error: Provider returned invalid result object after apply
```

The fix is simple. You can alternatively add this if block to an `else` block after line 1509 as well, if you like.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Terraform "Provider returned invalid result object after apply" error by ensuring `UserDataContentHash` is never left in an `Unknown` state after `readServer` completes. When `UserData` is absent or the API returns an empty hash, the field was never resolved from `Unknown` to a known value, causing Terraform to reject the result.

- Adds a trailing guard after the hash-fetch block in `readServer` that converts any remaining `Unknown` `UserDataContentHash` to `Null`, mirroring the identical pattern already used for `Billing` at line 1491.
- The guard is placed outside the `UserData`-presence check, covering both the case where `UserData` is unset and the case where the API fetch returns an empty string.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a four-line null-guard that unblocks a reproducible apply failure with no side-effects on normal operation.

The fix is a direct analog of the already-working Billing guard introduced earlier in the same function. The only path affected is when UserDataContentHash is still Unknown after readServer finishes, which Terraform explicitly rejects; converting it to Null is the correct resolution. No existing state-reading or drift-detection logic is impacted because the guard fires only on Unknown, not on a previously known hash.

No files require special attention.
</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readServer called after apply] --> B{UserData is set\nand known?}
    B -- No --> E[UserDataContentHash\nremains Unknown]
    B -- Yes --> C{UserDataContentHash\nis Null or Unknown?}
    C -- No --> G[Preserve existing hash\nfor drift detection]
    C -- Yes --> D[fetchUserDataContentHashFromAPI]
    D --> F{API returned\nnon-empty hash?}
    F -- Yes --> H[Set UserDataContentHash\nto fetched value]
    F -- No --> E
    H --> I{UserDataContentHash\nstill Unknown?}
    E --> I
    G --> I
    I -- Yes --> J["Set to Null - prevents Terraform unknown after apply error"]
    I -- No --> K[Return known state\nto Terraform]
    J --> K
```

<sub>Reviews (1): Last reviewed commit: ["Fix for &quot;Error: Provider returned invali..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/e9e6e64c4ba9d31b8c85d31737c6b815c71a2a15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37712069)</sub>

<!-- /greptile_comment -->