### PR TITLE
fix(vlan_assignment): wait for assignment to reach connected on create

### DIFF
--- a/latitudesh/resource_vlan_assignment.go
+++ b/latitudesh/resource_vlan_assignment.go
@@ -27,7 +27,24 @@ func NewVlanAssignmentResource() resource.Resource {
 
 type VlanAssignmentResource struct {
 	client *latitudeshgosdk.Latitudesh
+
+	// connectTimeout and connectPollInterval bound the post-create wait for
+	// the assignment to reach status "connected". Zero values fall back to the
+	// production defaults below; tests override them to keep runs fast.
+	connectTimeout      time.Duration
+	connectPollInterval time.Duration
 }
+
+// statusConnected is the terminal status a virtual network assignment reaches
+// once provisioning has completed. Until then it sits at
+// "connecting"; if that never completes the assignment never appears in the
+// console (see issue #190).
+const statusConnected = "connected"
+
+const (
+	defaultConnectTimeout      = 2 * time.Minute
+	defaultConnectPollInterval = 3 * time.Second
+)
 
 type VlanAssignmentResourceModel struct {
 	ID               types.String `tfsdk:"id"`
@@ -155,9 +172,21 @@ func (r *VlanAssignmentResource) Create(ctx context.Context, req resource.Create
 		}
 	}
 
-	// Read the resource to populate all attributes
-	r.readVlanAssignment(ctx, &data, &resp.Diagnostics)
+	// Wait for the assignment to actually reach "connected" and populate all
+	// attributes from the connected assignment. A bare 201 only means the
+	// request was accepted; provisioning happens asynchronously and
+	// may never complete. Reporting success here without waiting is the
+	// false-success gap in issue #190 (Terraform shows the VLAN assigned while
+	// the console shows nothing).
+	persist := r.waitForAssignmentConnected(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		if persist {
+			// The assignment never connected and couldn't be rolled back, so it
+			// still exists remotely. Save it to state so Terraform tracks it and
+			// replaces it on the next apply (create-with-error taints it) rather
+			// than leaking it or creating a duplicate.
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
 		return
 	}
 
@@ -264,6 +293,182 @@ func (r *VlanAssignmentResource) waitForAssignmentRemoval(ctx context.Context, i
 	}
 }
 
+// waitForAssignmentConnected polls the just-created assignment until it
+// reaches status "connected", then populates data from it. If the deadline
+// passes while the assignment is still "connecting" (or has not surfaced yet),
+// it fails the apply with an actionable diagnostic instead of silently
+// recording a phantom assignment. Reuses findAssignmentByID so the lookup is
+// filtered by server and survives pagination.
+// waitForAssignmentConnected returns whether the caller should persist the
+// assignment to state. It returns false on success (the caller saves the
+// connected assignment normally) and false when a non-connected assignment was
+// successfully rolled back (nothing to track). It returns true only when the
+// assignment never connected AND could not be rolled back — then it populates
+// data so the caller can save it to state, keeping the still-existing remote
+// assignment tracked (and tainted) for reconciliation on the next apply.
+func (r *VlanAssignmentResource) waitForAssignmentConnected(ctx context.Context, data *VlanAssignmentResourceModel, diags *diag.Diagnostics) (persist bool) {
+	timeout := r.connectTimeout
+	if timeout <= 0 {
+		timeout = defaultConnectTimeout
+	}
+	pollInterval := r.connectPollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultConnectPollInterval
+	}
+
+	assignmentID := data.ID.ValueString()
+	serverID := ""
+	if !data.ServerID.IsNull() {
+		serverID = data.ServerID.ValueString()
+	}
+
+	deadline := time.Now().Add(timeout)
+	lastStatus := ""
+	var lastAttrs *components.VirtualNetworkAssignmentDataAttributes
+
+poll:
+	for {
+		assignment, err := r.findAssignmentByID(ctx, assignmentID, serverID)
+		if err != nil {
+			// A transient lookup error (429/503/network) must not abandon the
+			// assignment we just created — keep polling within the deadline.
+			lastStatus = fmt.Sprintf("lookup error: %s", err)
+		} else if assignment != nil && assignment.Attributes != nil {
+			lastAttrs = assignment.Attributes
+			if lastAttrs.Status != nil {
+				lastStatus = *lastAttrs.Status
+			}
+			if lastStatus == statusConnected {
+				applyAssignmentAttributes(data, lastAttrs)
+				return false
+			}
+		}
+
+		if !time.Now().Add(pollInterval).Before(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			break poll
+		case <-time.After(pollInterval):
+		}
+	}
+
+	// Never reached "connected". Roll back the assignment the POST created so a
+	// half-provisioned one isn't left unmanaged in the API.
+	if r.rollbackAssignment(assignmentID) {
+		diags.AddError("Assignment Not Connected",
+			fmt.Sprintf("Virtual network assignment %q did not reach %q within %s (last status: %q). "+
+				"The request was accepted but provisioning did not complete; the assignment "+
+				"will not be visible in the console. Please retry again in a few moments.",
+				assignmentID, statusConnected, timeout, statusOrUnknown(lastStatus)))
+		return false
+	}
+
+	// Rollback failed — the assignment still exists remotely. Populate data from
+	// the last read (or nulls) so the caller can save it to state; Terraform
+	// then tracks it and replaces it on the next apply instead of leaking it.
+	if lastAttrs != nil {
+		applyAssignmentAttributes(data, lastAttrs)
+	} else {
+		data.Vid = types.Int64Null()
+		data.Description = types.StringNull()
+		data.Status = types.StringNull()
+	}
+	diags.AddError("Assignment Not Connected",
+		fmt.Sprintf("Virtual network assignment %q did not reach %q within %s (last status: %q) and could "+
+			"not be rolled back. It is now tracked in state and will be replaced on the next apply. "+
+			"Please retry again in a few moments.",
+			assignmentID, statusConnected, timeout, statusOrUnknown(lastStatus)))
+	return true
+}
+
+// rollbackAssignment removes an assignment that Create could not bring to
+// "connected", retrying transient failures within a bounded window. It runs on
+// a fresh context (the caller's may be cancelled). Returns true if the
+// assignment is gone (deleted, or already absent), false if it could not be
+// removed — the caller then keeps it in state for reconciliation.
+func (r *VlanAssignmentResource) rollbackAssignment(id string) bool {
+	if id == "" {
+		return true
+	}
+
+	interval := r.connectPollInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+
+	const attempts = 3
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(interval)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		result, err := r.client.PrivateNetworks.DeleteAssignment(ctx, id)
+		cancel()
+
+		// A 404 means the assignment is already gone — treat as success.
+		if err != nil && strings.Contains(err.Error(), "404") {
+			return true
+		}
+		// A real transport/API error (the SDK reports an empty success body as
+		// the literal "{}") — retry within the window.
+		if err != nil && err.Error() != "{}" {
+			continue
+		}
+		// No Go error: the SDK can still signal failure only in the HTTP status,
+		// so validate it like the Delete path does before declaring success.
+		if result != nil && result.HTTPMeta.Response != nil {
+			code := result.HTTPMeta.Response.StatusCode
+			if code == 404 {
+				return true
+			}
+			if code >= 400 {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func statusOrUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// applyAssignmentAttributes copies the readable attributes of an assignment
+// onto the resource model. Shared by the connected-wait and the read paths so
+// the mapping stays in one place.
+func applyAssignmentAttributes(data *VlanAssignmentResourceModel, attrs *components.VirtualNetworkAssignmentDataAttributes) {
+	if attrs == nil {
+		return
+	}
+	if attrs.Server != nil && attrs.Server.ID != nil {
+		data.ServerID = types.StringValue(*attrs.Server.ID)
+	}
+	if attrs.VirtualNetworkID != nil {
+		data.VirtualNetworkID = types.StringValue(*attrs.VirtualNetworkID)
+	}
+	if attrs.Vid != nil {
+		data.Vid = types.Int64Value(*attrs.Vid)
+	} else {
+		data.Vid = types.Int64Null()
+	}
+	if attrs.Description != nil {
+		data.Description = types.StringValue(*attrs.Description)
+	} else {
+		data.Description = types.StringNull()
+	}
+	if attrs.Status != nil {
+		data.Status = types.StringValue(*attrs.Status)
+	} else {
+		data.Status = types.StringNull()
+	}
+}
+
 func (r *VlanAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	var data VlanAssignmentResourceModel
 
@@ -332,24 +537,7 @@ func (r *VlanAssignmentResource) readVlanAssignment(ctx context.Context, data *V
 		}
 		found = true
 
-		if assignment.Attributes != nil {
-			attrs := assignment.Attributes
-			if attrs.Server != nil && attrs.Server.ID != nil {
-				data.ServerID = types.StringValue(*attrs.Server.ID)
-			}
-			if attrs.VirtualNetworkID != nil {
-				data.VirtualNetworkID = types.StringValue(*attrs.VirtualNetworkID)
-			}
-			if attrs.Vid != nil {
-				data.Vid = types.Int64Value(*attrs.Vid)
-			}
-			if attrs.Description != nil {
-				data.Description = types.StringValue(*attrs.Description)
-			}
-			if attrs.Status != nil {
-				data.Status = types.StringValue(*attrs.Status)
-			}
-		}
+		applyAssignmentAttributes(data, assignment.Attributes)
 
 		// If we got the vid, we're done. Otherwise retry.
 		if !data.Vid.IsNull() {

--- a/latitudesh/resource_vlan_assignment_connecting_test.go
+++ b/latitudesh/resource_vlan_assignment_connecting_test.go
@@ -1,0 +1,224 @@
+package latitudesh
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
+)
+
+// Regression tests for issue #190.
+//
+// The API accepts an assignment with HTTP 201 but provisioning runs
+// asynchronously; until it completes the assignment sits at status
+// "connecting" and shows nothing in the console. Create must wait for
+// "connected" instead of reporting a false success. Both tests drive Create()
+// directly against a mock API so no live credentials or VCR fixtures are
+// needed.
+
+// assignmentBody returns the JSON for a single assignment with the given status.
+func assignmentBody(status string) string {
+	return `{"id":"vnasg_STUCK01","type":"virtual_network_assignment",` +
+		`"attributes":{"virtual_network_id":"vlan_TEST","vid":2043,` +
+		`"description":"test VLAN","status":"` + status + `",` +
+		`"server":{"id":"sv_TEST","hostname":"test-server-01","label":"","status":"on"}}}`
+}
+
+// vlanMockServer stands up a mock API. POST always returns 201 with status
+// "connecting". GET (ListAssignments) returns "connecting" until connectAfter
+// GETs have been served, then "connected". connectAfter == 0 means it never
+// connects (the stuck case). failFirstGets makes the first N GETs return 503,
+// to simulate a transient lookup error. It also counts DELETEs so tests can
+// assert the rollback of an assignment that never connected.
+type vlanMock struct {
+	connectAfter  int32
+	failFirstGets int32
+	failDeletes   bool
+	gets          int32
+	deletes       int32
+}
+
+func (m *vlanMock) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":` + assignmentBody("connecting") + `}`))
+		case http.MethodGet:
+			n := atomic.AddInt32(&m.gets, 1)
+			if n <= m.failFirstGets {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"errors":[{"status":"503"}]}`))
+				return
+			}
+			status := "connecting"
+			if m.connectAfter > 0 && n >= m.connectAfter {
+				status = statusConnected
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[` + assignmentBody(status) + `],"meta":{}}`))
+		case http.MethodDelete:
+			atomic.AddInt32(&m.deletes, 1)
+			if m.failDeletes {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"errors":[{"status":"503"}]}`))
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// runCreate drives r.Create() with a plan for server sv_TEST / vlan vlan_TEST
+// and returns the response so callers can assert diagnostics and state.
+func runCreate(t *testing.T, r *VlanAssignmentResource) *resource.CreateResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	sch := schemaResp.Schema
+	objType := sch.Type().TerraformType(ctx)
+
+	planVal := tftypes.NewValue(objType, map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"server_id":          tftypes.NewValue(tftypes.String, "sv_TEST"),
+		"virtual_network_id": tftypes.NewValue(tftypes.String, "vlan_TEST"),
+		"vid":                tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+		"description":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"status":             tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Raw: planVal, Schema: sch}}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Raw: tftypes.NewValue(objType, nil), Schema: sch},
+	}
+	r.Create(ctx, req, resp)
+	return resp
+}
+
+func newTestVlanResource(serverURL string) *VlanAssignmentResource {
+	return &VlanAssignmentResource{
+		client: latitudeshgosdk.New(
+			latitudeshgosdk.WithSecurity("test"),
+			latitudeshgosdk.WithServerURL(serverURL),
+		),
+		connectTimeout:      150 * time.Millisecond,
+		connectPollInterval: 10 * time.Millisecond,
+	}
+}
+
+// TestVlanAssignmentCreate_StuckConnecting: an assignment that never leaves
+// "connecting" must fail the apply (not report success) and roll back the
+// assignment it created so nothing is left unmanaged.
+func TestVlanAssignmentCreate_StuckConnecting(t *testing.T) {
+	m := &vlanMock{connectAfter: 0} // never connects
+	server := m.server(t)
+
+	resp := runCreate(t, newTestVlanResource(server.URL))
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected Create to error when assignment is stuck 'connecting', but it succeeded")
+	}
+	found := false
+	for _, d := range resp.Diagnostics.Errors() {
+		if d.Summary() == "Assignment Not Connected" {
+			found = true
+			t.Logf("got expected diagnostic: %s: %s", d.Summary(), d.Detail())
+		}
+	}
+	if !found {
+		t.Fatalf("expected an 'Assignment Not Connected' diagnostic, got: %v", resp.Diagnostics.Errors())
+	}
+	if got := atomic.LoadInt32(&m.deletes); got == 0 {
+		t.Fatalf("expected the stuck assignment to be rolled back with a DELETE, got %d deletes", got)
+	}
+}
+
+// TestVlanAssignmentCreate_ReachesConnected: when the assignment transitions
+// connecting -> connected within the timeout, Create succeeds, commits the
+// connected status, and does not delete anything.
+func TestVlanAssignmentCreate_ReachesConnected(t *testing.T) {
+	m := &vlanMock{connectAfter: 2} // connects on the 2nd GET
+	server := m.server(t)
+
+	resp := runCreate(t, newTestVlanResource(server.URL))
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected Create to succeed once connected, got: %v", resp.Diagnostics.Errors())
+	}
+
+	var out VlanAssignmentResourceModel
+	resp.State.Get(context.Background(), &out)
+	if got := out.Status.ValueString(); got != statusConnected {
+		t.Fatalf("expected committed status %q, got %q", statusConnected, got)
+	}
+	if out.ID.ValueString() != "vnasg_STUCK01" || out.Vid.ValueInt64() != 2043 {
+		t.Fatalf("unexpected committed state: id=%q vid=%d", out.ID.ValueString(), out.Vid.ValueInt64())
+	}
+	if got := atomic.LoadInt32(&m.deletes); got != 0 {
+		t.Fatalf("expected no rollback on success, got %d deletes", got)
+	}
+}
+
+// TestVlanAssignmentCreate_TransientLookupError: a few transient 503s from the
+// status poll must not abandon the assignment — Create keeps polling within the
+// deadline and still succeeds once it reaches "connected".
+func TestVlanAssignmentCreate_TransientLookupError(t *testing.T) {
+	m := &vlanMock{connectAfter: 3, failFirstGets: 2} // GET 1&2 -> 503, GET 3 -> connected
+	server := m.server(t)
+
+	resp := runCreate(t, newTestVlanResource(server.URL))
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected Create to survive transient lookup errors and succeed, got: %v", resp.Diagnostics.Errors())
+	}
+
+	var out VlanAssignmentResourceModel
+	resp.State.Get(context.Background(), &out)
+	if got := out.Status.ValueString(); got != statusConnected {
+		t.Fatalf("expected committed status %q, got %q", statusConnected, got)
+	}
+	if got := atomic.LoadInt32(&m.deletes); got != 0 {
+		t.Fatalf("expected no rollback once connected, got %d deletes", got)
+	}
+}
+
+// TestVlanAssignmentCreate_RollbackFailurePersistsState: if the assignment
+// never connects AND the rollback DELETE keeps failing, Create must not leak
+// the assignment — it retries the delete, then persists the assignment to state
+// so Terraform tracks (and replaces) it on the next apply.
+func TestVlanAssignmentCreate_RollbackFailurePersistsState(t *testing.T) {
+	m := &vlanMock{connectAfter: 0, failDeletes: true} // never connects; rollback always 503
+	server := m.server(t)
+
+	resp := runCreate(t, newTestVlanResource(server.URL))
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected Create to error when the assignment never connects")
+	}
+	if got := atomic.LoadInt32(&m.deletes); got < 2 {
+		t.Fatalf("expected the rollback DELETE to be retried, got %d attempts", got)
+	}
+
+	// Rollback failed, so the still-existing assignment must be tracked in state
+	// (create-with-error taints it → replaced next apply) rather than leaked.
+	var out VlanAssignmentResourceModel
+	resp.State.Get(context.Background(), &out)
+	if out.ID.ValueString() != "vnasg_STUCK01" {
+		t.Fatalf("expected the un-rolled-back assignment to be persisted in state, got id=%q", out.ID.ValueString())
+	}
+}

--- a/latitudesh/resource_vlan_assignment_test.go
+++ b/latitudesh/resource_vlan_assignment_test.go
@@ -36,6 +36,12 @@ func TestAccVlanAssignment_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"latitudesh_vlan_assignment.test", "virtual_network_id",
 						"latitudesh_virtual_network.test", "id"),
+					// PD-6552: Create must wait for the assignment to reach
+					// "connected" before succeeding, so a completed apply must
+					// report that status (with an allocated vid) — not a
+					// still-"connecting" phantom.
+					resource.TestCheckResourceAttr("latitudesh_vlan_assignment.test", "status", "connected"),
+					resource.TestCheckResourceAttrSet("latitudesh_vlan_assignment.test", "vid"),
 				),
 			},
 			{


### PR DESCRIPTION
Fixes #190

## Problem

`latitudesh_vlan_assignment` reports a successful apply as soon as the API returns `201`. A `201` only means the request was accepted — the switch programming happens asynchronously and the assignment stays at `status: "connecting"` until it completes. When that never completes, the assignment never becomes `"connected"` and never appears in the console, yet Terraform records it as assigned. Users see a VLAN "assigned" in state that does not exist anywhere else.

## Fix

`Create` now waits for the assignment to reach `status == "connected"` before committing state:

- New `waitForAssignmentConnected` polls the assignment (via the server-filtered, pagination-safe `findAssignmentByID`) until it is connected, then populates state from the connected assignment.
- On timeout it fails the apply with an actionable diagnostic instead of silently recording a phantom assignment:
  > Assignment Not Connected — Virtual network assignment "…" did not reach "connected" within 2m0s (last status: "connecting"). The request was accepted but the switch programming did not complete; the assignment will not be visible in the console.
- Timeout/poll interval default to 2m/3s (matching the existing `waitForAssignmentRemoval`) and are overridable for tests.
- Extracted `applyAssignmentAttributes` so the attribute mapping is shared between the connected-wait and `readVlanAssignment`.

A hard `4XX` from the API (e.g. an interface with no connected switch endpoint) already surfaces as an error and is unaffected — this only closes the soft "connecting forever" case.

## Tests

`resource_vlan_assignment_connecting_test.go` drives `Create()` directly against a mock API (no live credentials / VCR fixtures):

- stuck `"connecting"` → apply errors (previously reported false success)
- `"connecting"` → `"connected"` transition → apply succeeds and commits `status = "connected"`

## Test plan

- `go test ./...` passes; `go vet ./...` and `gofmt` clean.
- Manual: apply a `latitudesh_vlan_assignment` against a server whose port reaches `connected` — apply succeeds and state shows `status = "connected"`. Against a server whose tagging never completes, apply fails with the "Assignment Not Connected" diagnostic instead of a phantom success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR waits for VLAN assignments to finish connecting before recording a successful create. The main changes are:

- Polls assignments until they reach `connected`.
- Retries transient lookup failures within the connection timeout.
- Rolls back assignments that do not connect.
- Preserves state when rollback cannot remove the assignment.
- Shares assignment attribute mapping between create and read paths.
- Adds tests for connection, timeout, transient errors, and rollback failure.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated polling path survives transient lookup failures.
- Failed connection attempts are rolled back or retained in state for later reconciliation.
- No blocking issues remain in the changed code.

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(vlan\_assignment): wait for assignmen..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/b65b7321f9cb7b78af6d55d0f666b40e9d9259ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44545755)</sub>

<!-- /greptile_comment -->