### PR TITLE
feat(provider): identify requests with terraform-provider user-agent header

### DIFF
--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -120,7 +121,8 @@ func (p *latitudeshProvider) Configure(ctx context.Context, req provider.Configu
 
 	baseClient := p.httpClient
 	if baseClient == nil {
-		baseClient = &http.Client{}
+		// match the SDK's default client behavior
+		baseClient = &http.Client{Timeout: 60 * time.Second}
 	}
 	baseTransport := baseClient.Transport
 	if baseTransport == nil {

--- a/latitudesh/provider.go
+++ b/latitudesh/provider.go
@@ -2,6 +2,7 @@ package latitudesh
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"sync"
@@ -23,6 +24,24 @@ var _ provider.Provider = &latitudeshProvider{}
 type latitudeshProvider struct {
 	version    string
 	httpClient *http.Client // optional: used in tests for VCR recording/playback
+}
+
+// userAgentTransport overrides the User-Agent header on every request so the
+// API can distinguish Terraform traffic from direct Go SDK usage. The SDK's
+// own User-Agent (set before the transport runs) is preserved as a suffix.
+type userAgentTransport struct {
+	base      http.RoundTripper
+	userAgent string
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	if sdkUA := req.Header.Get("User-Agent"); sdkUA != "" {
+		req.Header.Set("User-Agent", t.userAgent+" "+sdkUA)
+	} else {
+		req.Header.Set("User-Agent", t.userAgent)
+	}
+	return t.base.RoundTrip(req)
 }
 
 // latitudeshProviderModel describes the provider data model.
@@ -94,8 +113,29 @@ func (p *latitudeshProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
+	userAgent := fmt.Sprintf("terraform-provider-latitudesh/%s", p.version)
+	if req.TerraformVersion != "" {
+		userAgent += fmt.Sprintf(" Terraform/%s", req.TerraformVersion)
+	}
+
+	baseClient := p.httpClient
+	if baseClient == nil {
+		baseClient = &http.Client{}
+	}
+	baseTransport := baseClient.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	httpClient := &http.Client{
+		Transport:     &userAgentTransport{base: baseTransport, userAgent: userAgent},
+		Timeout:       baseClient.Timeout,
+		CheckRedirect: baseClient.CheckRedirect,
+		Jar:           baseClient.Jar,
+	}
+
 	sdkOpts := []latitudeshgosdk.SDKOption{
 		latitudeshgosdk.WithSecurity(authToken),
+		latitudeshgosdk.WithClient(httpClient),
 		latitudeshgosdk.WithRetryConfig(retry.Config{
 			Strategy: "backoff",
 			Backoff: &retry.BackoffStrategy{
@@ -106,9 +146,6 @@ func (p *latitudeshProvider) Configure(ctx context.Context, req provider.Configu
 			},
 			RetryConnectionErrors: false,
 		}),
-	}
-	if p.httpClient != nil {
-		sdkOpts = append(sdkOpts, latitudeshgosdk.WithClient(p.httpClient))
 	}
 	sdkClient := latitudeshgosdk.New(sdkOpts...)
 	project := data.Project.ValueString()

--- a/latitudesh/provider_test.go
+++ b/latitudesh/provider_test.go
@@ -29,6 +29,51 @@ func TestFrameworkProvider(t *testing.T) {
 	}
 }
 
+// roundTripperFunc adapts a function to http.RoundTripper for tests
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestUserAgentTransport(t *testing.T) {
+	var gotUserAgent string
+	transport := &userAgentTransport{
+		base: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			gotUserAgent = req.Header.Get("User-Agent")
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+		userAgent: "terraform-provider-latitudesh/dev Terraform/1.9.0",
+	}
+
+	// SDK sets its own User-Agent before the transport runs: it must be kept as a suffix
+	req, _ := http.NewRequest(http.MethodGet, "https://api.latitude.sh/servers", nil)
+	req.Header.Set("User-Agent", "speakeasy-sdk/go 1.16.7")
+
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+
+	want := "terraform-provider-latitudesh/dev Terraform/1.9.0 speakeasy-sdk/go 1.16.7"
+	if gotUserAgent != want {
+		t.Errorf("Expected User-Agent %q, got %q", want, gotUserAgent)
+	}
+
+	// The original request must not be mutated
+	if ua := req.Header.Get("User-Agent"); ua != "speakeasy-sdk/go 1.16.7" {
+		t.Errorf("Original request User-Agent was mutated: %q", ua)
+	}
+
+	// Without an SDK User-Agent, only the provider identifier is sent
+	reqNoUA, _ := http.NewRequest(http.MethodGet, "https://api.latitude.sh/servers", nil)
+	if _, err := transport.RoundTrip(reqNoUA); err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	if gotUserAgent != "terraform-provider-latitudesh/dev Terraform/1.9.0" {
+		t.Errorf("Expected User-Agent %q, got %q", "terraform-provider-latitudesh/dev Terraform/1.9.0", gotUserAgent)
+	}
+}
+
 func TestAccEnvVarAuthTokenSet(t *testing.T) {
 	if os.Getenv("TF_ACC") != "1" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")


### PR DESCRIPTION
### Summary

Since the migration to the Speakeasy-generated Go SDK, the provider sends the SDK's default `User-Agent` (`speakeasy-sdk/go ...`), making it impossible to distinguish Terraform traffic from direct Go SDK usage in API logs. The v1 provider used to identify itself as `Latitude-Terraform-Provider/x.y.z`, and that was lost in the migration.

This PR adds a custom `http.RoundTripper` that prefixes the `User-Agent` with the provider and Terraform versions, keeping the SDK's own identifier as a suffix:

```
User-Agent: terraform-provider-latitudesh/2.3.1 Terraform/1.9.5 speakeasy-sdk/go 1.16.7 2.915.0 2023-06-01 github.com/latitudesh/latitudesh-go-sdk
```

Requests coming from Terraform now start with `terraform-provider-latitudesh/`, while direct Go SDK requests keep the plain `speakeasy-sdk/go ...` value. The VCR test client is wrapped (not replaced), so e2e recording/playback keeps working.

### Testing

```bash
go test ./latitudesh/ -run TestUserAgentTransport -v
go build ./...
```

The new `TestUserAgentTransport` covers header composition, requests without a prior User-Agent, and non-mutation of the original request.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores Terraform-specific request identification while preserving the SDK identifier. The main changes are:

- Adds a transport that prefixes each request's `User-Agent`.
- Includes provider and Terraform versions in the prefix.
- Preserves custom HTTP transports used by VCR and mock clients.
- Adds tests for header composition and request immutability.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(provider): identify requests with t..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/76e0b07f222f92f8c86b8f9a05c1d6f77f21e457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46124782)</sub>

<!-- /greptile_comment -->