### PR TITLE
fix(virtual-network): paginate ID lookup and drop deleted networks from state

### DIFF
--- a/latitudesh/resource_virtual_network.go
+++ b/latitudesh/resource_virtual_network.go
@@ -301,9 +301,15 @@ func (r *VirtualNetworkResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// Use readVirtualNetworkByID which uses the Get endpoint directly
 	r.readVirtualNetworkByID(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If readVirtualNetworkByID found no such network and nulled the ID, the
+	// network is gone; drop it from state instead of persisting a null ID.
+	if data.ID.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -338,6 +344,16 @@ func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.Update
 
 	r.readVirtualNetworkByID(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// A network that vanished mid-update must fail the apply rather than commit
+	// a state entry with a null ID.
+	if plan.ID.IsNull() {
+		resp.Diagnostics.AddError(
+			"Virtual Network Not Found",
+			"The virtual network could not be found after updating it. It may have been deleted outside of Terraform.",
+		)
 		return
 	}
 
@@ -535,25 +551,12 @@ func (r *VirtualNetworkResource) ImportState(ctx context.Context, req resource.I
 		return
 	}
 
-	listRequest := operations.GetVirtualNetworksRequest{}
-	listResponse, err := r.client.PrivateNetworks.List(ctx, listRequest)
+	// Project is unknown at import time, so this searches every project the
+	// token can see, paginating so networks past the first page are found.
+	foundVnet, err := r.findVirtualNetworkByID(ctx, vlanID, "")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", "Unable to list virtual networks, got error: "+err.Error())
 		return
-	}
-
-	if listResponse.VirtualNetworks == nil || listResponse.VirtualNetworks.Data == nil {
-		resp.Diagnostics.AddError("API Error", "No virtual networks found")
-		return
-	}
-
-	// Find the virtual network with the matching ID
-	var foundVnet *components.VirtualNetworkData
-	for _, vnet := range listResponse.VirtualNetworks.Data {
-		if vnet.GetID() != nil && *vnet.GetID() == vlanID {
-			foundVnet = &vnet
-			break
-		}
 	}
 
 	if foundVnet == nil {
@@ -632,6 +635,49 @@ func (r *VirtualNetworkResource) ImportState(ctx context.Context, req resource.I
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// findVirtualNetworkByID locates a virtual network by its ID. When project is
+// known the list is filtered down to that project; otherwise (e.g. terraform
+// import, where only the ID is available) every project the token can see is
+// searched. Either way it paginates, so networks beyond the first page are
+// still found — the API serves 20 items per page by default and returns no
+// pagination metadata, so the walk stops on the first short page.
+// Returns (nil, nil) when the network genuinely does not exist.
+func (r *VirtualNetworkResource) findVirtualNetworkByID(ctx context.Context, vlanID, project string) (*components.VirtualNetworkData, error) {
+	pageSize := int64(100)
+
+	for pageNumber := int64(1); ; pageNumber++ {
+		page := pageNumber
+		size := pageSize
+		listRequest := operations.GetVirtualNetworksRequest{
+			PageSize:   &size,
+			PageNumber: &page,
+		}
+		if project != "" {
+			listRequest.FilterProject = &project
+		}
+
+		response, err := r.client.PrivateNetworks.List(ctx, listRequest)
+		if err != nil {
+			return nil, err
+		}
+		if response.VirtualNetworks == nil || response.VirtualNetworks.Data == nil ||
+			len(response.VirtualNetworks.Data) == 0 {
+			return nil, nil
+		}
+
+		for _, v := range response.VirtualNetworks.Data {
+			if v.GetID() != nil && *v.GetID() == vlanID {
+				vnet := v
+				return &vnet, nil
+			}
+		}
+
+		if int64(len(response.VirtualNetworks.Data)) < pageSize {
+			return nil, nil
+		}
+	}
+}
+
 func (r *VirtualNetworkResource) readVirtualNetworkByID(ctx context.Context, data *VirtualNetworkResourceModel, diags *diag.Diagnostics) {
 	vlanID := data.ID.ValueString()
 	if vlanID == "" {
@@ -639,25 +685,10 @@ func (r *VirtualNetworkResource) readVirtualNetworkByID(ctx context.Context, dat
 		return
 	}
 
-	listRequest := operations.GetVirtualNetworksRequest{}
-	listResponse, err := r.client.PrivateNetworks.List(ctx, listRequest)
+	foundVnet, err := r.findVirtualNetworkByID(ctx, vlanID, data.Project.ValueString())
 	if err != nil {
 		diags.AddError("Client Error", "Unable to list virtual networks, got error: "+err.Error())
 		return
-	}
-
-	if listResponse.VirtualNetworks == nil || listResponse.VirtualNetworks.Data == nil {
-		data.ID = types.StringNull()
-		return
-	}
-
-	// Find the virtual network with the matching ID
-	var foundVnet *components.VirtualNetworkData
-	for _, vnet := range listResponse.VirtualNetworks.Data {
-		if vnet.GetID() != nil && *vnet.GetID() == vlanID {
-			foundVnet = &vnet
-			break
-		}
 	}
 
 	if foundVnet == nil {
@@ -762,29 +793,11 @@ func (r *VirtualNetworkResource) readVirtualNetworkByID(ctx context.Context, dat
 
 func (r *VirtualNetworkResource) readVirtualNetwork(ctx context.Context, data *VirtualNetworkResourceModel, diags *diag.Diagnostics) {
 	vlanID := data.ID.ValueString()
-	project := data.Project.ValueString()
 
-	listRequest := operations.GetVirtualNetworksRequest{
-		FilterProject: &project,
-	}
-
-	response, err := r.client.PrivateNetworks.List(ctx, listRequest)
+	foundVnet, err := r.findVirtualNetworkByID(ctx, vlanID, data.Project.ValueString())
 	if err != nil {
 		diags.AddError("Client Error", "Unable to list virtual networks, got error: "+err.Error())
 		return
-	}
-
-	if response.VirtualNetworks == nil || response.VirtualNetworks.Data == nil {
-		data.ID = types.StringNull()
-		return
-	}
-
-	var foundVnet *components.VirtualNetworkData
-	for _, vnet := range response.VirtualNetworks.Data {
-		if vnet.GetID() != nil && *vnet.GetID() == vlanID {
-			foundVnet = &vnet
-			break
-		}
 	}
 
 	if foundVnet == nil {

--- a/latitudesh/resource_virtual_network_pagination_test.go
+++ b/latitudesh/resource_virtual_network_pagination_test.go
@@ -1,0 +1,235 @@
+package latitudesh
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
+)
+
+// Regression tests for the virtual network Read path.
+//
+// Read looks the network up by walking GET /virtual_networks. That walk used to
+// request a single unfiltered page, so a network that sat beyond the first page
+// was reported as missing. The "missing" branch then nulled the ID in place
+// without removing the resource, leaving state with every attribute intact but
+// `id = null`. Terraform surfaced that as phantom drift
+// (`- id = "vlan_..." -> null`), and any config referencing the network's id
+// failed to plan:
+//
+//	Error: Missing Configuration for Required Attribute
+//	Must set a configuration value for the virtual_network_id attribute
+//
+// Both tests drive Read() directly against a mock API so no live credentials or
+// VCR fixtures are needed.
+
+const (
+	testPagVNetID   = "vlan_PAGE2"
+	testPagProject  = "proj_TEST"
+	testPagVNetDesc = "test VLAN"
+	testPagVNetVid  = 2145
+)
+
+// vnetPage renders one JSON:API page of virtual networks. Only the target
+// network carries meaningful attributes; the fillers exist to pad the page.
+func vnetPage(entries []string) string {
+	return `{"data":[` + strings.Join(entries, ",") + `],"meta":{}}`
+}
+
+func vnetEntry(id, description string, vid int) string {
+	return fmt.Sprintf(`{"id":%q,"type":"virtual_networks","attributes":{`+
+		`"vid":%d,"description":%q,"assignments_count":3,`+
+		`"project":{"id":%q},`+
+		`"region":{"city":"Test City","country":"TC","site":{"id":"site_TEST","slug":"TEST1"}}}}`,
+		id, vid, description, testPagProject)
+}
+
+// vnetMock stands up a mock API for GET /virtual_networks. It serves
+// totalPages pages of pageSize entries each; the target network is placed on
+// targetPage. targetPage == 0 means the network is absent entirely, simulating
+// one deleted outside of Terraform. It records the pages actually requested so
+// tests can assert the walk happened.
+type vnetMock struct {
+	totalPages int
+	targetPage int
+	pageSize   int
+	requests   int32
+	lastPage   int32
+}
+
+func (m *vnetMock) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		atomic.AddInt32(&m.requests, 1)
+
+		page, _ := strconv.Atoi(r.URL.Query().Get("page[number]"))
+		if page == 0 {
+			page = 1
+		}
+		atomic.StoreInt32(&m.lastPage, int32(page))
+
+		// Honour the page size the provider asked for; the walk relies on a
+		// short page to know it has reached the end.
+		size := m.pageSize
+		if requested, err := strconv.Atoi(r.URL.Query().Get("page[size]")); err == nil && requested > 0 {
+			size = requested
+		}
+
+		if page > m.totalPages {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(vnetPage(nil)))
+			return
+		}
+
+		entries := make([]string, 0, size)
+		for i := 0; i < size; i++ {
+			entries = append(entries, vnetEntry(fmt.Sprintf("vlan_FILL%d_%d", page, i), "filler", 1000+i))
+		}
+		if page == m.targetPage {
+			// Replace one filler so the page still has exactly `size` entries
+			// and the walk does not stop early on a short page.
+			entries[0] = vnetEntry(testPagVNetID, testPagVNetDesc, testPagVNetVid)
+		}
+		if page == m.totalPages {
+			// Last page is short, which is how the walk detects the end.
+			entries = entries[:len(entries)-1]
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vnetPage(entries)))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func newTestVirtualNetworkResource(serverURL string) *VirtualNetworkResource {
+	return &VirtualNetworkResource{
+		client: latitudeshgosdk.New(
+			latitudeshgosdk.WithSecurity("test"),
+			latitudeshgosdk.WithServerURL(serverURL),
+		),
+	}
+}
+
+// runVirtualNetworkRead drives r.Read() with a prior state describing an
+// already-applied virtual network, and returns the response.
+func runVirtualNetworkRead(t *testing.T, r *VirtualNetworkResource) *resource.ReadResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	sch := schemaResp.Schema
+	objType := sch.Type().TerraformType(ctx).(tftypes.Object)
+
+	stateVal := tftypes.NewValue(objType, map[string]tftypes.Value{
+		"id":                tftypes.NewValue(tftypes.String, testPagVNetID),
+		"project":           tftypes.NewValue(tftypes.String, testPagProject),
+		"site":              tftypes.NewValue(tftypes.String, "TEST1"),
+		"description":       tftypes.NewValue(tftypes.String, testPagVNetDesc),
+		"tags":              tftypes.NewValue(objType.AttributeTypes["tags"], nil),
+		"vid":               tftypes.NewValue(tftypes.Number, testPagVNetVid),
+		"region":            tftypes.NewValue(tftypes.String, "TEST1"),
+		"assignments_count": tftypes.NewValue(tftypes.Number, 3),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Raw: stateVal, Schema: sch}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Raw: stateVal, Schema: sch}}
+	r.Read(ctx, req, resp)
+	return resp
+}
+
+// TestVirtualNetworkRead_BeyondFirstPage: a virtual network that lives past the
+// first page of GET /virtual_networks must still be found. Before the fix the
+// lookup read only page 1, concluded the network was gone, and nulled its ID.
+func TestVirtualNetworkRead_BeyondFirstPage(t *testing.T) {
+	// Small pages so the test stays cheap; the walk is page-size agnostic.
+	m := &vnetMock{totalPages: 3, targetPage: 3, pageSize: 100}
+	server := m.server(t)
+
+	resp := runVirtualNetworkRead(t, newTestVirtualNetworkResource(server.URL))
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatalf("network exists on page %d but Read removed it from state", m.targetPage)
+	}
+
+	var out VirtualNetworkResourceModel
+	if diags := resp.State.Get(context.Background(), &out); diags.HasError() {
+		t.Fatalf("reading state: %v", diags.Errors())
+	}
+	if out.ID.IsNull() {
+		t.Fatalf("id was nulled for a network that exists — this is the phantom `id -> null` drift")
+	}
+	if got := out.ID.ValueString(); got != testPagVNetID {
+		t.Fatalf("expected id %q, got %q", testPagVNetID, got)
+	}
+	if got := out.Vid.ValueInt64(); got != testPagVNetVid {
+		t.Fatalf("expected vid %d, got %d", testPagVNetVid, got)
+	}
+	if got := out.Description.ValueString(); got != testPagVNetDesc {
+		t.Fatalf("expected description %q, got %q", testPagVNetDesc, got)
+	}
+	if got := atomic.LoadInt32(&m.lastPage); got < 3 {
+		t.Fatalf("expected the lookup to walk to page 3, highest page requested was %d", got)
+	}
+}
+
+// TestVirtualNetworkRead_DeletedOutOfBand: a network that genuinely no longer
+// exists must be removed from state so Terraform plans a fresh create. Nulling
+// the ID in place instead leaves a half-populated state entry whose `id` is
+// null, which breaks every config that references it.
+func TestVirtualNetworkRead_DeletedOutOfBand(t *testing.T) {
+	m := &vnetMock{totalPages: 2, targetPage: 0, pageSize: 100} // never present
+	server := m.server(t)
+
+	resp := runVirtualNetworkRead(t, newTestVirtualNetworkResource(server.URL))
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	if !resp.State.Raw.IsNull() {
+		var out VirtualNetworkResourceModel
+		resp.State.Get(context.Background(), &out)
+		t.Fatalf("expected a deleted network to be removed from state, got a retained entry with id=%v", out.ID)
+	}
+}
+
+// TestVirtualNetworkRead_ScopedToProject: when the project is known from state
+// the walk must filter by it, so a token that can see many projects does not
+// have to page through all of them.
+func TestVirtualNetworkRead_ScopedToProject(t *testing.T) {
+	var gotFilter string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFilter = r.URL.Query().Get("filter[project]")
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vnetPage([]string{vnetEntry(testPagVNetID, testPagVNetDesc, testPagVNetVid)})))
+	}))
+	t.Cleanup(s.Close)
+
+	resp := runVirtualNetworkRead(t, newTestVirtualNetworkResource(s.URL))
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	if gotFilter != testPagProject {
+		t.Fatalf("expected the lookup to be scoped to filter[project]=%s, got %q", testPagProject, gotFilter)
+	}
+}


