### PR TITLE
test(acc): run acceptance tests in a shared project instead of per-test projects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,14 @@ on:
       - reopened
       - ready_for_review
 
+# The acceptance suite runs against one shared Latitude account/project, so two
+# runs in flight at once would create colliding resource names. Serialize them:
+# a new run queues until the previous finishes (never cancels it mid-run, which
+# would leak half-created resources).
+concurrency:
+  group: latitudesh-acceptance-tests
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/latitudesh/resource_firewall_test.go
+++ b/latitudesh/resource_firewall_test.go
@@ -82,10 +82,10 @@ func testAccCheckFirewallExists(n string, firewall *components.FirewallData) res
 }
 
 func testAccCheckLatitudeFirewallConfig_basic() string {
-	return testAccProjectBlock("tf-acc-firewall") + `
+	return `
 resource "latitudesh_firewall" "test" {
   name = "test-firewall"
-  project = latitudesh_project.test.id
+  project = "` + testAccProjectID() + `"
   # Default rule - API will automatically add this
   rules {
     from = "ANY"

--- a/latitudesh/resource_server_test.go
+++ b/latitudesh/resource_server_test.go
@@ -546,10 +546,10 @@ func TestAccServer_Locked(t *testing.T) {
 }
 
 func testAccCheckServerLockedWithSite(site string, locked bool) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "hourly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"
@@ -690,14 +690,10 @@ func testAccCheckServerExists(n string) resource.TestCheckFunc {
 			serverOS = *server.Attributes.OperatingSystem.Slug
 		}
 
-		// The expected project is created in-config as latitudesh_project.test;
+		// All acceptance tests run in the shared project (testAccProjectID);
 		// the API may report it by ID or slug.
-		expectedProjectID := ""
-		expectedProjectSlug := ""
-		if prj, ok := s.RootModule().Resources["latitudesh_project.test"]; ok {
-			expectedProjectID = prj.Primary.ID
-			expectedProjectSlug = prj.Primary.Attributes["slug"]
-		}
+		expectedProjectID := testAccProjectID()
+		expectedProjectSlug := testAccProjectSlugBestEffort()
 
 		// Check if server meets all required conditions
 		if (status == "on" || status == "inventory" || status == "deploying") &&
@@ -792,6 +788,7 @@ func TestAccServer_DefaultTimeout(t *testing.T) {
 }
 
 func TestAccServer_ProjectSlugConsistency(t *testing.T) {
+	projectSlug := testAccProjectSlug(t)
 	runTestWithSiteFallback(t, func(site string, recorder *recorder.Recorder) resource.TestCase {
 		return resource.TestCase{
 			PreCheck: func() {
@@ -801,12 +798,11 @@ func TestAccServer_ProjectSlugConsistency(t *testing.T) {
 			CheckDestroy:             testAccCheckServerDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccCheckServerWithProjectSlugWithSite(site),
+					Config: testAccCheckServerWithProjectSlugWithSite(site, projectSlug),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckServerExists("latitudesh_server.test_item"),
-						resource.TestCheckResourceAttrPair(
-							"latitudesh_server.test_item", "project",
-							"latitudesh_project.test", "slug"),
+						resource.TestCheckResourceAttr(
+							"latitudesh_server.test_item", "project", projectSlug),
 						resource.TestCheckResourceAttr(
 							"latitudesh_server.test_item", "hostname", testServerHostname),
 						resource.TestCheckResourceAttr(
@@ -815,7 +811,7 @@ func TestAccServer_ProjectSlugConsistency(t *testing.T) {
 				},
 				// Verify that project value doesn't change after read
 				{
-					Config:             testAccCheckServerWithProjectSlugWithSite(site),
+					Config:             testAccCheckServerWithProjectSlugWithSite(site, projectSlug),
 					PlanOnly:           true,
 					ExpectNonEmptyPlan: false, // Should be no changes
 				},
@@ -827,10 +823,10 @@ func TestAccServer_ProjectSlugConsistency(t *testing.T) {
 // Config generators with site parameter
 
 func testAccCheckServerBasicWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"
@@ -845,10 +841,10 @@ resource "latitudesh_server" "test_item" {
 }
 
 func testAccCheckServerUpdateInitialWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "hourly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "test-initial"
 	plan     = "%s"
 	site     = "%s"
@@ -862,10 +858,10 @@ resource "latitudesh_server" "test_item" {
 }
 
 func testAccCheckServerUpdateChangedWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "test-initial"
 	plan     = "%s"
 	site     = "%s"
@@ -879,10 +875,10 @@ resource "latitudesh_server" "test_item" {
 }
 
 func testAccCheckServerUpdateHostnameWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "test-updated"
 	plan     = "%s"
 	site     = "%s"
@@ -897,10 +893,10 @@ resource "latitudesh_server" "test_item" {
 }
 
 func testAccServerConfigWithSSHKeysWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"
@@ -916,10 +912,10 @@ resource "latitudesh_server" "test_item" {
 }
 
 func testAccCheckServerCustomTimeoutWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
 	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"
@@ -938,11 +934,11 @@ resource "latitudesh_server" "test_item" {
 	)
 }
 
-func testAccCheckServerWithProjectSlugWithSite(site string) string {
-	return testAccProjectBlock("tf-acc-server") + fmt.Sprintf(`
+func testAccCheckServerWithProjectSlugWithSite(site, projectSlug string) string {
+	return fmt.Sprintf(`
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.slug
+	project = "`+projectSlug+`"
 	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"

--- a/latitudesh/resource_server_userdata_test.go
+++ b/latitudesh/resource_server_userdata_test.go
@@ -111,7 +111,7 @@ func pointersEqual(a, b *string) bool {
 }
 
 func testAccCheckServerWithUserData(site string) string {
-	return testAccProjectBlock("tf-acc-server-user-data") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_user_data" "test" {
 	description = "tf-acc-server-user-data"
 	content     = "%s"
@@ -119,7 +119,7 @@ resource "latitudesh_user_data" "test" {
 
 resource "latitudesh_server" "test_item" {
 	billing = "monthly"
-	project = latitudesh_project.test.id
+	project = "`+testAccProjectID()+`"
   	hostname = "%s"
 	plan     = "%s"
 	site     = "%s"

--- a/latitudesh/resource_virtual_machine_test.go
+++ b/latitudesh/resource_virtual_machine_test.go
@@ -126,12 +126,12 @@ func testAccCheckVirtualMachineExists(n string) resource.TestCheckFunc {
 }
 
 func testAccVirtualMachineBasic(plan string) string {
-	return testAccProjectBlock("tf-acc-virtual-machine") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_virtual_machine" "test_item" {
   name    = %q
   site    = %q
   plan    = %q
-  project = latitudesh_project.test.id
+  project = "`+testAccProjectID()+`"
 }
 `, testVMName, testVMSite, plan)
 }

--- a/latitudesh/resource_virtual_network_test.go
+++ b/latitudesh/resource_virtual_network_test.go
@@ -27,10 +27,9 @@ func TestAccVirtualNetwork_Basic(t *testing.T) {
 
 	resourceName := "latitudesh_virtual_network.test_item"
 
-	// This test exercises the provider-level default project, which cannot
-	// reference a resource from the same config — pre-create it via the API.
-	projectID, cleanup := testAccCreateProject(t, "tf-acc-virtual-network-"+testRunID)
-	defer cleanup()
+	// This test exercises the provider-level default project. Use the shared
+	// pre-existing project instead of creating a throwaway one.
+	projectID := testAccProjectID()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -144,7 +143,7 @@ func TestAccVirtualNetwork_WithTags(t *testing.T) {
 }
 
 func testAccConfigVirtualNetworkWithTags(desc, site string, tagExprs []string) string {
-	return testAccProjectBlock("tf-acc-virtual-network-tags") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_tag" "a" {
   name  = "tf-acc-vn-tag-a-%[1]s"
   color = "#ff0000"
@@ -156,7 +155,7 @@ resource "latitudesh_tag" "b" {
 }
 
 resource "latitudesh_virtual_network" "test_item" {
-  project     = latitudesh_project.test.id
+  project     = "`+testAccProjectID()+`"
   description = "%[2]s"
   site        = "%[3]s"
   tags        = [%[4]s]
@@ -231,9 +230,9 @@ func TestAccVirtualNetwork_InvalidTagFailsBeforePOST(t *testing.T) {
 }
 
 func testAccConfigVirtualNetworkBogusTag(desc, site, bogusTagID string) string {
-	return testAccProjectBlock("tf-acc-virtual-network-orphan") + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "latitudesh_virtual_network" "test_item" {
-  project     = latitudesh_project.test.id
+  project     = "`+testAccProjectID()+`"
   description = "%s"
   site        = "%s"
   tags        = ["%s"]

--- a/latitudesh/test_utils.go
+++ b/latitudesh/test_utils.go
@@ -1,7 +1,6 @@
 package latitudesh
 
 import (
-	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
@@ -13,7 +12,6 @@ import (
 	"testing"
 
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
-	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
@@ -110,47 +108,6 @@ func testGenerateSSHPublicKey(t *testing.T) string {
 		t.Fatalf("converting to SSH public key: %s", err)
 	}
 	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
-}
-
-// testAccCreateProject provisions a project via the API for tests that need a
-// pre-existing project (e.g. to exercise the provider-level default project,
-// which cannot reference resources created in the same config). The returned
-// cleanup function deletes it. Callers must only invoke it when TF_ACC is set.
-func testAccCreateProject(t *testing.T, name string) (string, func()) {
-	t.Helper()
-
-	// This helper provisions a real project with a raw SDK client, which
-	// cannot be served from VCR cassettes.
-	if mode, err := testRecordMode(); err == nil && mode == recorder.ModeReplayOnly {
-		t.Skip("testAccCreateProject requires live API access; not available in VCR replay mode")
-	}
-
-	client := createVCRClient(nil)
-	env := operations.CreateProjectEnvironmentDevelopment
-
-	result, err := client.Projects.Create(context.Background(), operations.CreateProjectProjectsRequestBody{
-		Data: &operations.CreateProjectProjectsData{
-			Type: operations.CreateProjectProjectsTypeProjects,
-			Attributes: &operations.CreateProjectProjectsAttributes{
-				Name:             name,
-				ProvisioningType: operations.CreateProjectProvisioningTypeOnDemand,
-				Environment:      &env,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("creating test project: %s", err)
-	}
-	if result.Object == nil || result.Object.Data == nil || result.Object.Data.ID == nil {
-		t.Fatal("test project create response missing ID")
-	}
-
-	id := *result.Object.Data.ID
-	return id, func() {
-		if _, err := client.Projects.Delete(context.Background(), id); err != nil {
-			t.Logf("cleanup: failed to delete test project %s: %s", id, err)
-		}
-	}
 }
 
 // createVCRClient creates a Latitude.sh SDK client with VCR recording/playback

--- a/latitudesh/test_utils_shared_test.go
+++ b/latitudesh/test_utils_shared_test.go
@@ -76,6 +76,15 @@ func resolveProjectSlug() (string, error) {
 // (which can't derive a slug from a bare ID).
 func testAccProjectSlug(t *testing.T) string {
 	t.Helper()
+
+	// The slug is resolved with a raw SDK client (no recorder), so it can't be
+	// served from a cassette. Skip in replay mode, mirroring the other
+	// live-only helpers (testAccSharedServers), so we don't make a live call
+	// before the cassette-backed provider is installed.
+	if mode, err := testRecordMode(); err == nil && mode == recorder.ModeReplayOnly {
+		t.Skip("resolving project slug requires live API access; not available in VCR replay mode")
+	}
+
 	slug, err := resolveProjectSlug()
 	if err != nil {
 		t.Fatalf("resolving shared project slug: %s", err)

--- a/latitudesh/test_utils_shared_test.go
+++ b/latitudesh/test_utils_shared_test.go
@@ -19,16 +19,75 @@ import (
 // from aborted ones.
 var testRunID = acctest.RandString(6)
 
-// testAccProjectBlock returns an HCL block creating a run-unique project for
-// self-contained acceptance tests.
-func testAccProjectBlock(prefix string) string {
-	return fmt.Sprintf(`
-resource "latitudesh_project" "test" {
-  name              = "%s-%s"
-  environment       = "Development"
-  provisioning_type = "on_demand"
+// defaultTestProjectID is the pre-existing project (DevTools QA) that all
+// acceptance tests share. Concentrating tests in one project avoids creating a
+// throwaway project per test — those leak on aborted runs and then collide on
+// the API's unique-project-name constraint.
+const defaultTestProjectID = "proj_jv6m5JyZDNLPe"
+
+// testAccProjectID returns the shared project ID. Override with
+// LATITUDESH_TEST_PROJECT to run the suite against a different account.
+func testAccProjectID() string {
+	if v := os.Getenv("LATITUDESH_TEST_PROJECT"); v != "" {
+		return v
+	}
+	return defaultTestProjectID
 }
-`, prefix, testRunID)
+
+var (
+	testProjectSlugOnce sync.Once
+	testProjectSlug     string
+	testProjectSlugErr  error
+)
+
+// resolveProjectSlug looks up the shared project's slug from the API by
+// matching testAccProjectID(), caching the result (and any error) once.
+func resolveProjectSlug() (string, error) {
+	testProjectSlugOnce.Do(func() {
+		client := createVCRClient(nil)
+		ctx := context.Background()
+		id := testAccProjectID()
+		size := int64(100)
+
+		resp, err := client.Projects.List(ctx, operations.GetProjectsRequest{PageSize: &size})
+		for err == nil && resp != nil && resp.Projects != nil {
+			for _, p := range resp.Projects.Data {
+				if p.ID != nil && *p.ID == id && p.Attributes != nil && p.Attributes.Slug != nil {
+					testProjectSlug = *p.Attributes.Slug
+					return
+				}
+			}
+			if resp.Next == nil {
+				break
+			}
+			resp, err = resp.Next()
+		}
+		if err != nil {
+			testProjectSlugErr = err
+			return
+		}
+		testProjectSlugErr = fmt.Errorf("project %s not found while resolving its slug", id)
+	})
+	return testProjectSlug, testProjectSlugErr
+}
+
+// testAccProjectSlug returns the shared project's slug, failing the test if it
+// can't be resolved. Needed by tests that exercise the project-by-slug path
+// (which can't derive a slug from a bare ID).
+func testAccProjectSlug(t *testing.T) string {
+	t.Helper()
+	slug, err := resolveProjectSlug()
+	if err != nil {
+		t.Fatalf("resolving shared project slug: %s", err)
+	}
+	return slug
+}
+
+// testAccProjectSlugBestEffort returns the shared project's slug, or "" if it
+// can't be resolved. For check helpers that have no *testing.T to fail.
+func testAccProjectSlugBestEffort() string {
+	slug, _ := resolveProjectSlug()
+	return slug
 }
 
 // Shared acceptance-test fixture: attachment-style tests (VLAN/firewall
@@ -67,8 +126,7 @@ func testAccSharedServers(t *testing.T, n int) (projectID, site string, serverID
 	ctx := context.Background()
 
 	if f.projectID == "" {
-		id, _ := testAccCreateProject(t, "tf-acc-shared-"+testRunID)
-		f.projectID = id
+		f.projectID = testAccProjectID()
 	}
 
 	var created []string
@@ -180,39 +238,13 @@ func testSharedFixtureTeardown() {
 	client := createVCRClient(nil)
 	ctx := context.Background()
 
+	// Only the servers this fixture provisioned are torn down. The project is
+	// pre-existing and shared (see testAccProjectID) — it must survive the run.
 	for _, id := range f.serverIDs {
 		if _, err := client.Servers.Delete(ctx, id, nil); err != nil {
 			fmt.Fprintf(os.Stderr, "shared fixture teardown: failed to delete server %s: %s\n", id, err)
 		}
 	}
-
-	// Server deletion is asynchronous and the project cannot be deleted while
-	// its servers (and their IPs) are still deprovisioning — wait them out.
-	deadline := time.Now().Add(10 * time.Minute)
-	for _, id := range f.serverIDs {
-		for {
-			response, err := client.Servers.Get(ctx, id, nil)
-			if err != nil || response.Server == nil || response.Server.Data == nil {
-				break
-			}
-			if time.Now().After(deadline) {
-				fmt.Fprintf(os.Stderr, "shared fixture teardown: server %s still deprovisioning after 10m\n", id)
-				break
-			}
-			time.Sleep(10 * time.Second)
-		}
-	}
-
-	var lastErr error
-	for attempt := 0; attempt < 6; attempt++ {
-		if attempt > 0 {
-			time.Sleep(10 * time.Second)
-		}
-		if _, lastErr = client.Projects.Delete(ctx, f.projectID); lastErr == nil {
-			return
-		}
-	}
-	fmt.Fprintf(os.Stderr, "shared fixture teardown: failed to delete project %s (clean it up manually): %s\n", f.projectID, lastErr)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Concentrate the acceptance suite in one pre-existing project instead of creating a throwaway `tf-acc-*` project per test.

## Problem

Each acceptance test spun up its own project (`testAccProjectBlock` inline HCL, or `testAccCreateProject` for the shared fixture and `TestAccVirtualNetwork_Basic`). The API rejects duplicate project names, so a project left behind by an aborted CI run collides with a later run that reuses the same `<prefix>-<testRunID>` name:

```
TestAccVirtualNetwork_InvalidTagFailsBeforePOST … Status 400 PROJECT_CREATION_ERROR
"A project with the same name already exists."
```

The leftovers also pile up as orphan projects (some with billed servers).

## Change

- Add `testAccProjectID()` — returns a fixed shared project, overridable with `LATITUDESH_TEST_PROJECT` (defaults to the DevTools QA project). All resource tests now target it via `project = "<id>"`.
- Remove `testAccProjectBlock` and `testAccCreateProject`; repoint the server/VM/firewall/user-data/virtual-network configs at the shared project.
- Shared fixture (`testAccSharedServers`) reuses the shared project and **no longer deletes it** in teardown — it only tears down the servers it provisioned.
- `TestAccServer_ProjectSlugConsistency` needs a slug, so a cached `testAccProjectSlug()` resolves the shared project’s slug from the API.
- Left unchanged: the four `*_UnknownProject` tests (PlanOnly — never create a real project) and `TestAccProject_Basic` (its subject *is* creating a project via Terraform; it cleans up via `CheckDestroy`).

Net effect: only `TestAccProject_Basic` still creates a project, so runs stop leaking projects and can never collide on a reused name again.

## Test plan

- `go build ./...`, `go vet ./latitudesh/`, `gofmt -l` all clean.
- `grep -rn "testAccProjectBlock\|testAccCreateProject" latitudesh/` returns nothing.
- Live run against the API: `TF_ACC=1 go test ./latitudesh -run TestAccVirtualNetwork -v` — all four pass, including the previously-failing `InvalidTagFailsBeforePOST`. Verified via the API that the run created **no** `tf-acc-*` project and left no orphan virtual networks in the shared project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves acceptance tests to a shared, pre-existing project. The main changes are:

- Uses a configurable shared project ID across resource tests.
- Preserves the shared project while cleaning up provisioned servers.
- Resolves the project slug for slug-specific server coverage.
- Serializes acceptance workflow runs to avoid resource-name collisions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The workflow now serializes all current acceptance runs that use the shared project.
- The replay-mode fix prevents the slug-specific test from making its setup request during cassette playback.
- No additional blocking issue qualifies for this follow-up review.

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: serialize acceptance-test runs to av..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/c4e8747fbbfa93fd56204f03209c1ded7ddf9a8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44569073)</sub>

<!-- /greptile_comment -->