### PR TITLE
fix(server): make billing default explicit in plan output and docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,9 @@ provider "latitudesh" {}
 
 ```hcl
 variable "billing" {
+  # hourly and monthly for on-demand projects, yearly for reserved projects.
+  # Defaults to monthly, which is charged upfront based on the proration of
+  # the current billing cycle. Use hourly for dynamic workloads.
   description = "The server billing type"
   default     = "monthly"
 }

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -19,10 +19,14 @@ The `latitudesh_server` resource allows you to deploy and manage bare metal serv
 
 ## Example usage
 
+> **Billing**
+>
+> `billing` defaults to `monthly`, which is charged upfront based on the proration of the current billing cycle. For dynamic or short-lived workloads, set `billing = "hourly"` explicitly. `yearly` is available for reserved projects.
+
 ```hcl
 # Create a server with custom timeouts
 resource "latitudesh_server" "server" {
-  billing           = "monthly"
+  billing           = "monthly" # hourly, monthly (default) or yearly
   hostname          = "my-server"
   plan              = "m4-metal-medium"
   site              = "ASH"
@@ -140,8 +144,7 @@ With the above, only `user_data` changes (ID or content) cause a reinstall. Chan
 
 - `allow_reinstall` (Boolean) Allow server reinstallation when `operating_system`, `hostname`, `ssh_keys`, `user_data` (ID or content), `raid`, or `ipxe` changes. **Defaults to `false`.** When `false`, `hostname` changes are applied in-place via PATCH and any other reinstall-only field change fails the plan with an explicit error; set this to `true` on resources where you want reinstalls to happen automatically. See `allowed_reinstall_triggers` to further restrict which kinds of changes are permitted to cause a reinstall.
 - `allowed_reinstall_triggers` (List of String) Optional list restricting which field changes are allowed to trigger a server reinstall when `allow_reinstall = true`. When omitted, all reinstall-only field changes trigger a reinstall (default behavior). When set, only listed names cause a reinstall; changes to reinstall-only fields not in the list fail the plan with an explicit error, except `hostname` which falls back to its in-place PATCH path. Valid values: `operating_system`, `user_data`, `raid`, `disk_layout`, `ipxe`, `ssh_keys`, `hostname`. The token `user_data` covers both ID changes and content changes of the referenced `latitudesh_user_data` resource.
-- `billing` (String) The server billing type.
-    Accepts hourly and monthly for on demand projects and yearly for reserved projects.
+- `billing` (String) The server billing type. Accepts `hourly` and `monthly` for on-demand projects and `yearly` for reserved projects. **Defaults to `monthly`**, which is charged upfront based on the proration of the current billing cycle. Use `hourly` for dynamic or short-lived workloads. When omitted, the plan shows the effective value (`billing = "monthly"` on create).
 - `disk_layout` (Attributes List) Custom disk layout made of one or more disk groups, used instead of `raid`. Mutually exclusive with `raid` and `ipxe`. The layout is refreshed from the server deploy config on read, so out-of-band changes are detected and imported servers populate it. Changing it requires a reinstall and only succeeds when `allow_reinstall = true`. The OS group's filesystem is always `ext4` (managed by the API) and is not configurable here. (see [below for nested schema](#nestedatt--disk_layout))
 - `ipxe` (String) The iPXE script to boot. Accepts either a URL pointing at the script, or the script encoded in base64. Required when `operating_system = "ipxe"`; the plan fails with an explicit error if it is missing. Updating ipxe requires a reinstall and only succeeds when `allow_reinstall = true`; otherwise the plan fails with an error.
 - `locked` (Boolean) Lock/unlock the server. A locked server cannot be deleted or updated.

--- a/internal/planmodifiers/default_on_create.go
+++ b/internal/planmodifiers/default_on_create.go
@@ -1,0 +1,44 @@
+package planmodifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// DefaultOnCreate sets a static default for an optional+computed string
+// attribute only when the resource is being created, so the default is
+// visible in the plan instead of "(known after apply)". On updates with the
+// attribute omitted, the value already in state is preserved — unlike a
+// schema Default, which would also override the state value on update.
+type DefaultOnCreate struct {
+	Value string
+}
+
+var _ planmodifier.String = (*DefaultOnCreate)(nil)
+
+func (m DefaultOnCreate) Description(_ context.Context) string {
+	return fmt.Sprintf("Defaults to %q on create; preserves the state value on update.", m.Value)
+}
+
+func (m DefaultOnCreate) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m DefaultOnCreate) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// A value is set in config (or comes from an unknown reference) — leave it.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Update with the attribute omitted — keep whatever is in state.
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+
+	// Create with the attribute omitted — apply the default at plan time.
+	resp.PlanValue = types.StringValue(m.Value)
+}