### PR DESCRIPTION
## Problem

`latitudesh_virtual_network` refresh nulls the `id` of a network that still exists, which breaks every resource that references it.

On a workspace whose virtual network is not in the first 20 results of `GET /virtual_networks`, `terraform plan` reports phantom drift:

```
Note: Objects have changed outside of Terraform

  # latitudesh_virtual_network.example has changed
  ~ resource "latitudesh_virtual_network" "example" {
      - id = "vlan_xxxxxxxxxxxx" -> null
        # (6 unchanged attributes hidden)
    }
```

and then fails, because `latitudesh_vlan_assignment.virtual_network_id` is a Required attribute that cannot take a null value:

```
Error: Missing Configuration for Required Attribute

  with latitudesh_vlan_assignment.example,
  on main.tf line 12, in resource "latitudesh_vlan_assignment" "example":
  12:   virtual_network_id = latitudesh_virtual_network.example.id

Must set a configuration value for the virtual_network_id attribute as the
provider has marked it as required.
```

The workspace is stuck: nothing can be planned or applied until the user passes `-refresh=false`. Worse, an `apply` that gets past refresh persists `id = null` into state, after which even `-refresh=false` no longer helps.

## Root cause

Two independent defects in the same code path.

**1. The lookup only ever reads the first page.**

