### PR TITLE
Skip e2e job on PRs that don't touch provider code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,30 @@ on:
       - reopened
       - ready_for_review
 
-# The acceptance suite runs against one shared Latitude account/project, so two
-# runs in flight at once would create colliding resource names. Serialize them:
-# a new run queues until the previous finishes (never cancels it mid-run, which
-# would leak half-created resources).
-concurrency:
-  group: latitudesh-acceptance-tests
-  cancel-in-progress: false
-
 jobs:
+  # Detect whether the PR touches provider code. Docs-only changes (docs/,
+  # examples/, templates/, *.md, release config) skip the expensive e2e job,
+  # which provisions real infrastructure and serializes behind other runs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Detect provider code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/test.yml'
+
   build:
     runs-on: ubuntu-latest
 
@@ -47,7 +62,15 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
+    if: needs.changes.outputs.code == 'true'
+    # The acceptance suite runs against one shared Latitude account/project, so
+    # two runs in flight at once would create colliding resource names.
+    # Serialize them: a new run queues until the previous finishes (never
+    # cancels it mid-run, which would leak half-created resources).
+    concurrency:
+      group: latitudesh-acceptance-tests
+      cancel-in-progress: false
     steps:
       -
         name: Checkout


### PR DESCRIPTION
### Summary

- Add a `changes` job using `dorny/paths-filter` and gate the `e2e` job on the PR touching provider code (`**/*.go`, `go.mod`, `go.sum`, or the workflow itself). Docs-only PRs now run build/unit tests only.
- Move the acceptance-test concurrency group from workflow level to the `e2e` job, so docs-only PRs no longer queue behind in-flight e2e runs.

Jira: [PD-6616](https://latitude.atlassian.net/browse/PD-6616)

### Testing

```bash
actionlint .github/workflows/test.yml
```

Open a PR touching only `docs/` and confirm the `e2e` job is skipped; this PR itself touches the workflow, so `e2e` runs.

[PD-6616]: https://latitude.atlassian.net/browse/PD-6616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR skips acceptance tests when a pull request does not change provider code. The main changes are:

- Adds path-based change detection for Go code and module files.
- Gates the `e2e` job on the change-detection output.
- Moves shared-resource concurrency control to the `e2e` job.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The only job that uses the shared Latitude account remains serialized.
- The filter output and `e2e` condition are connected consistently.

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(test): skip e2e job when PR does not ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/761953940d972b4458d3c5ebcccfcd08b746a7a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46387911)</sub>

<!-- /greptile_comment -->