--- a/internal/planmodifiers/default_on_create_test.go
+++ b/internal/planmodifiers/default_on_create_test.go
@@ -1,0 +1,76 @@
+package planmodifiers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDefaultOnCreate_PlanModifyString(t *testing.T) {
+	tests := []struct {
+		name        string
+		configValue types.String
+		stateValue  types.String
+		planValue   types.String
+		expected    types.String
+	}{
+		{
+			name:        "create with attribute omitted - default applied at plan time",
+			configValue: types.StringNull(),
+			stateValue:  types.StringNull(),
+			planValue:   types.StringUnknown(),
+			expected:    types.StringValue("monthly"),
+		},
+		{
+			name:        "create with explicit value - keep config value",
+			configValue: types.StringValue("hourly"),
+			stateValue:  types.StringNull(),
+			planValue:   types.StringValue("hourly"),
+			expected:    types.StringValue("hourly"),
+		},
+		{
+			name:        "update with attribute omitted - preserve state value",
+			configValue: types.StringNull(),
+			stateValue:  types.StringValue("yearly"),
+			planValue:   types.StringUnknown(),
+			expected:    types.StringValue("yearly"),
+		},
+		{
+			name:        "update with explicit value - keep config value",
+			configValue: types.StringValue("monthly"),
+			stateValue:  types.StringValue("hourly"),
+			planValue:   types.StringValue("monthly"),
+			expected:    types.StringValue("monthly"),
+		},
+		{
+			name:        "config from unknown reference - leave plan untouched",
+			configValue: types.StringUnknown(),
+			stateValue:  types.StringValue("hourly"),
+			planValue:   types.StringUnknown(),
+			expected:    types.StringUnknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := DefaultOnCreate{Value: "monthly"}
+
+			req := planmodifier.StringRequest{
+				ConfigValue: tt.configValue,
+				StateValue:  tt.stateValue,
+				PlanValue:   tt.planValue,
+			}
+			resp := &planmodifier.StringResponse{
+				PlanValue: tt.planValue,
+			}
+
+			m.PlanModifyString(context.Background(), req, resp)
+
+			if !resp.PlanValue.Equal(tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, resp.PlanValue)
+			}
+		})
+	}
+}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -212,11 +212,12 @@ func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"billing": schema.StringAttribute{
-				MarkdownDescription: "The server billing type (hourly, monthly, yearly). Defaults to monthly.",
+				MarkdownDescription: "The server billing type. Accepts `hourly` and `monthly` for on-demand projects and `yearly` for reserved projects. Defaults to `monthly`, which is charged upfront based on the proration of the current billing cycle. Use `hourly` for dynamic or short-lived workloads.",
 				Optional:            true,
 				Computed:            true,
 				Validators:          validators.Billing(),
 				PlanModifiers: []planmodifier.String{
+					planmodifiers.DefaultOnCreate{Value: validators.BillingMonthly},
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
@@ -729,9 +730,10 @@ func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Set default value for billing if not provided
-	if data.Billing.IsNull() || data.Billing.IsUnknown() || strings.TrimSpace(data.Billing.ValueString()) == "" {
-		data.Billing = types.StringValue("monthly")
+	// billing defaults to "monthly" at plan time via the DefaultOnCreate plan
+	// modifier; guard against unknown values from unresolved references.
+	if data.Billing.IsNull() || data.Billing.IsUnknown() {
+		data.Billing = types.StringValue(validators.BillingMonthly)
 	}
 
 	attrs := &operations.CreateServerServersAttributes{}

--- a/latitudesh/resource_server_billing_test.go
+++ b/latitudesh/resource_server_billing_test.go
@@ -1,0 +1,213 @@
+package latitudesh
+
+// These tests exercise the server `billing` attribute against a local mock of
+// the Latitude.sh API, injected through the provider's httpClient (the same
+// hook the VCR tests use). They run under TF_ACC without requiring
+// credentials or creating real resources.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	testServerMockID       = "sv_mock_1"
+	testServerMockHostname = "test-billing"
+	testServerMockPlan     = "c2-small-x86"
+	testServerMockOS       = "ubuntu_24_04_x64_lts"
+)
+
+type mockServerAPI struct {
+	mu             sync.Mutex
+	createdBilling *string // billing received in the create payload (nil = omitted)
+	billing        string  // billing the mock reports back on reads
+	exists         bool
+	deleted        bool
+}
+
+func (m *mockServerAPI) serverEnvelope() map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"id":   testServerMockID,
+			"type": "servers",
+			"attributes": map[string]any{
+				"hostname":         testServerMockHostname,
+				"status":           "on",
+				"locked":           false,
+				"primary_ipv4":     "203.0.113.20",
+				"operating_system": map[string]any{"slug": testServerMockOS},
+				"plan": map[string]any{
+					"id":      "plan_mock_1",
+					"name":    "c2.small.x86",
+					"slug":    testServerMockPlan,
+					"billing": m.billing,
+				},
+			},
+		},
+	}
+}
+
+func (m *mockServerAPI) handler(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/servers":
+		var payload struct {
+			Data struct {
+				Attributes map[string]any `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if b, ok := payload.Data.Attributes["billing"].(string); ok {
+			m.createdBilling = &b
+			m.billing = b
+		} else {
+			// Mirror the real API: monthly when billing is omitted.
+			m.billing = "monthly"
+		}
+		m.exists = true
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(m.serverEnvelope())
+
+	case r.Method == http.MethodGet && r.URL.Path == "/servers/"+testServerMockID:
+		if !m.exists || m.deleted {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"404"}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(m.serverEnvelope())
+
+	case r.Method == http.MethodGet && r.URL.Path == "/servers/"+testServerMockID+"/deploy_config":
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"id":         "deploy_mock_1",
+				"type":       "deploy_config",
+				"attributes": map[string]any{},
+			},
+		})
+
+	case r.Method == http.MethodDelete && r.URL.Path == "/servers/"+testServerMockID:
+		m.deleted = true
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"status":"404"}]}`))
+	}
+}
+
+func testAccServerBillingConfig(billingLine string) string {
+	return fmt.Sprintf(`
+provider "latitudesh" {
+  auth_token = "mock-token"
+}
+
+resource "latitudesh_server" "test_item" {
+  hostname         = %q
+%s
+  plan             = %q
+  site             = "ASH"
+  operating_system = %q
+  project          = "proj_mock_1"
+}
+`, testServerMockHostname, billingLine, testServerMockPlan, testServerMockOS)
+}
+
+func testAccCheckMockServerDestroyed(m *mockServerAPI) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.exists && !m.deleted {
+			return fmt.Errorf("mock server still exists after destroy")
+		}
+		return nil
+	}
+}
+
+// When billing is omitted, the DefaultOnCreate plan modifier must resolve it
+// to "monthly" at plan time, so the create payload carries it explicitly and
+// state ends up with "monthly". The next plan must be empty.
+func TestAccServer_BillingDefaultsToMonthlyWhenOmitted(t *testing.T) {
+	mock := &mockServerAPI{}
+	server := httptest.NewServer(http.HandlerFunc(mock.handler))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithMock(server),
+		CheckDestroy:             testAccCheckMockServerDestroyed(mock),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerBillingConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("latitudesh_server.test_item", "billing", "monthly"),
+					func(s *terraform.State) error {
+						mock.mu.Lock()
+						defer mock.mu.Unlock()
+						if mock.createdBilling == nil {
+							return fmt.Errorf("create payload did not include billing; the plan-time default was not applied")
+						}
+						if *mock.createdBilling != "monthly" {
+							return fmt.Errorf("create payload billing = %q, want %q", *mock.createdBilling, "monthly")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config:   testAccServerBillingConfig(""),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// Removing the billing attribute from the config of an existing server must
+// preserve the value in state — it must not fall back to the create default
+// (which would plan a billing change and, for yearly servers, fail the plan
+// as a forbidden downgrade).
+func TestAccServer_BillingPreservedWhenRemovedFromConfig(t *testing.T) {
+	mock := &mockServerAPI{}
+	server := httptest.NewServer(http.HandlerFunc(mock.handler))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithMock(server),
+		CheckDestroy:             testAccCheckMockServerDestroyed(mock),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerBillingConfig(`  billing          = "hourly"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("latitudesh_server.test_item", "billing", "hourly"),
+				),
+			},
+			{
+				Config:   testAccServerBillingConfig(""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccServerBillingConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("latitudesh_server.test_item", "billing", "hourly"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Summary

Closes [PD-6524](https://latitude.atlassian.net/browse/PD-6524).

A customer was overcharged after creating servers without `billing` for dynamic workloads: the attribute silently defaults to `monthly` and neither the docs nor the plan output said so.

- Resolve the `monthly` default at plan time via a new `DefaultOnCreate` plan modifier, so `terraform plan` shows `billing = "monthly"` instead of `(known after apply)`. On updates with the attribute omitted, the state value is preserved — a plain schema default would plan a `yearly -> monthly` downgrade and fail validation for existing configs.
- Update the `billing` attribute description (schema and registry docs) to state the accepted values, the default, and that monthly is charged upfront based on the proration of the current billing cycle.
- Add a billing note to the server resource and getting-started examples.

### Testing

```bash
go test ./internal/planmodifiers/ -run TestDefaultOnCreate -v
TF_ACC=1 go test ./latitudesh/ -run 'TestAccServer_Billing' -v
```

The new acceptance tests run against a local mock API (no credentials, no real resources) and cover: billing omitted -> create payload carries `"monthly"` explicitly and the next plan is empty; billing removed from the config of an existing server -> state value preserved, no spurious diff.

All `TestAccServer_*` VCR tests pass locally.

[PD-6524]: https://latitude.atlassian.net/browse/PD-6524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes server billing defaults visible in plans and updates the billing docs. The main changes are:

- Added a `DefaultOnCreate` plan modifier for optional computed strings.
- Applied the new modifier to `latitudesh_server.billing`.
- Updated server billing descriptions and examples.
- Added billing-focused tests for omitted and removed config.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small cleanup to the create-time billing fallback.

- The new plan modifier preserves state on updates and sets the create default as intended.
- A narrow apply-time path can still pass an empty resolved billing value to the API.
- The issue is contained to invalid dynamic input and has a small local fix.

latitudesh/resource_server.go
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
latitudesh/resource_server.go:735-737
**Resolved Empty Billing Reaches API**

When `billing` comes from an unknown expression that resolves to `""` or whitespace during apply, this guard no longer normalizes it to `monthly`. The value is no longer null or unknown, so Create can send an invalid `billing` value to the API and fail apply instead of preserving the previous defaulting behavior.

```suggestion
	if data.Billing.IsNull() || data.Billing.IsUnknown() || strings.TrimSpace(data.Billing.ValueString()) == "" {
		data.Billing = types.StringValue(validators.BillingMonthly)
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): make billing default explic..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/801ddff112187ad3392e93568734dcaac26e6ab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44169177)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->