`readVirtualNetworkByID` says it "uses the Get endpoint directly", but it actually lists:

```go
listRequest := operations.GetVirtualNetworksRequest{}
listResponse, err := r.client.PrivateNetworks.List(ctx, listRequest)
```

That request sets neither `FilterProject` nor `PageNumber`/`PageSize`, and `GetVirtualNetworksRequest` defaults to `page[size]=20, page[number]=1`. A token that can see more than 20 virtual networks across its projects will not find networks past the first page, and the endpoint returns no pagination metadata to hint that more exist.

**2. "Not found" corrupts state instead of clearing it.**

```go
if foundVnet == nil {
    data.ID = types.StringNull()
    return
}
```

This nulls the ID but never removes the resource, so `Read` writes back a state entry with every attribute intact and `id = null` — exactly the drift above. `Update` had the same hole and would commit a null-ID entry.

Both defects have been present since `v2.8.1`. `afe6d38` switched `Read` from `readVirtualNetwork` (which passed `FilterProject`) to `readVirtualNetworkByID` (which passes nothing). It only became reachable for a given account once its virtual network count crossed one page.

The same unpaginated lookup also affected `ImportState` (importing any network past the first page failed with "not found") and the post-create read.

## Fix

Add `findVirtualNetworkByID`, which paginates and scopes to a project when one is known. This deliberately mirrors `findAssignmentByID` in `resource_vlan_assignment.go`, which already solved this exact problem for assignments — same page size, same "stop on the first short page" termination, same optional filter.

Route all four exact-ID lookups through it: `Read`, `Update`, `ImportState`, and the post-create read. Import passes an empty project since only the ID is known there.

Have `Read` call `resp.State.RemoveResource(ctx)` when the network is genuinely gone, matching the idiom already used in `resource_elastic_ip.go`, so Terraform plans a fresh create rather than holding an unusable state entry. `Update` now raises a diagnostic instead of committing a null-ID state.

## Tests

`resource_virtual_network_pagination_test.go` drives `Read()` against an `httptest` mock API, in the style of `resource_vlan_assignment_connecting_test.go` — no live credentials or VCR fixtures.

- `TestVirtualNetworkRead_BeyondFirstPage` — network on page 3 is found and keeps its `id`, `vid` and `description`.
- `TestVirtualNetworkRead_DeletedOutOfBand` — a genuinely deleted network is removed from state rather than retained with a null `id`.
- `TestVirtualNetworkRead_ScopedToProject` — the walk sends `filter[project]` when the project is known.

All three fail on `main` and pass here:

```
--- FAIL: TestVirtualNetworkRead_BeyondFirstPage
    id was nulled for a network that exists — this is the phantom `id -> null` drift
--- FAIL: TestVirtualNetworkRead_DeletedOutOfBand
    expected a deleted network to be removed from state, got a retained entry with id=<null>
--- FAIL: TestVirtualNetworkRead_ScopedToProject
    expected the lookup to be scoped to filter[project]=proj_TEST, got ""
```

`go vet ./...` is clean and the unit suite passes. Also verified end to end against a real account whose virtual network sits on page 2: with a `dev_overrides` build of this branch, the drift note disappears and a plan that previously failed with `Missing Configuration for Required Attribute` now completes normally, with no `-refresh=false` workaround.

## Note for reviewers

`findVirtualNetworkByProject` — the fallback used when a create response omits the ID — is still unpaginated. It scores candidates across the whole list rather than matching one ID, so converting it needs a different shape. Left out to keep this change reviewable; happy to follow up.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes virtual-network lookups and deleted-resource handling.
- Adds project-scoped pagination for exact-ID lookups during create, refresh, update, and import.
- Removes genuinely deleted virtual networks from Terraform state and prevents updates from persisting a null ID.
- Adds mock-server regression coverage for pagination, out-of-band deletion, and project filtering.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new lookup consistently paginates exact-ID searches, preserves project scoping when available, and cleanly distinguishes successful refreshes from missing resources in each updated lifecycle path.
</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read virtual network state] --> B[Search by ID]
    B --> C{Project known?}
    C -->|Yes| D[Apply project filter]
    C -->|No| E[Search all visible projects]
    D --> F[Request paginated results]
    E --> F
    F --> G{ID found?}
    G -->|Yes| H[Refresh resource attributes]
    G -->|No| I[Remove resource from state]
```

<sub>Reviews (1): Last reviewed commit: ["fix(virtual-network): paginate ID lookup..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/7abc7bb4c3af8a8b227e3298253b0fc9a4f0c276) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47564839)</sub>

<!-- /greptile_comment -->