### PR TITLE
feat(sdkcoverage): reconcile SDK service groups against provider coverage

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,3 +40,44 @@ version-resolver:
 
 exclude-labels:
   - 'skip-changelog'
+
+# Derive the category labels from the conventional-commit prefix in the PR title.
+# The categories and version-resolver above are driven entirely by labels, so
+# without this they depend on someone remembering to apply one by hand — and a PR
+# that slips through lands in "Other changes" and never influences the version
+# bump. The prefix already carries the information, so read it from there.
+#
+# Note that every matching rule is applied, not just the first, so these have to be
+# mutually exclusive. That is why the bug and maintenance rules explicitly exclude a
+# `deps` scope: this repo writes dependency bumps as `fix(deps):` / `chore(deps):`,
+# which would otherwise be categorised twice.
+#
+# Autolabeling does not work on pull requests from forks, because the token is
+# read-only there. Supporting those needs the `pull_request_target` event that sits
+# commented out in the workflow — a separate security decision. Until then, label
+# fork PRs by hand.
+autolabeler:
+  # Breaking changes are marked with `!` in the prefix (`feat(api)!: ...`), so they
+  # do not depend on anyone remembering the label either. A `feat!:` title
+  # deliberately picks up both labels: `breaking` wins the version bump, and the
+  # Breaking category is listed first.
+  - label: 'type: breaking'
+    title: ['/^\w+(\([^)]+\))?!:/']
+
+  - label: 'type: feature'
+    title: ['/^feat(\([^)]+\))?!?:/']
+
+  - label: 'type: dependencies'
+    title: ['/^\w+\(deps(-dev)?\)!?:/']
+    branch: ['/^dependabot\//']
+
+  - label: 'type: bug'
+    title: ['/^fix(?!\(deps)(\([^)]+\))?!?:/']
+
+  - label: 'type: docs'
+    title: ['/^docs(\([^)]+\))?!?:/']
+
+  # `test` is the second most common prefix in this repo's history and had no
+  # category at all before.
+  - label: 'type: maintenance'
+    title: ['/^(chore|refactor|test|ci|build|style|perf)(?!\(deps)(\([^)]+\))?!?:/']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    # `labeled`/`unlabeled` are deliberately absent. Subscribing to them would mean
-    # any label change on any PR re-evaluates the e2e condition, and on a PR that
-    # touched provider code that provisions real infrastructure — so labelling a PR
-    # `documentation` would spin up servers. The cost of that outweighs the gap it
-    # closes. Consequence: removing `e2e: skip` does not re-trigger the suite on its
-    # own; push a commit, or run this workflow from the Actions tab.
   # Run the acceptance suite deliberately: before a release, after a large
   # refactor, or to sweep tests the curated list below leaves out. There is no
   # scheduled run on purpose — the suite provisions real, billable infrastructure,
@@ -104,11 +98,16 @@ jobs:
     # passthrough and CI never sets LATITUDE_TEST_RECORDER), so a draft carrying
     # unreviewed or generated Terraform would provision real infrastructure before
     # anyone had looked at it. Marking the PR ready for review triggers this job.
+    #
+    # There is deliberately no opt-out label. A label is only read on runs that
+    # happen anyway, so removing it would not re-trigger the suite — and fixing that
+    # by subscribing to `unlabeled` would mean any label change on a provider PR
+    # provisions real infrastructure again. Draft status covers the same need
+    # without going stale, and `workflow_dispatch` covers running it on demand.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (needs.changes.outputs.provider == 'true' &&
-       github.event.pull_request.draft == false &&
-       !contains(github.event.pull_request.labels.*.name, 'e2e: skip'))
+       github.event.pull_request.draft == false)
     # The acceptance suite runs against one shared Latitude account/project, so
     # two runs in flight at once would create colliding resource names.
     # Serialize them: a new run queues until the previous finishes (never

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    # `labeled`/`unlabeled` are deliberately absent. Subscribing to them would mean
+    # any label change on any PR re-evaluates the e2e condition, and on a PR that
+    # touched provider code that provisions real infrastructure — so labelling a PR
+    # `documentation` would spin up servers. The cost of that outweighs the gap it
+    # closes. Consequence: removing `e2e: skip` does not re-trigger the suite on its
+    # own; push a commit, or run this workflow from the Actions tab.
   # Run the acceptance suite deliberately: before a release, after a large
   # refactor, or to sweep tests the curated list below leaves out. There is no
   # scheduled run on purpose — the suite provisions real, billable infrastructure,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,27 +8,52 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  # Run the acceptance suite deliberately: before a release, after a large
+  # refactor, or to sweep tests the curated list below leaves out. There is no
+  # scheduled run on purpose — the suite provisions real, billable infrastructure,
+  # and on a branch nobody merged to it would cost money to learn nothing.
+  workflow_dispatch:
+    inputs:
+      acceptance_tests:
+        description: "Test name regex. Defaults to the curated list; pass TestAcc to sweep everything (slower, provisions more real infrastructure)."
+        required: false
+        default: ""
+
+env:
+  # The acceptance tests that run on pull requests. This is an allowlist: a test
+  # whose prefix is missing here never runs in CI, so a newly added resource needs
+  # its prefix added too.
+  CURATED_ACCEPTANCE_TESTS: "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag|TestAccRegion|TestAccVirtualNetwork|TestAccVirtualMachine|TestAccFirewall|TestAccElasticIP|TestAccProject|TestAccUserData|TestAccLatitudeFirewall|TestAccVlanAssignment|TestAccRole"
 
 jobs:
-  # Detect whether the PR touches provider code. Docs-only changes (docs/,
-  # examples/, templates/, *.md, release config) skip the expensive e2e job,
-  # which provisions real infrastructure and serializes behind other runs.
+  # Detect whether the PR touches code that can change provider behavior. Tooling
+  # (cmd/, internal/sdkcoverage/) and docs cannot, so they must not trigger the
+  # expensive e2e job, which provisions real infrastructure and serializes behind
+  # other runs.
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # A skipped filter step leaves this empty, which defaults to "true": a manual
+      # dispatch has no pull request to diff against, and should run the suite.
+      provider: ${{ steps.filter.outputs.provider || 'true' }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
       -
         name: Detect provider code changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            code:
-              - '**/*.go'
+            provider:
+              - 'latitudesh/**/*.go'
+              - 'internal/modifiers/**'
+              - 'internal/planmodifiers/**'
+              - 'internal/provider/**'
+              - 'internal/validators/**'
+              - 'main.go'
               - 'go.mod'
               - 'go.sum'
               - '.github/workflows/test.yml'
@@ -47,10 +72,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '^1.23.0'
-      - 
+      -
         name: Install dependencies
         run: go get .
-      - 
+      -
         name: Build
         run: go build -v ./...
       -
@@ -59,11 +84,25 @@ jobs:
       -
         name: Run Plan Modifier Tests
         run: go test ./internal/planmodifiers -v
+      -
+        # Neither step above covers this package: the -run filter only matches tests
+        # in ./latitudesh. Without its own step the SDK coverage suite never runs.
+        name: Run SDK Coverage Tests
+        run: go test ./internal/sdkcoverage -v
 
   e2e:
     runs-on: ubuntu-latest
     needs: [build, changes]
-    if: needs.changes.outputs.code == 'true'
+    # Draft pull requests are excluded deliberately, and not just to save time:
+    # acceptance tests run against the live API (the recorder defaults to
+    # passthrough and CI never sets LATITUDE_TEST_RECORDER), so a draft carrying
+    # unreviewed or generated Terraform would provision real infrastructure before
+    # anyone had looked at it. Marking the PR ready for review triggers this job.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (needs.changes.outputs.provider == 'true' &&
+       github.event.pull_request.draft == false &&
+       !contains(github.event.pull_request.labels.*.name, 'e2e: skip'))
     # The acceptance suite runs against one shared Latitude account/project, so
     # two runs in flight at once would create colliding resource names.
     # Serialize them: a new run queues until the previous finishes (never
@@ -92,7 +131,14 @@ jobs:
         run: go get .
       -
         name: Run E2E Tests
-        run: go test ./latitudesh -v -timeout 60m -run "TestAccEnvVarAuthTokenSet|TestAccServerUserDataValidation|TestAccServer|TestAccTag|TestAccSSHKey|TestAccDataSourceSSHKey|TestAccDataSourcePlan|TestAccDataSourceTag|TestAccRegion|TestAccVirtualNetwork|TestAccVirtualMachine|TestAccFirewall|TestAccElasticIP|TestAccProject|TestAccUserData|TestAccLatitudeFirewall|TestAccVlanAssignment|TestAccRole"
+        # The test selector goes through the environment rather than being
+        # interpolated into the command. Expression interpolation happens before the
+        # shell parses this script, so a dispatch input spliced in directly would let
+        # anyone who can dispatch run arbitrary commands — in the one step that has
+        # LATITUDESH_AUTH_TOKEN in its environment. Quoted "$ACCEPTANCE_TESTS" is
+        # only ever an argument.
+        run: go test ./latitudesh -v -timeout 60m -run "$ACCEPTANCE_TESTS"
         env:
+          ACCEPTANCE_TESTS: ${{ github.event.inputs.acceptance_tests || env.CURATED_ACCEPTANCE_TESTS }}
           TF_ACC: '1'
           LATITUDESH_AUTH_TOKEN: ${{ secrets.LATITUDESH_AUTH_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,38 @@ terraform init
 Terraform will pick up your local build through the override configured in `~/.terraformrc`.
 
 > **Note:** Remove any `version` line from `required_providers` to ensure Terraform always uses your local build.
+
+## Coverage of the Latitude.sh SDK
+
+[`sdk-coverage.yaml`](sdk-coverage.yaml) is an **exception list**, not a work queue.
+An SDK service group with no entry is one we intend to expose, and scaffolding gets
+generated for it automatically — a resource, a data source, or both, according to the
+CRUD shape derived from its method names.
+
+So a new service group in an SDK bump does **not** fail CI. It produces a draft PR
+instead, and reviewing that real code is where the keep-or-drop decision gets made:
+
+- **Keep it** — merge, and the entry lands in `implemented_by`.
+- **Drop it** — close the PR and record the decision here with a `ceiling` and a
+  `rationale`, so it stops being regenerated.
+
+`ceiling` caps how much is generated (`none`, or `datasource` to allow a data source
+but no resource). `rationale` says why (`api_constraint`, `product_decision`,
+`deprecated`). Both or neither — a cap without a reason is unauditable. The reason
+matters because it decides whether the exclusion expires: an `api_constraint` is
+re-checked every run and reported once the API grows past it, while a
+`product_decision` is never revisited. Neither ever fails CI.
+
+What `TestProviderSDKCoverage` does fail on is contradiction — most often a resource
+added or renamed without updating `implemented_by`. So if you write a resource by
+hand, add its Terraform type name to the group it calls.
+
+To see the current state:
+
+```sh
+make coverage-report   # coverage, the generation queue, and recorded exclusions
+make coverage-check    # what CI enforces
+```
+
+Both run offline against the module cache and need no API token. The file's header
+comment explains every field.

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,13 @@ test:
 	go test -i $(TEST) || exit 1                                                   
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
-testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m 
+testacc:
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+
+# Coverage of the pinned SDK's service groups by this provider. Both targets are
+# offline: they read the SDK from the module cache and need no API token.
+coverage-report:
+	go run ./cmd/sdkcoverage report -format text
+
+coverage-check:
+	go run ./cmd/sdkcoverage check 

--- a/cmd/sdkcoverage/main.go
+++ b/cmd/sdkcoverage/main.go
@@ -1,0 +1,215 @@
+// Command sdkcoverage reports how much of the pinned latitudesh-go-sdk surface
+// the Terraform provider exposes, and fails when the SDK, the coverage manifest,
+// and the provider's registration disagree.
+//
+// Usage:
+//
+//	sdkcoverage report            # markdown coverage table
+//	sdkcoverage check             # exit 1 on any violation
+//	sdkcoverage groups            # dump the raw SDK surface (no manifest needed)
+//
+// Everything runs offline against the module cache; no API token is involved.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/latitudesh"
+)
+
+// providerTypeName mirrors what the provider reports in its own Metadata, and is
+// the prefix every Terraform type name carries.
+const providerTypeName = "latitudesh"
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		// Errors from internal/sdkcoverage already carry a "sdkcoverage:" prefix.
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		usage()
+		return fmt.Errorf("no command given")
+	}
+
+	command := args[0]
+	flags := flag.NewFlagSet(command, flag.ContinueOnError)
+	manifestPath := flags.String("manifest", defaultManifestPath(), "path to the coverage manifest")
+	sdkDir := flags.String("sdk-dir", "", "SDK source directory (defaults to the pinned module in the module cache)")
+	format := flags.String("format", "", "report format: markdown or text (report only)")
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
+
+	switch command {
+	case "groups":
+		return runGroups(*sdkDir)
+	case "report":
+		return runReport(*manifestPath, *sdkDir, *format)
+	case "check":
+		return runCheck(*manifestPath, *sdkDir)
+	default:
+		usage()
+		return fmt.Errorf("unknown command %q", command)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage: sdkcoverage <report|check|groups> [flags]
+
+  report   render the coverage table (markdown by default)
+  check    exit non-zero when the SDK, the manifest, and the provider disagree
+  groups   dump the raw SDK service-group surface, for seeding the manifest
+
+flags:
+  -manifest path   coverage manifest (default: sdk-coverage.yaml at the repo root)
+  -sdk-dir path    SDK source directory (default: pinned module in the module cache)
+  -format fmt      markdown (default) or text, for report
+`)
+}
+
+// runGroups prints the SDK surface without consulting the manifest, which is how
+// the manifest gets seeded in the first place and how a human inspects what the
+// parser actually sees.
+func runGroups(sdkDir string) error {
+	surface, dir, err := loadSurface(sdkDir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("# %s\n# %d service groups\n\n", dir, len(surface.Groups))
+	for _, name := range surface.Names() {
+		group := surface.Groups[name]
+		caps := sdkcoverage.Classify(group.Methods)
+
+		fmt.Printf("%-26s %s", name, caps.Summary())
+		fmt.Printf("  %s\n", caps.ShapeHint())
+
+		if group.TypeName != lastSegment(name) {
+			fmt.Printf("  type: %s\n", group.TypeName)
+		}
+		for _, method := range group.Methods {
+			fmt.Printf("  - %s\n", method)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func runReport(manifestPath, sdkDir, format string) error {
+	report, version, err := reconcile(manifestPath, sdkDir)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "text":
+		fmt.Print(report.Text(version))
+	case "", "markdown":
+		fmt.Print(report.Markdown(version))
+	default:
+		// Falling back to markdown here would hand automation a different format
+		// than it asked for, and report success while doing it.
+		return fmt.Errorf("unsupported report format %q (want markdown or text)", format)
+	}
+	return nil
+}
+
+func runCheck(manifestPath, sdkDir string) error {
+	report, version, err := reconcile(manifestPath, sdkDir)
+	if err != nil {
+		return err
+	}
+
+	if report.OK() {
+		fmt.Printf("ok: %s — %d/%d covered, %d pending generation, %d excluded, %d need a human\n",
+			version, len(report.Covered), report.Total(),
+			len(report.Pending), len(report.Excluded), len(report.Unshaped))
+		if len(report.Revisit) > 0 {
+			// Informational by design: an API that grew is an opportunity, not a
+			// defect, so it must not fail the run.
+			fmt.Printf("note: %d group(s) excluded on API grounds now exceed their recorded ceiling — see `report`\n",
+				len(report.Revisit))
+		}
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "%d violation(s):\n", len(report.Violations))
+	for _, v := range report.Violations {
+		fmt.Fprintf(os.Stderr, "  - %s\n", v)
+	}
+	return fmt.Errorf("coverage manifest is out of sync")
+}
+
+func reconcile(manifestPath, sdkDir string) (sdkcoverage.Report, string, error) {
+	surface, dir, err := loadSurface(sdkDir)
+	if err != nil {
+		return sdkcoverage.Report{}, "", err
+	}
+
+	manifest, err := sdkcoverage.LoadManifest(manifestPath)
+	if err != nil {
+		return sdkcoverage.Report{}, "", err
+	}
+
+	ctx := context.Background()
+	shipped := sdkcoverage.ShippedTypeNames(ctx, latitudesh.New("dev")(), providerTypeName)
+
+	return sdkcoverage.Reconcile(surface, manifest, shipped), filepath.Base(dir), nil
+}
+
+func loadSurface(sdkDir string) (sdkcoverage.Surface, string, error) {
+	dir := sdkDir
+	if dir == "" {
+		resolved, err := sdkcoverage.PinnedModuleDir(sdkcoverage.SDKModulePath)
+		if err != nil {
+			return sdkcoverage.Surface{}, "", err
+		}
+		dir = resolved
+	}
+
+	surface, err := sdkcoverage.ParseSurface(dir)
+	if err != nil {
+		return sdkcoverage.Surface{}, "", err
+	}
+	return surface, dir, nil
+}
+
+// defaultManifestPath finds the manifest by walking up from the working
+// directory, so the command works from anywhere in the repo.
+func defaultManifestPath() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return sdkcoverage.ManifestFile
+	}
+	for {
+		candidate := filepath.Join(dir, sdkcoverage.ManifestFile)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return sdkcoverage.ManifestFile
+		}
+		dir = parent
+	}
+}
+
+func lastSegment(dotted string) string {
+	if i := len(dotted) - 1; i >= 0 {
+		for ; i >= 0; i-- {
+			if dotted[i] == '.' {
+				return dotted[i+1:]
+			}
+		}
+	}
+	return dotted
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/latitudesh/latitudesh-go-sdk v1.18.1
 	golang.org/x/crypto v0.52.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -85,5 +86,4 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/sdkcoverage/capabilities.go
+++ b/internal/sdkcoverage/capabilities.go
@@ -1,0 +1,169 @@
+package sdkcoverage
+
+import (
+	"sort"
+	"strings"
+)
+
+// capability is what a single SDK method tells us a group can do.
+type capability int
+
+const (
+	capUnknown capability = iota
+	capCreate
+	capRead
+	capUpdate
+	capDelete
+	capAction
+)
+
+// Capabilities is the CRUD shape of a service group, derived from its method
+// names on every run and never persisted — so the manifest cannot drift out of
+// sync with the SDK.
+type Capabilities struct {
+	Creatable bool
+	Readable  bool
+	Updatable bool
+	Deletable bool
+
+	// Actions are methods that operate on an existing entity rather than
+	// implementing CRUD (server lock, rescue mode, metrics). A group made up
+	// only of these is usually not resource-worthy.
+	Actions []string
+
+	// Unclassified are methods whose name matched no known prefix. A non-empty
+	// list means the SDK introduced a naming style this classifier does not
+	// understand yet, and a human should look.
+	Unclassified []string
+}
+
+// Summary renders the CRUD shape compactly, e.g. "CRUD", "CR-D", "-R--".
+func (c Capabilities) Summary() string {
+	flag := func(set bool, letter string) string {
+		if set {
+			return letter
+		}
+		return "-"
+	}
+	return flag(c.Creatable, "C") + flag(c.Readable, "R") + flag(c.Updatable, "U") + flag(c.Deletable, "D")
+}
+
+// ResourceShaped reports whether the group looks like something Terraform could
+// manage: it can be created and destroyed, and read back.
+func (c Capabilities) ResourceShaped() bool {
+	return c.Creatable && c.Deletable && c.Readable
+}
+
+// DataSourceShaped reports whether the group is strictly read-only, which maps to
+// a Terraform data source rather than a resource (regions, roles).
+//
+// Updatable counts against this: Plans and UserProfile are read-mostly but do
+// expose an update, so calling them read-only would overstate the case. They fall
+// through as neither shape and get triaged by hand.
+func (c Capabilities) DataSourceShaped() bool {
+	return c.Readable && !c.Creatable && !c.Deletable && !c.Updatable
+}
+
+// ShapeHint describes what a group could become in Terraform, based only on its
+// derived capabilities. It is a hint for triage, not a decision — the manifest's
+// ceiling is where a decision gets recorded.
+func (c Capabilities) ShapeHint() string {
+	switch {
+	case c.ResourceShaped():
+		return "resource-shaped"
+	case c.DataSourceShaped():
+		return "read-only"
+	default:
+		return "partial lifecycle"
+	}
+}
+
+// methodPrefixes maps a method-name prefix to the capability it implies.
+//
+// Prefix matching rather than exact names is deliberate: the SDK is generated
+// per-operation and its CRUD naming is not consistent across groups. All of
+// VirtualMachines.UpdateVirtualMachine, BlockStorage.PostStorageVolumes,
+// SSHKeys.Retrieve, ElasticIps.CreateElasticIP and Tags.List (a group with no
+// Get at all) have to land in the right bucket.
+var methodPrefixes = map[string]capability{
+	// create
+	"Create": capCreate,
+	"Post":   capCreate,
+	"Assign": capCreate,
+	// read
+	"Get":      capRead,
+	"List":     capRead,
+	"Retrieve": capRead,
+	"Fetch":    capRead,
+	"Show":     capRead,
+	// update
+	"Update": capUpdate,
+	"Patch":  capUpdate,
+	"Put":    capUpdate,
+	"Modify": capUpdate,
+	// delete
+	"Delete":  capDelete,
+	"Destroy": capDelete,
+	"Remove":  capDelete,
+	// actions
+	"Lock":       capAction,
+	"Unlock":     capAction,
+	"Start":      capAction,
+	"Exit":       capAction,
+	"Run":        capAction,
+	"Reinstall":  capAction,
+	"Schedule":   capAction,
+	"Unschedule": capAction,
+	"Refresh":    capAction,
+	"Mount":      capAction,
+}
+
+// orderedPrefixes is methodPrefixes sorted longest-first, so that the most
+// specific prefix wins: "UnscheduleDeletion" must match "Unschedule" and not
+// "Schedule", and "Unlock" must not be read as "Lock".
+var orderedPrefixes = buildOrderedPrefixes()
+
+func buildOrderedPrefixes() []string {
+	prefixes := make([]string, 0, len(methodPrefixes))
+	for prefix := range methodPrefixes {
+		prefixes = append(prefixes, prefix)
+	}
+	sort.Slice(prefixes, func(i, j int) bool {
+		if len(prefixes[i]) != len(prefixes[j]) {
+			return len(prefixes[i]) > len(prefixes[j])
+		}
+		return prefixes[i] < prefixes[j]
+	})
+	return prefixes
+}
+
+// Classify derives a group's CRUD shape from its method names.
+func Classify(methods []string) Capabilities {
+	var caps Capabilities
+	for _, method := range methods {
+		switch classifyMethod(method) {
+		case capCreate:
+			caps.Creatable = true
+		case capRead:
+			caps.Readable = true
+		case capUpdate:
+			caps.Updatable = true
+		case capDelete:
+			caps.Deletable = true
+		case capAction:
+			caps.Actions = append(caps.Actions, method)
+		default:
+			caps.Unclassified = append(caps.Unclassified, method)
+		}
+	}
+	return caps
+}
+
+func classifyMethod(method string) capability {
+	for _, prefix := range orderedPrefixes {
+		if strings.HasPrefix(method, prefix) {
+			return methodPrefixes[prefix]
+		}
+	}
+	return capUnknown
+}

--- a/internal/sdkcoverage/capabilities_test.go
+++ b/internal/sdkcoverage/capabilities_test.go
@@ -1,0 +1,171 @@
+package sdkcoverage
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Every case here is a real naming pattern taken from latitudesh-go-sdk v1.18.1.
+// Exact-name CRUD matching fails on most of them, which is why the classifier is
+// prefix-based.
+func TestClassifyRealSDKNamingPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		methods []string
+		want    string
+	}{
+		{
+			name:    "bare CRUD with suffixed update",
+			methods: []string{"Create", "List", "Get", "Delete", "UpdateVirtualMachine"},
+			want:    "CRUD",
+		},
+		{
+			name:    "single read is Retrieve, not Get",
+			methods: []string{"Create", "Retrieve", "Update", "Delete", "ListAll", "RemoveFromProject"},
+			want:    "CRUD",
+		},
+		{
+			name:    "HTTP-verb prefixes and no update",
+			methods: []string{"GetStorageVolumes", "PostStorageVolumes", "GetStorageVolume", "DeleteStorageVolumes"},
+			want:    "CR-D",
+		},
+		{
+			name:    "fully entity-suffixed CRUD",
+			methods: []string{"ListKubernetesClusters", "CreateKubernetesCluster", "GetKubernetesCluster", "UpdateKubernetesCluster", "DeleteKubernetesCluster"},
+			want:    "CRUD",
+		},
+		{
+			name:    "readable only through List, no Get at all",
+			methods: []string{"List", "Create", "Update", "Delete"},
+			want:    "CRUD",
+		},
+		{
+			name:    "delete-only fragment is not resource-shaped",
+			methods: []string{"Delete"},
+			want:    "---D",
+		},
+		{
+			name:    "read-only group maps to a data source",
+			methods: []string{"List"},
+			want:    "-R--",
+		},
+		{
+			name:    "Fetch counts as a read",
+			methods: []string{"Fetch", "Get"},
+			want:    "-R--",
+		},
+		{
+			name:    "assignment create and delete",
+			methods: []string{"Assign", "ListAssignments", "DeleteAssignment"},
+			want:    "CR-D",
+		},
+		{
+			name:    "Modify counts as an update",
+			methods: []string{"ModifyProjectKey"},
+			want:    "--U-",
+		},
+		{
+			name:    "no methods at all",
+			methods: nil,
+			want:    "----",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Classify(tt.methods).Summary(); got != tt.want {
+				t.Errorf("Summary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The longest matching prefix has to win, or "Unlock" reads as "Lock" and
+// "UnscheduleDeletion" as "Schedule".
+func TestClassifyPrefersLongestPrefix(t *testing.T) {
+	tests := []struct {
+		method string
+		want   capability
+	}{
+		{"Lock", capAction},
+		{"Unlock", capAction},
+		{"ScheduleDeletion", capAction},
+		{"UnscheduleDeletion", capAction},
+		{"Update", capUpdate},
+		{"Put", capUpdate},
+		{"Post", capCreate},
+		{"Patch", capUpdate},
+		{"DeleteAssignment", capDelete},
+		{"DestroyNetworkAttachment", capDelete},
+		{"ShowVirtualMachineMetrics", capRead},
+		{"FrobnicateWidget", capUnknown},
+	}
+
+	for _, tt := range tests {
+		if got := classifyMethod(tt.method); got != tt.want {
+			t.Errorf("classifyMethod(%q) = %v, want %v", tt.method, got, tt.want)
+		}
+	}
+}
+
+func TestClassifySeparatesActionsFromCRUD(t *testing.T) {
+	caps := Classify([]string{
+		"List", "Create", "Get", "Update", "Delete",
+		"Lock", "Unlock", "RunAction", "StartRescueMode", "ExitRescueMode",
+		"ScheduleDeletion", "UnscheduleDeletion", "Reinstall",
+	})
+
+	if got := caps.Summary(); got != "CRUD" {
+		t.Errorf("Summary() = %q, want CRUD", got)
+	}
+	want := []string{
+		"Lock", "Unlock", "RunAction", "StartRescueMode", "ExitRescueMode",
+		"ScheduleDeletion", "UnscheduleDeletion", "Reinstall",
+	}
+	if !reflect.DeepEqual(caps.Actions, want) {
+		t.Errorf("Actions = %v, want %v", caps.Actions, want)
+	}
+	if len(caps.Unclassified) != 0 {
+		t.Errorf("Unclassified = %v, want none", caps.Unclassified)
+	}
+}
+
+// An unfamiliar naming style must surface rather than being silently dropped, so
+// a human notices that the classifier needs a new rule.
+func TestClassifyReportsUnclassifiedMethods(t *testing.T) {
+	caps := Classify([]string{"FrobnicateWidget", "Get"})
+
+	if want := []string{"FrobnicateWidget"}; !reflect.DeepEqual(caps.Unclassified, want) {
+		t.Errorf("Unclassified = %v, want %v", caps.Unclassified, want)
+	}
+	if !caps.Readable {
+		t.Error("Readable = false, want true (Get should still classify)")
+	}
+}
+
+func TestCapabilityShapes(t *testing.T) {
+	tests := []struct {
+		name           string
+		methods        []string
+		wantResource   bool
+		wantDataSource bool
+	}{
+		{"full CRUD", []string{"Create", "Get", "Update", "Delete"}, true, false},
+		{"create read delete", []string{"PostStorageVolumes", "GetStorageVolume", "DeleteStorageVolumes"}, true, false},
+		{"read only", []string{"List", "Get"}, false, true},
+		{"delete only fragment", []string{"Delete"}, false, false},
+		{"actions only", []string{"Lock", "Unlock"}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caps := Classify(tt.methods)
+			if got := caps.ResourceShaped(); got != tt.wantResource {
+				t.Errorf("ResourceShaped() = %v, want %v", got, tt.wantResource)
+			}
+			if got := caps.DataSourceShaped(); got != tt.wantDataSource {
+				t.Errorf("DataSourceShaped() = %v, want %v", got, tt.wantDataSource)
+			}
+		})
+	}
+}

--- a/internal/sdkcoverage/manifest.go
+++ b/internal/sdkcoverage/manifest.go
@@ -1,0 +1,141 @@
+package sdkcoverage
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SDKModulePath is the Go module this package reconciles against.
+const SDKModulePath = "github.com/latitudesh/latitudesh-go-sdk"
+
+// ManifestFile is the manifest's conventional name at the repository root.
+const ManifestFile = "sdk-coverage.yaml"
+
+// SupportedManifestVersion is the only manifest schema version this code
+// understands. Bump it together with any breaking change to the layout below.
+const SupportedManifestVersion = 1
+
+// Ceiling caps how far Terraform goes for a service group, and so how much of it
+// gets generated. It only appears on exclusions: with generation as the default,
+// "generate everything the shape supports" is expressed by having no entry at all.
+type Ceiling string
+
+const (
+	// CeilingNone excludes the group from Terraform entirely.
+	CeilingNone Ceiling = "none"
+
+	// CeilingDataSource allows a data source but not a resource — for groups whose
+	// lifecycle is too incomplete to manage (no destroy, no read by id), or that
+	// simply should not be managed.
+	CeilingDataSource Ceiling = "datasource"
+)
+
+// Rationale explains why a group is excluded. It exists because the reason decides
+// whether the exclusion should ever expire: an API limitation can disappear when
+// the API grows, while a product decision does not change because an endpoint
+// appeared.
+type Rationale string
+
+const (
+	// RationaleAPIConstraint means the API does not offer enough to go further.
+	// These are re-checked against the SDK surface on every run and reported once
+	// the constraint stops holding — as information, never as a failure.
+	RationaleAPIConstraint Rationale = "api_constraint"
+
+	// RationaleProductDecision means we do not want this in Terraform, whatever
+	// the API offers. Never auto-revisited.
+	RationaleProductDecision Rationale = "product_decision"
+
+	// RationaleDeprecated means the upstream endpoint is going away.
+	RationaleDeprecated Rationale = "deprecated"
+)
+
+// Entry is the manifest record for one SDK service group.
+//
+// Coverage is not stated here: a group is covered exactly when ImplementedBy is
+// non-empty, and that list is verified against the provider's own registration.
+// A separate status field would be a second source of truth for the same fact, free
+// to contradict the first.
+//
+// An entry is optional. A group with no entry is generated, which is why there is
+// no "planned" or "undecided" state — nothing waits on a human writing a line.
+type Entry struct {
+	// ImplementedBy lists the Terraform type names backed by this group. Written by
+	// the scaffolding agent when its PR merges, or by hand when a resource is
+	// written the usual way. It is a list because the mapping is many-to-many:
+	// PrivateNetworks backs both latitudesh_virtual_network and
+	// latitudesh_vlan_assignment, while Tags is used by four provider files.
+	ImplementedBy []string `yaml:"implemented_by,omitempty"`
+
+	// Ceiling and Rationale record an exclusion. Both or neither: a ceiling without
+	// a reason is unauditable, and a reason without a ceiling does not say how much
+	// to stop generating.
+	Ceiling   Ceiling   `yaml:"ceiling,omitempty"`
+	Rationale Rationale `yaml:"rationale,omitempty"`
+
+	// Notes is free-form context for whoever reviews this group next. Useful on its
+	// own: an entry carrying only notes still generates, it just arrives with the
+	// reviewer already warned about something.
+	Notes string `yaml:"notes,omitempty"`
+}
+
+// Covered reports whether the provider implements this group.
+func (e Entry) Covered() bool { return len(e.ImplementedBy) > 0 }
+
+// Excluded reports whether this entry caps generation.
+func (e Entry) Excluded() bool { return e.Ceiling != "" || e.Rationale != "" }
+
+// Manifest is the hand-curated record of intent, keyed by the SDK's dotted group
+// path.
+type Manifest struct {
+	Version   int              `yaml:"version"`
+	SDKModule string           `yaml:"sdk_module"`
+	Groups    map[string]Entry `yaml:"groups"`
+}
+
+// LoadManifest reads and parses the manifest at path.
+func LoadManifest(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("sdkcoverage: reading manifest: %w", err)
+	}
+
+	var manifest Manifest
+	// KnownFields makes a typo in a manifest key an error rather than a setting
+	// that silently does nothing.
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("sdkcoverage: parsing %s: %w", path, err)
+	}
+
+	// version and sdk_module are the manifest's identity. Decoding them without
+	// checking them would let a manifest describe a different schema or a
+	// different SDK than the one actually being reconciled, and still pass.
+	if manifest.Version != SupportedManifestVersion {
+		return Manifest{}, fmt.Errorf(
+			"sdkcoverage: %s declares version %d, but this build understands version %d",
+			path, manifest.Version, SupportedManifestVersion)
+	}
+	if manifest.SDKModule != SDKModulePath {
+		return Manifest{}, fmt.Errorf(
+			"sdkcoverage: %s declares sdk_module %q, but coverage is reconciled against %q",
+			path, manifest.SDKModule, SDKModulePath)
+	}
+
+	if manifest.Groups == nil {
+		manifest.Groups = map[string]Entry{}
+	}
+	return manifest, nil
+}
+
+func knownCeilings() []Ceiling {
+	return []Ceiling{CeilingNone, CeilingDataSource}
+}
+
+func knownRationales() []Rationale {
+	return []Rationale{RationaleAPIConstraint, RationaleProductDecision, RationaleDeprecated}
+}

--- a/internal/sdkcoverage/manifest_test.go
+++ b/internal/sdkcoverage/manifest_test.go
@@ -1,0 +1,118 @@
+package sdkcoverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), ManifestFile)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	return path
+}
+
+const validHeader = "version: 1\nsdk_module: github.com/latitudesh/latitudesh-go-sdk\n"
+
+func TestLoadManifestValid(t *testing.T) {
+	path := writeManifest(t, validHeader+`groups:
+  Servers:
+    implemented_by: [latitudesh_server]
+  Teams:
+    rationale: product_decision
+    ceiling: none
+    notes: not a Terraform concern
+`)
+
+	manifest, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if manifest.Version != SupportedManifestVersion {
+		t.Errorf("Version = %d, want %d", manifest.Version, SupportedManifestVersion)
+	}
+	if !manifest.Groups["Servers"].Covered() {
+		t.Error("Servers should read as covered from a non-empty implemented_by")
+	}
+	if manifest.Groups["Teams"].Covered() {
+		t.Error("Teams has no implemented_by and must not read as covered")
+	}
+	if got := manifest.Groups["Teams"].Ceiling; got != CeilingNone {
+		t.Errorf("ceiling = %q, want %q", got, CeilingNone)
+	}
+}
+
+// A manifest declaring a schema version this build does not know must be
+// rejected, not reconciled on a guess.
+func TestLoadManifestRejectsUnknownVersion(t *testing.T) {
+	path := writeManifest(t, "version: 99\nsdk_module: github.com/latitudesh/latitudesh-go-sdk\ngroups: {}\n")
+
+	_, err := LoadManifest(path)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported schema version")
+	}
+	if !strings.Contains(err.Error(), "version 99") {
+		t.Errorf("error should name the offending version, got: %v", err)
+	}
+}
+
+// Likewise a manifest that claims to describe some other module: the reconciler
+// always parses SDKModulePath, so a mismatch means the file is misleading.
+func TestLoadManifestRejectsWrongModule(t *testing.T) {
+	path := writeManifest(t, "version: 1\nsdk_module: github.com/totally/wrong-module\ngroups: {}\n")
+
+	_, err := LoadManifest(path)
+	if err == nil {
+		t.Fatal("expected an error for a mismatched sdk_module")
+	}
+	if !strings.Contains(err.Error(), "wrong-module") {
+		t.Errorf("error should name the offending module, got: %v", err)
+	}
+}
+
+// A missing version reads as 0, which must not be silently treated as v1.
+func TestLoadManifestRejectsMissingIdentity(t *testing.T) {
+	path := writeManifest(t, "groups: {}\n")
+
+	if _, err := LoadManifest(path); err == nil {
+		t.Fatal("expected an error when version and sdk_module are absent")
+	}
+}
+
+// A mistyped key must fail loudly rather than become a setting that does nothing.
+func TestLoadManifestRejectsUnknownField(t *testing.T) {
+	path := writeManifest(t, validHeader+`groups:
+  Servers:
+    implemented_bt: [latitudesh_server]
+`)
+
+	_, err := LoadManifest(path)
+	if err == nil {
+		t.Fatal("expected an error for an unknown field")
+	}
+	if !strings.Contains(err.Error(), "implemented_bt") {
+		t.Errorf("error should name the unknown field, got: %v", err)
+	}
+}
+
+func TestLoadManifestMissingFile(t *testing.T) {
+	if _, err := LoadManifest(filepath.Join(t.TempDir(), "absent.yaml")); err == nil {
+		t.Fatal("expected an error for a missing manifest")
+	}
+}
+
+// The committed manifest must load and describe the pinned SDK.
+func TestLoadManifestRepoFileIsValid(t *testing.T) {
+	manifest, err := LoadManifest(filepath.Join("..", "..", ManifestFile))
+	if err != nil {
+		t.Fatalf("loading the committed manifest: %v", err)
+	}
+	if len(manifest.Groups) == 0 {
+		t.Error("the committed manifest declares no groups")
+	}
+}

--- a/internal/sdkcoverage/provider.go
+++ b/internal/sdkcoverage/provider.go
@@ -1,0 +1,51 @@
+package sdkcoverage
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// ShippedTypeNames returns the Terraform type names a provider registers, asking
+// each registered constructor for its own Metadata.
+//
+// Reading the registration at runtime rather than grepping the source keeps the
+// reconciliation honest: Resources()/DataSources() is what Terraform actually
+// serves, so a resource that exists as a file but was never registered does not
+// count as shipped, and a rename cannot slip past.
+//
+// The parameter is the framework's provider.Provider interface, so this package
+// still never imports the provider implementation — the gate test lives in that
+// package and would otherwise form an import cycle.
+func ShippedTypeNames(ctx context.Context, p provider.Provider, providerTypeName string) []string {
+	seen := map[string]bool{}
+	var names []string
+
+	add := func(name string) {
+		// A type name can legitimately appear twice: ssh_key and tag each ship as
+		// both a resource and a data source.
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	for _, newResource := range p.Resources(ctx) {
+		var resp resource.MetadataResponse
+		newResource().Metadata(ctx, resource.MetadataRequest{ProviderTypeName: providerTypeName}, &resp)
+		add(resp.TypeName)
+	}
+
+	for _, newDataSource := range p.DataSources(ctx) {
+		var resp datasource.MetadataResponse
+		newDataSource().Metadata(ctx, datasource.MetadataRequest{ProviderTypeName: providerTypeName}, &resp)
+		add(resp.TypeName)
+	}
+
+	sort.Strings(names)
+	return names
+}

--- a/internal/sdkcoverage/reconcile.go
+++ b/internal/sdkcoverage/reconcile.go
@@ -1,0 +1,331 @@
+package sdkcoverage
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Violation is a disagreement between the SDK surface, the manifest, and what the
+// provider actually ships. Every violation is actionable by a human editing the
+// manifest or the provider.
+//
+// Violations are limited to contradictions. Two things deliberately are not
+// violations:
+//
+//   - A group with no entry. That is the normal trigger for generating one, not a
+//     blind spot, so an SDK bump does not go red over it.
+//   - An API that grew past a recorded ceiling. That is an opportunity, and the
+//     person bumping the SDK is not the person who decides product scope. It
+//     surfaces as Revisit instead.
+type Violation struct {
+	// Group is the SDK group the violation concerns, or "" when it concerns a
+	// Terraform type with no owning group.
+	Group   string
+	Message string
+}
+
+func (v Violation) String() string {
+	if v.Group == "" {
+		return v.Message
+	}
+	return v.Group + ": " + v.Message
+}
+
+// GroupReport is one row of the coverage report: the SDK facts, the manifest's
+// intent, and the capabilities derived from the methods.
+type GroupReport struct {
+	Group
+	Entry
+	Capabilities Capabilities
+}
+
+// Generates reports what scaffolding this group should produce, given its derived
+// shape and any ceiling. Returns nil when nothing should be generated.
+func (g GroupReport) Generates() []string {
+	if g.Covered() {
+		return nil
+	}
+
+	var kinds []string
+	switch g.Ceiling {
+	case CeilingNone:
+		return nil
+	case CeilingDataSource:
+		if g.Capabilities.Readable {
+			kinds = append(kinds, "datasource")
+		}
+	default:
+		if g.Capabilities.ResourceShaped() {
+			kinds = append(kinds, "resource")
+		}
+		if g.Capabilities.Readable {
+			kinds = append(kinds, "datasource")
+		}
+	}
+	return kinds
+}
+
+// Report is the full reconciliation result.
+type Report struct {
+	Violations []Violation
+
+	Covered  []GroupReport
+	Excluded []GroupReport
+
+	// Pending are groups with no entry whose shape supports scaffolding. This is
+	// the generation queue, and it needs no bookkeeping to stay current.
+	Pending []GroupReport
+
+	// Unshaped are groups with no entry whose lifecycle is too partial to generate
+	// anything coherent from. They need a human, not an agent.
+	Unshaped []GroupReport
+
+	// Revisit holds groups excluded on API grounds whose constraint no longer
+	// holds, because the SDK has since grown past the recorded ceiling.
+	// Informational: a prompt to re-triage, never a failure.
+	Revisit []GroupReport
+}
+
+// OK reports whether the SDK, the manifest, and the provider all agree.
+func (r Report) OK() bool { return len(r.Violations) == 0 }
+
+func (r Report) all() []GroupReport {
+	var out []GroupReport
+	for _, bucket := range [][]GroupReport{r.Covered, r.Excluded, r.Pending, r.Unshaped} {
+		out = append(out, bucket...)
+	}
+	return out
+}
+
+// Total is the number of SDK groups accounted for.
+func (r Report) Total() int { return len(r.all()) }
+
+// Unclassified returns groups with methods the prefix classifier did not
+// recognize. Reported but never a violation: an unfamiliar naming style is a
+// signal for a human, not a reason to fail an SDK bump.
+func (r Report) Unclassified() []GroupReport {
+	var out []GroupReport
+	for _, g := range r.all() {
+		if len(g.Capabilities.Unclassified) > 0 {
+			out = append(out, g)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Reconcile cross-checks the SDK surface, the manifest, and the Terraform type
+// names the provider registers.
+//
+// shipped is passed in as plain strings rather than read from the provider here,
+// so this package never imports the provider package — the gate test lives inside
+// that package and would otherwise be an import cycle.
+func Reconcile(surface Surface, manifest Manifest, shipped []string) Report {
+	var report Report
+
+	shippedSet := make(map[string]bool, len(shipped))
+	for _, name := range shipped {
+		shippedSet[name] = true
+	}
+	claimed := make(map[string]bool, len(shipped))
+
+	for _, name := range surface.Names() {
+		group := surface.Groups[name]
+		entry := manifest.Groups[name] // zero value is a valid "no entry"
+		row := GroupReport{Group: group, Entry: entry, Capabilities: Classify(group.Methods)}
+
+		if entry.Covered() {
+			report.Violations = append(report.Violations, validateCovered(name, entry)...)
+			for _, tfType := range entry.ImplementedBy {
+				claimed[tfType] = true
+				if !shippedSet[tfType] {
+					report.Violations = append(report.Violations, Violation{
+						Group: name,
+						Message: fmt.Sprintf(
+							"implemented_by names %q, which the provider does not register, so this group's coverage is a fiction — "+
+								"update the name here if the resource was renamed, or drop it from the list if it was removed", tfType),
+					})
+				}
+			}
+			report.Covered = append(report.Covered, row)
+			continue
+		}
+
+		report.Violations = append(report.Violations, validateUncovered(name, entry)...)
+
+		switch {
+		case entry.Excluded():
+			report.Excluded = append(report.Excluded, row)
+			// An API-grounds exclusion is only true while the API stays put.
+			if entry.Rationale == RationaleAPIConstraint && outgrewCeiling(entry.Ceiling, row.Capabilities) {
+				report.Revisit = append(report.Revisit, row)
+			}
+		case len(row.Generates()) > 0:
+			report.Pending = append(report.Pending, row)
+		default:
+			report.Unshaped = append(report.Unshaped, row)
+		}
+	}
+
+	// Manifest entries for groups the SDK no longer exposes: a rename or removal
+	// on an SDK bump that would otherwise pass unnoticed.
+	for name := range manifest.Groups {
+		if _, ok := surface.Groups[name]; ok {
+			continue
+		}
+		report.Violations = append(report.Violations, Violation{
+			Group: name,
+			Message: fmt.Sprintf(
+				"listed in %s but the SDK no longer exposes it — rename this entry to match if the group was renamed "+
+					"upstream, or delete it if the group is gone (`sdkcoverage groups` lists the current names)", ManifestFile),
+		})
+	}
+
+	// Terraform types no group claims. With undeclared groups no longer a
+	// violation, this check carries real weight: an unclaimed type means its SDK
+	// group still reads as ungenerated, so the scaffolding agent would write a
+	// second resource competing with the one already there.
+	for _, tfType := range shipped {
+		if !claimed[tfType] {
+			report.Violations = append(report.Violations, Violation{
+				Message: fmt.Sprintf(
+					"the provider registers %q but no group claims it, so that group still counts as ungenerated and "+
+						"would be scaffolded again — add %q to implemented_by on the SDK group its resource calls "+
+						"(`sdkcoverage groups` lists them)", tfType, tfType),
+			})
+		}
+	}
+
+	sort.Slice(report.Violations, func(i, j int) bool {
+		if report.Violations[i].Group != report.Violations[j].Group {
+			return report.Violations[i].Group < report.Violations[j].Group
+		}
+		return report.Violations[i].Message < report.Violations[j].Message
+	})
+
+	return report
+}
+
+// validateCovered checks an implemented group. A ceiling caps what to generate and a
+// rationale explains why nothing was generated, so neither belongs on a group that
+// is already built — what got built is the answer.
+func validateCovered(name string, entry Entry) []Violation {
+	if !entry.Excluded() {
+		return nil
+	}
+	return []Violation{{
+		Group:   name,
+		Message: "implemented_by is set, so ceiling and rationale do not apply — drop them",
+	}}
+}
+
+// validateUncovered checks a group nothing was built for. Having no entry at all is
+// fine and means "generate it"; what cannot stand is a half-written exclusion.
+func validateUncovered(name string, entry Entry) []Violation {
+	var violations []Violation
+
+	switch {
+	case entry.Ceiling == "" && entry.Rationale == "":
+		return nil // no entry, or notes only: generate it
+	case entry.Ceiling == "":
+		violations = append(violations, Violation{
+			Group: name,
+			Message: fmt.Sprintf(
+				"rationale %q needs a ceiling to say how much to stop generating (%s)",
+				entry.Rationale, ceilingList()),
+		})
+	case entry.Rationale == "":
+		violations = append(violations, Violation{
+			Group: name,
+			Message: fmt.Sprintf(
+				"ceiling %q needs a rationale (%s)", entry.Ceiling, rationaleList()),
+		})
+	}
+
+	if entry.Ceiling != "" && !validCeiling(entry.Ceiling) {
+		violations = append(violations, Violation{
+			Group:   name,
+			Message: fmt.Sprintf("unknown ceiling %q (want %s)", entry.Ceiling, ceilingList()),
+		})
+	}
+	if entry.Rationale != "" && !validRationale(entry.Rationale) {
+		violations = append(violations, Violation{
+			Group:   name,
+			Message: fmt.Sprintf("unknown rationale %q (want %s)", entry.Rationale, rationaleList()),
+		})
+	}
+
+	return violations
+}
+
+// outgrewCeiling reports whether the SDK now offers more than the recorded ceiling
+// assumed, which means an api_constraint exclusion is stale.
+func outgrewCeiling(ceiling Ceiling, caps Capabilities) bool {
+	switch ceiling {
+	case CeilingNone:
+		// Anything readable is at least data-source material.
+		return caps.Readable
+	case CeilingDataSource:
+		return caps.ResourceShaped()
+	default:
+		return false
+	}
+}
+
+func validCeiling(c Ceiling) bool {
+	for _, known := range knownCeilings() {
+		if c == known {
+			return true
+		}
+	}
+	return false
+}
+
+func validRationale(r Rationale) bool {
+	for _, known := range knownRationales() {
+		if r == known {
+			return true
+		}
+	}
+	return false
+}
+
+func ceilingList() string {
+	names := make([]string, 0, len(knownCeilings()))
+	for _, c := range knownCeilings() {
+		names = append(names, string(c))
+	}
+	return strings.Join(names, ", ")
+}
+
+func rationaleList() string {
+	names := make([]string, 0, len(knownRationales()))
+	for _, r := range knownRationales() {
+		names = append(names, string(r))
+	}
+	return strings.Join(names, ", ")
+}
+
+func methodList(methods []string) string {
+	if len(methods) == 0 {
+		return "none"
+	}
+	return strings.Join(methods, ", ")
+}
+
+// PinnedModuleDir resolves the local source directory of a module already
+// required by this repo, so the SDK surface can be parsed straight from the
+// module cache with no network access and no vendoring.
+func PinnedModuleDir(modulePath string) (string, error) {
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", modulePath).Output()
+	if err != nil {
+		return "", fmt.Errorf("sdkcoverage: resolving %s: %w", modulePath, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return "", fmt.Errorf("sdkcoverage: %s has no local directory (run `go mod download`)", modulePath)
+	}
+	return dir, nil
+}

--- a/internal/sdkcoverage/reconcile_test.go
+++ b/internal/sdkcoverage/reconcile_test.go
@@ -1,0 +1,424 @@
+package sdkcoverage
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func surfaceOf(groups map[string][]string) Surface {
+	s := Surface{Groups: make(map[string]Group, len(groups))}
+	for name, methods := range groups {
+		s.Groups[name] = Group{Name: name, TypeName: name, Methods: methods}
+	}
+	return s
+}
+
+func joinViolations(report Report) string {
+	msgs := make([]string, 0, len(report.Violations))
+	for _, v := range report.Violations {
+		msgs = append(msgs, v.String())
+	}
+	return strings.Join(msgs, "\n")
+}
+
+// requireViolation asserts exactly one violation, mentioning needle. The gate is
+// only worth having if each disagreement produces an actionable message, so the
+// message text is part of the contract.
+func requireViolation(t *testing.T, report Report, needle string) {
+	t.Helper()
+
+	if len(report.Violations) != 1 {
+		t.Fatalf("got %d violations, want 1: %s", len(report.Violations), joinViolations(report))
+	}
+	if got := report.Violations[0].String(); !strings.Contains(got, needle) {
+		t.Errorf("violation %q does not mention %q", got, needle)
+	}
+}
+
+// The headline behaviour of the generate-by-default model: a group nobody has
+// declared is the trigger for scaffolding, not a blind spot. An SDK bump that adds
+// surface must NOT go red — otherwise every bump is blocked on a product decision
+// its author was never asked to make.
+func TestReconcileUndeclaredGroupIsPendingNotAViolation(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"Servers":         {"Create", "Get", "Delete"},
+		"ManagedDatabase": {"CreateDatabase", "GetDatabase", "DeleteDatabase"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {ImplementedBy: []string{"latitudesh_server"}},
+	}}
+
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	if !report.OK() {
+		t.Fatalf("an undeclared group must not be a violation, got:\n%s", joinViolations(report))
+	}
+	if len(report.Pending) != 1 || report.Pending[0].Name != "ManagedDatabase" {
+		t.Fatalf("Pending = %v, want one entry for ManagedDatabase", report.Pending)
+	}
+}
+
+// What gets generated follows the derived shape. Generating a resource for a
+// read-only group would be incoherent — there is no create or delete to wire up.
+func TestGeneratesFollowsDerivedShape(t *testing.T) {
+	tests := []struct {
+		name    string
+		methods []string
+		entry   Entry
+		want    []string
+	}{
+		{
+			name:    "full CRUD gets both",
+			methods: []string{"Create", "Get", "Update", "Delete"},
+			want:    []string{"resource", "datasource"},
+		},
+		{
+			name:    "create-read-delete is still resource-shaped",
+			methods: []string{"PostStorageVolumes", "GetStorageVolume", "DeleteStorageVolumes"},
+			want:    []string{"resource", "datasource"},
+		},
+		{
+			name:    "read-only gets a data source only",
+			methods: []string{"List"},
+			want:    []string{"datasource"},
+		},
+		{
+			name:    "create without delete cannot be a resource",
+			methods: []string{"Create", "Get"},
+			want:    []string{"datasource"},
+		},
+		{
+			name:    "delete-only yields nothing",
+			methods: []string{"Delete"},
+			want:    nil,
+		},
+		{
+			name:    "actions only yield nothing",
+			methods: []string{"Lock", "Unlock"},
+			want:    nil,
+		},
+		{
+			name:    "ceiling none suppresses everything",
+			methods: []string{"Create", "Get", "Update", "Delete"},
+			entry:   Entry{Ceiling: CeilingNone, Rationale: RationaleProductDecision},
+			want:    nil,
+		},
+		{
+			name:    "ceiling datasource suppresses the resource only",
+			methods: []string{"Create", "Get", "Update", "Delete"},
+			entry:   Entry{Ceiling: CeilingDataSource, Rationale: RationaleAPIConstraint},
+			want:    []string{"datasource"},
+		},
+		{
+			name:    "a covered group generates nothing further",
+			methods: []string{"Create", "Get", "Update", "Delete"},
+			entry:   Entry{ImplementedBy: []string{"latitudesh_thing"}},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := GroupReport{
+				Group:        Group{Name: "X", Methods: tt.methods},
+				Entry:        tt.entry,
+				Capabilities: Classify(tt.methods),
+			}
+			if got := row.Generates(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Generates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A group whose lifecycle is too partial to generate anything from needs a human,
+// so it is reported separately rather than sitting in the generation queue.
+func TestReconcileSortsUnshapedGroupsAside(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"VirtualNetworks": {"Delete"},
+		"Events":          {"List"},
+	})
+
+	report := Reconcile(surface, Manifest{Groups: map[string]Entry{}}, nil)
+
+	if !report.OK() {
+		t.Fatalf("unexpected violations:\n%s", joinViolations(report))
+	}
+	if len(report.Pending) != 1 || report.Pending[0].Name != "Events" {
+		t.Errorf("Pending = %v, want only Events", report.Pending)
+	}
+	if len(report.Unshaped) != 1 || report.Unshaped[0].Name != "VirtualNetworks" {
+		t.Errorf("Unshaped = %v, want only VirtualNetworks", report.Unshaped)
+	}
+}
+
+// An entry carrying only notes is an annotation, not an exclusion: it still
+// generates, it just arrives with the reviewer already warned about something.
+func TestReconcileNotesOnlyEntryStillGenerates(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"ObjectStorage": {"PostStorageBuckets", "GetStorageBucket", "DeleteStorageBuckets"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"ObjectStorage": {Notes: "the spec understates this API"},
+	}}
+
+	report := Reconcile(surface, manifest, nil)
+
+	if !report.OK() {
+		t.Fatalf("a notes-only entry must be valid, got:\n%s", joinViolations(report))
+	}
+	if len(report.Pending) != 1 {
+		t.Fatalf("Pending = %v, want the group still queued for generation", report.Pending)
+	}
+	if len(report.Pending[0].Generates()) == 0 {
+		t.Error("a notes-only entry must not suppress generation")
+	}
+}
+
+func TestReconcileExcludedGroup(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"VpnSessions": {"Create", "List", "Delete"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"VpnSessions": {Ceiling: CeilingNone, Rationale: RationaleProductDecision},
+	}}
+
+	report := Reconcile(surface, manifest, nil)
+
+	if !report.OK() {
+		t.Fatalf("unexpected violations:\n%s", joinViolations(report))
+	}
+	if len(report.Excluded) != 1 || len(report.Pending) != 0 {
+		t.Errorf("excluded=%d pending=%d, want 1/0", len(report.Excluded), len(report.Pending))
+	}
+}
+
+// A cap without a reason is unauditable; a reason without a cap does not say how
+// much to stop generating. Both or neither.
+func TestReconcileRequiresCeilingAndRationaleTogether(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Teams": {"Create", "Get", "Update"}})
+
+	report := Reconcile(surface, Manifest{Groups: map[string]Entry{
+		"Teams": {Rationale: RationaleProductDecision},
+	}}, nil)
+	requireViolation(t, report, "needs a ceiling")
+
+	report = Reconcile(surface, Manifest{Groups: map[string]Entry{
+		"Teams": {Ceiling: CeilingNone},
+	}}, nil)
+	requireViolation(t, report, "needs a rationale")
+}
+
+func TestReconcileRejectsUnknownCeilingAndRationale(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Events": {"List"}})
+
+	report := Reconcile(surface, Manifest{Groups: map[string]Entry{
+		"Events": {Ceiling: CeilingNone, Rationale: Rationale("someday")},
+	}}, nil)
+	requireViolation(t, report, `unknown rationale "someday"`)
+
+	report = Reconcile(surface, Manifest{Groups: map[string]Entry{
+		"Events": {Ceiling: Ceiling("module"), Rationale: RationaleProductDecision},
+	}}, nil)
+	requireViolation(t, report, `unknown ceiling "module"`)
+}
+
+// Ceiling and rationale describe what not to generate. Neither belongs on a group
+// that is already built — what got built is the answer.
+func TestReconcileRejectsCeilingOrRationaleOnCoveredGroup(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Servers": {"Create", "Get", "Delete"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {
+			ImplementedBy: []string{"latitudesh_server"},
+			Ceiling:       CeilingNone,
+			Rationale:     RationaleProductDecision,
+		},
+	}}
+
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	requireViolation(t, report, "do not apply")
+}
+
+// A group renamed or dropped upstream while the manifest keeps claiming it.
+func TestReconcileFlagsGroupMissingFromSDK(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Servers": {"Create", "Get", "Delete"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers":     {ImplementedBy: []string{"latitudesh_server"}},
+		"OldEndpoint": {Ceiling: CeilingNone, Rationale: RationaleDeprecated},
+	}}
+
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	requireViolation(t, report, "OldEndpoint")
+}
+
+// A resource renamed in the provider without updating the manifest.
+func TestReconcileFlagsImplementedByUnknownToProvider(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Servers": {"Create", "Get", "Delete"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {ImplementedBy: []string{"latitudesh_server_renamed"}},
+	}}
+
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	// Both directions break: the manifest names something unregistered, and the
+	// registered resource is unclaimed.
+	if len(report.Violations) != 2 {
+		t.Fatalf("got %d violations, want 2:\n%s", len(report.Violations), joinViolations(report))
+	}
+	joined := joinViolations(report)
+	for _, needle := range []string{"latitudesh_server_renamed", "latitudesh_server"} {
+		if !strings.Contains(joined, needle) {
+			t.Errorf("violations do not mention %q: %s", needle, joined)
+		}
+	}
+}
+
+// With undeclared groups no longer failing, this is the check that still forces the
+// manifest to be filled in once a resource actually lands — whether the agent wrote
+// it or a human did.
+func TestReconcileFlagsUnclaimedProviderType(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Servers": {"Create", "Get", "Delete"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {ImplementedBy: []string{"latitudesh_server"}},
+	}}
+
+	report := Reconcile(surface, manifest, []string{"latitudesh_server", "latitudesh_brand_new"})
+
+	requireViolation(t, report, "latitudesh_brand_new")
+}
+
+// One group legitimately backing several resources must not be reported as a
+// problem: PrivateNetworks backs both latitudesh_virtual_network and
+// latitudesh_vlan_assignment.
+func TestReconcileAllowsManyToManyMapping(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"PrivateNetworks": {"Create", "List", "Update", "Assign", "DeleteAssignment"},
+		"VirtualNetworks": {"Delete"},
+		"Tags":            {"List", "Create", "Update", "Delete"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"PrivateNetworks": {ImplementedBy: []string{"latitudesh_virtual_network", "latitudesh_vlan_assignment"}},
+		"VirtualNetworks": {ImplementedBy: []string{"latitudesh_virtual_network"}},
+		"Tags":            {ImplementedBy: []string{"latitudesh_tag"}},
+	}}
+
+	report := Reconcile(surface, manifest,
+		[]string{"latitudesh_virtual_network", "latitudesh_vlan_assignment", "latitudesh_tag"})
+
+	if !report.OK() {
+		t.Fatalf("many-to-many mapping should be valid, got:\n%s", joinViolations(report))
+	}
+}
+
+// An api_constraint exclusion is only true while the API stays put. When the SDK
+// grows past the recorded ceiling the group surfaces for re-triage — as information,
+// never as a violation.
+func TestReconcileFlagsOutgrownAPIConstraintWithoutFailing(t *testing.T) {
+	manifest := Manifest{Groups: map[string]Entry{
+		"Teams": {Ceiling: CeilingDataSource, Rationale: RationaleAPIConstraint},
+	}}
+
+	// Before: no delete, so a resource is genuinely impossible.
+	before := Reconcile(surfaceOf(map[string][]string{"Teams": {"Create", "Get", "Update"}}), manifest, nil)
+	if !before.OK() {
+		t.Fatalf("unexpected violations: %s", joinViolations(before))
+	}
+	if len(before.Revisit) != 0 {
+		t.Errorf("nothing to revisit while the constraint holds, got %d", len(before.Revisit))
+	}
+
+	// After: the API grew a delete, so the ceiling no longer reflects reality.
+	after := Reconcile(surfaceOf(map[string][]string{"Teams": {"Create", "Get", "Update", "Delete"}}), manifest, nil)
+	if !after.OK() {
+		t.Fatalf("an outgrown ceiling must not be a violation, got: %s", joinViolations(after))
+	}
+	if len(after.Revisit) != 1 || after.Revisit[0].Name != "Teams" {
+		t.Fatalf("Revisit = %v, want one entry for Teams", after.Revisit)
+	}
+}
+
+// A product decision is exempt: it does not change because an endpoint appeared.
+func TestReconcileNeverRevisitsProductDecision(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"VpnSessions": {"Create", "Get", "List", "Update", "Delete"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"VpnSessions": {Ceiling: CeilingNone, Rationale: RationaleProductDecision},
+	}}
+
+	report := Reconcile(surface, manifest, nil)
+
+	if !report.OK() {
+		t.Fatalf("unexpected violations: %s", joinViolations(report))
+	}
+	if len(report.Revisit) != 0 {
+		t.Errorf("a product decision must never be auto-revisited, got %d", len(report.Revisit))
+	}
+}
+
+// ceiling: none on API grounds is outgrown as soon as anything is readable.
+func TestReconcileRevisitsNoneCeilingWhenReadable(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Events": {"List"}})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Events": {Ceiling: CeilingNone, Rationale: RationaleAPIConstraint},
+	}}
+
+	report := Reconcile(surface, manifest, nil)
+
+	if len(report.Revisit) != 1 {
+		t.Errorf("a readable group under ceiling none should surface, got %d", len(report.Revisit))
+	}
+}
+
+func TestReconcileReportsUnclassifiedWithoutFailing(t *testing.T) {
+	surface := surfaceOf(map[string][]string{"Oddities": {"FrobnicateWidget", "Get"}})
+
+	report := Reconcile(surface, Manifest{Groups: map[string]Entry{}}, nil)
+
+	if !report.OK() {
+		t.Errorf("unrecognized method names must not be a violation, got: %s", joinViolations(report))
+	}
+	unclassified := report.Unclassified()
+	if len(unclassified) != 1 || unclassified[0].Name != "Oddities" {
+		t.Fatalf("Unclassified() = %v, want one entry for Oddities", unclassified)
+	}
+}
+
+// End-to-end over the frozen tree with an entirely empty manifest — the state a
+// brand-new repo would be in. Everything should queue for generation, nothing
+// should fail.
+func TestReconcileAgainstFrozenSurfaceWithEmptyManifest(t *testing.T) {
+	surface, err := ParseSurface(miniSDK)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+
+	report := Reconcile(surface, Manifest{Groups: map[string]Entry{}}, nil)
+
+	if !report.OK() {
+		t.Fatalf("an empty manifest must not fail, got:\n%s", joinViolations(report))
+	}
+	if report.Total() != len(surface.Groups) {
+		t.Errorf("Total() = %d, want %d", report.Total(), len(surface.Groups))
+	}
+	if len(report.Pending)+len(report.Unshaped) != len(surface.Groups) {
+		t.Errorf("every group should be pending or unshaped, got %d+%d of %d",
+			len(report.Pending), len(report.Unshaped), len(surface.Groups))
+	}
+	// VirtualNetworks is delete-only in the frozen tree, so nothing can be built
+	// from it; Projects.SSHKeys is create-only.
+	unshaped := map[string]bool{}
+	for _, g := range report.Unshaped {
+		unshaped[g.Name] = true
+	}
+	for _, name := range []string{"VirtualNetworks", "Projects.SSHKeys"} {
+		if !unshaped[name] {
+			t.Errorf("%s should be too partial to generate", name)
+		}
+	}
+	// Markdown rendering must not panic on a fully-populated report.
+	if out := report.Markdown("v0.0.0-test"); !strings.Contains(out, "Firewalls.Assignments") {
+		t.Error("markdown output is missing the nested group")
+	}
+}

--- a/internal/sdkcoverage/report.go
+++ b/internal/sdkcoverage/report.go
@@ -1,0 +1,154 @@
+package sdkcoverage
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Markdown renders the report as a coverage table suitable for a tracking issue
+// or a roadmap document.
+func (r Report) Markdown(sdkVersion string) string {
+	var b strings.Builder
+
+	b.WriteString("# Terraform provider coverage of `latitudesh-go-sdk`\n\n")
+	if sdkVersion != "" {
+		fmt.Fprintf(&b, "SDK version: `%s`\n\n", sdkVersion)
+	}
+	fmt.Fprintf(&b, "%d of %d service groups covered — %d pending generation, %d excluded, %d need a human.\n",
+		len(r.Covered), r.Total(), len(r.Pending), len(r.Excluded), len(r.Unshaped))
+
+	b.WriteString("\nCRUD shapes are derived from the SDK's method names. The SDK is generated " +
+		"from the API's OpenAPI spec, so a shape can understate what the API actually offers " +
+		"when the spec is incomplete — treat it as a floor, not a ceiling.\n")
+
+	if len(r.Violations) > 0 {
+		fmt.Fprintf(&b, "\n## Violations (%d)\n\n", len(r.Violations))
+		for _, v := range r.Violations {
+			fmt.Fprintf(&b, "- %s\n", v)
+		}
+	}
+
+	if len(r.Pending) > 0 {
+		b.WriteString("\n## Pending generation\n\n")
+		b.WriteString("No manifest entry, so scaffolding is expected. Reviewing the generated " +
+			"PR is where the keep-or-drop decision gets made; dropping it means adding a " +
+			"ceiling and rationale here.\n\n")
+		b.WriteString("| Group | CRUD | Would generate | Notes |\n|---|---|---|---|\n")
+		for _, g := range r.Pending {
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s | %s |\n",
+				g.Name, g.Capabilities.Summary(), strings.Join(g.Generates(), " + "), orDash(g.Notes))
+		}
+	}
+
+	if len(r.Unshaped) > 0 {
+		b.WriteString("\n## Too partial to generate\n\n")
+		b.WriteString("Readable but not resource-shaped, or not readable at all — no coherent " +
+			"resource or data source falls out of these. They need a human decision, not an agent.\n\n")
+		b.WriteString("| Group | CRUD | Methods | Notes |\n|---|---|---|---|\n")
+		for _, g := range r.Unshaped {
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s | %s |\n",
+				g.Name, g.Capabilities.Summary(), methodList(g.Methods), orDash(g.Notes))
+		}
+	}
+
+	if len(r.Revisit) > 0 {
+		b.WriteString("\n## Worth revisiting\n\n")
+		b.WriteString("Excluded on API grounds, but the SDK has since grown past the recorded " +
+			"ceiling. Not a failure — re-triage when convenient.\n\n")
+		b.WriteString("| Group | Ceiling | CRUD now | Notes |\n|---|---|---|---|\n")
+		for _, g := range r.Revisit {
+			fmt.Fprintf(&b, "| `%s` | %s | `%s` | %s |\n",
+				g.Name, g.Ceiling, g.Capabilities.Summary(), orDash(g.Notes))
+		}
+	}
+
+	if len(r.Covered) > 0 {
+		b.WriteString("\n## Covered\n\n")
+		b.WriteString("| Group | CRUD | Implemented by |\n|---|---|---|\n")
+		for _, g := range r.Covered {
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s |\n",
+				g.Name, g.Capabilities.Summary(), codeList(g.ImplementedBy))
+		}
+	}
+
+	if len(r.Excluded) > 0 {
+		b.WriteString("\n## Excluded\n\n")
+		b.WriteString("| Group | Ceiling | Rationale | Notes |\n|---|---|---|---|\n")
+		for _, g := range r.Excluded {
+			fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
+				g.Name, g.Ceiling, g.Rationale, orDash(g.Notes))
+		}
+	}
+
+	if unclassified := r.Unclassified(); len(unclassified) > 0 {
+		b.WriteString("\n## Unrecognized method names\n\n")
+		b.WriteString("The SDK uses a naming style this classifier does not know. ")
+		b.WriteString("Worth a look, but not a failure.\n\n")
+		for _, g := range unclassified {
+			fmt.Fprintf(&b, "- `%s`: %s\n", g.Name, methodList(g.Capabilities.Unclassified))
+		}
+	}
+
+	return b.String()
+}
+
+// Text renders a short human-readable summary for terminal use.
+func (r Report) Text(sdkVersion string) string {
+	var b strings.Builder
+
+	if sdkVersion != "" {
+		fmt.Fprintf(&b, "SDK %s\n", sdkVersion)
+	}
+	fmt.Fprintf(&b, "%d/%d covered, %d pending generation, %d excluded, %d need a human\n",
+		len(r.Covered), r.Total(), len(r.Pending), len(r.Excluded), len(r.Unshaped))
+
+	section := func(title string, rows []GroupReport, detail func(GroupReport) string) {
+		if len(rows) == 0 {
+			return
+		}
+		fmt.Fprintf(&b, "\n%s:\n", title)
+		for _, g := range rows {
+			fmt.Fprintf(&b, "  %-24s %s  %s\n", g.Name, g.Capabilities.Summary(), detail(g))
+		}
+	}
+
+	section("Pending generation", r.Pending, func(g GroupReport) string {
+		return strings.Join(g.Generates(), " + ")
+	})
+	section("Too partial to generate", r.Unshaped, func(g GroupReport) string {
+		return g.Capabilities.ShapeHint()
+	})
+	section("Excluded", r.Excluded, func(g GroupReport) string {
+		return string(g.Ceiling) + " / " + string(g.Rationale)
+	})
+	section("Worth revisiting", r.Revisit, func(g GroupReport) string {
+		return "recorded ceiling " + string(g.Ceiling) + ", SDK now offers more"
+	})
+
+	if len(r.Violations) > 0 {
+		fmt.Fprintf(&b, "\n%d violation(s):\n", len(r.Violations))
+		for _, v := range r.Violations {
+			fmt.Fprintf(&b, "  %s\n", v)
+		}
+	}
+
+	return b.String()
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "—"
+	}
+	return s
+}
+
+func codeList(items []string) string {
+	if len(items) == 0 {
+		return "—"
+	}
+	quoted := make([]string, len(items))
+	for i, item := range items {
+		quoted[i] = "`" + item + "`"
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/internal/sdkcoverage/surface.go
+++ b/internal/sdkcoverage/surface.go
@@ -1,0 +1,225 @@
+// Package sdkcoverage reconciles the service groups exposed by the pinned
+// latitudesh-go-sdk against the resources and data sources this provider ships,
+// using a hand-curated manifest as the record of intent.
+//
+// The SDK is Speakeasy-generated: every service group is a struct hanging off
+// the root client, and new platform capability shows up there first. Parsing is
+// purely syntactic (go/ast, no type-checking) so it needs nothing but the module
+// source already in the local module cache.
+package sdkcoverage
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// rootClientType is the SDK's top-level client struct. Its exported fields
+// enumerate every service group the SDK exposes, which makes it the single
+// authoritative starting point for the walk.
+const rootClientType = "Latitudesh"
+
+// maxGroupDepth bounds the nesting walk. The SDK nests exactly one level today
+// (Firewalls.Assignments, Teams.Members, Plans.VM, Projects.SSHKeys); the extra
+// level is slack so a future addition still gets picked up.
+const maxGroupDepth = 3
+
+// Group is one SDK service group together with the exported methods declared on
+// it.
+type Group struct {
+	// Name is the dotted access path from the root client, e.g. "Firewalls" or
+	// "Firewalls.Assignments".
+	Name string
+
+	// TypeName is the Go type backing the group. It usually matches the last
+	// segment of Name, but not always: the field Projects.SSHKeys is typed
+	// LatitudeshProjectsSSHKeys, so methods must be resolved by type, never by
+	// field name.
+	TypeName string
+
+	// Methods are the exported method names on TypeName, sorted.
+	Methods []string
+}
+
+// Surface is the exported service-group surface of one SDK version, keyed by
+// dotted path.
+type Surface struct {
+	Groups map[string]Group
+}
+
+// Names returns the dotted group paths in sorted order.
+func (s Surface) Names() []string {
+	names := make([]string, 0, len(s.Groups))
+	for name := range s.Groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ParseSurface reads every non-test .go file at the root of dir (the SDK's
+// service groups all live in one flat package) and walks the root client struct
+// to build the group graph.
+func ParseSurface(dir string) (Surface, error) {
+	idx, err := indexPackage(dir)
+	if err != nil {
+		return Surface{}, err
+	}
+	if _, ok := idx.structFields[rootClientType]; !ok {
+		return Surface{}, fmt.Errorf("sdkcoverage: root client type %q not found in %s", rootClientType, dir)
+	}
+
+	surface := Surface{Groups: make(map[string]Group)}
+	idx.collectGroups(rootClientType, "", 0, surface.Groups, map[string]bool{})
+	return surface, nil
+}
+
+// structField is an exported pointer-to-struct field, the shape the SDK uses for
+// every service group.
+type structField struct {
+	name     string
+	typeName string
+}
+
+// pkgIndex is the raw syntactic index of one SDK source tree.
+type pkgIndex struct {
+	// structFields maps a struct type name to its exported pointer-to-struct
+	// fields, in declaration order.
+	structFields map[string][]structField
+
+	// methods maps a receiver type name to its exported method names.
+	methods map[string][]string
+}
+
+func indexPackage(dir string) (*pkgIndex, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("sdkcoverage: reading %s: %w", dir, err)
+	}
+
+	idx := &pkgIndex{
+		structFields: make(map[string][]structField),
+		methods:      make(map[string][]string),
+	}
+	fset := token.NewFileSet()
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("sdkcoverage: parsing %s: %w", name, err)
+		}
+		idx.addFile(file)
+	}
+
+	return idx, nil
+}
+
+func (idx *pkgIndex) addFile(file *ast.File) {
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv == nil || d.Name == nil || !d.Name.IsExported() {
+				continue
+			}
+			if recv := receiverTypeName(d.Recv); recv != "" {
+				idx.methods[recv] = append(idx.methods[recv], d.Name.Name)
+			}
+		case *ast.GenDecl:
+			if d.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				idx.structFields[ts.Name.Name] = groupFields(st)
+			}
+		}
+	}
+}
+
+// collectGroups walks the exported pointer-to-struct fields of typeName,
+// recording each one that resolves to a struct in the same package as a group.
+// seen guards against a struct referencing itself or an ancestor (the SDK's
+// groups hold an unexported *Latitudesh back-reference, which is already
+// filtered out, but the guard keeps the walk safe regardless).
+func (idx *pkgIndex) collectGroups(typeName, prefix string, depth int, out map[string]Group, seen map[string]bool) {
+	if depth >= maxGroupDepth || seen[typeName] {
+		return
+	}
+	seen[typeName] = true
+
+	for _, field := range idx.structFields[typeName] {
+		if _, isLocalStruct := idx.structFields[field.typeName]; !isLocalStruct {
+			continue
+		}
+
+		path := field.name
+		if prefix != "" {
+			path = prefix + "." + field.name
+		}
+
+		methods := append([]string(nil), idx.methods[field.typeName]...)
+		sort.Strings(methods)
+		out[path] = Group{Name: path, TypeName: field.typeName, Methods: methods}
+
+		idx.collectGroups(field.typeName, path, depth+1, out, seen)
+	}
+}
+
+// groupFields keeps only exported fields of the form `Name *LocalType`. That
+// excludes the root client's `SDKVersion string`, every unexported field, and
+// qualified types such as `config.SDKConfiguration` (a SelectorExpr, not an
+// Ident).
+func groupFields(st *ast.StructType) []structField {
+	if st.Fields == nil {
+		return nil
+	}
+
+	var fields []structField
+	for _, field := range st.Fields.List {
+		star, ok := field.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		ident, ok := star.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.IsExported() {
+				fields = append(fields, structField{name: name.Name, typeName: ident.Name})
+			}
+		}
+	}
+	return fields
+}
+
+func receiverTypeName(recv *ast.FieldList) string {
+	if recv == nil || len(recv.List) == 0 {
+		return ""
+	}
+	switch t := recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := t.X.(*ast.Ident); ok {
+			return ident.Name
+		}
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}

--- a/internal/sdkcoverage/surface_test.go
+++ b/internal/sdkcoverage/surface_test.go
@@ -1,0 +1,99 @@
+package sdkcoverage
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const miniSDK = "testdata/minisdk"
+
+func TestParseSurfaceFindsTopLevelAndNestedGroups(t *testing.T) {
+	surface, err := ParseSurface(miniSDK)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+
+	want := []string{
+		"BlockStorage",
+		"ElasticIps",
+		"Events",
+		"Firewalls",
+		"Firewalls.Assignments",
+		"Oddities",
+		"Projects",
+		"Projects.SSHKeys",
+		"SSHKeys",
+		"Servers",
+		"Tags",
+		"VirtualMachines",
+		"VirtualNetworks",
+	}
+	if got := surface.Names(); !reflect.DeepEqual(got, want) {
+		t.Errorf("group paths:\n got %v\nwant %v", got, want)
+	}
+}
+
+// The field Projects.SSHKeys is typed LatitudeshProjectsSSHKeys, so anything that
+// resolves methods by field name instead of by type silently reports an empty
+// group. Guard that explicitly.
+func TestParseSurfaceResolvesNestedGroupByTypeNotFieldName(t *testing.T) {
+	surface, err := ParseSurface(miniSDK)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+
+	group, ok := surface.Groups["Projects.SSHKeys"]
+	if !ok {
+		t.Fatal("Projects.SSHKeys not found")
+	}
+	if group.TypeName != "LatitudeshProjectsSSHKeys" {
+		t.Errorf("TypeName = %q, want LatitudeshProjectsSSHKeys", group.TypeName)
+	}
+	if want := []string{"PostProjectSSHKey"}; !reflect.DeepEqual(group.Methods, want) {
+		t.Errorf("methods = %v, want %v", group.Methods, want)
+	}
+
+	// The top-level SSHKeys group is a different type and must not be confused
+	// with the nested one despite sharing a field name.
+	if top := surface.Groups["SSHKeys"]; top.TypeName != "SSHKeys" {
+		t.Errorf("top-level SSHKeys TypeName = %q, want SSHKeys", top.TypeName)
+	}
+}
+
+func TestParseSurfaceSkipsNonGroupFields(t *testing.T) {
+	surface, err := ParseSurface(miniSDK)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+
+	// SDKVersion (a plain string), the unexported sdkConfiguration/hooks fields,
+	// and the unexported back-reference rootSDK must never become groups.
+	for _, name := range []string{"SDKVersion", "sdkConfiguration", "hooks", "rootSDK", "Latitudesh"} {
+		if _, ok := surface.Groups[name]; ok {
+			t.Errorf("%q was collected as a group", name)
+		}
+	}
+}
+
+func TestParseSurfaceSkipsUnexportedMethods(t *testing.T) {
+	surface, err := ParseSurface(miniSDK)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+
+	for _, method := range surface.Groups["VirtualMachines"].Methods {
+		if method == "unexportedShouldBeSkipped" {
+			t.Error("unexported method was collected")
+		}
+	}
+}
+
+func TestParseSurfaceErrorsWithoutRootClient(t *testing.T) {
+	// A directory with no Latitudesh struct means the SDK was restructured; that
+	// has to be a loud error rather than an empty surface, which would make the
+	// gate silently pass.
+	if _, err := ParseSurface(filepath.Join("testdata")); err == nil {
+		t.Fatal("expected an error when the root client type is absent")
+	}
+}

--- a/internal/sdkcoverage/testdata/minisdk/latitudesh.go
+++ b/internal/sdkcoverage/testdata/minisdk/latitudesh.go
@@ -1,0 +1,111 @@
+// A frozen miniature of the latitudesh-go-sdk root package, used to pin the
+// parser and the prefix classifier against the SDK's real naming quirks without
+// depending on any particular version being present in the module cache.
+//
+// This tree lives under testdata/ so the go tool ignores it; it only ever has to
+// be parseable, not buildable.
+package latitudeshgosdk
+
+type Latitudesh struct {
+	SDKVersion string
+
+	VirtualMachines *VirtualMachines
+	SSHKeys         *SSHKeys
+	BlockStorage    *BlockStorage
+	ElasticIps      *ElasticIps
+	Tags            *Tags
+	VirtualNetworks *VirtualNetworks
+	Firewalls       *Firewalls
+	Projects        *Projects
+	Servers         *Servers
+	Events          *Events
+	Oddities        *Oddities
+
+	sdkConfiguration config.SDKConfiguration
+	hooks            *hooks.Hooks
+}
+
+// VirtualMachines mixes bare CRUD with a suffixed Update.
+type VirtualMachines struct {
+	rootSDK *Latitudesh
+}
+
+func (s *VirtualMachines) Create() {}
+func (s *VirtualMachines) List()   {}
+func (s *VirtualMachines) Get()    {}
+func (s *VirtualMachines) Delete() {}
+
+func (s *VirtualMachines) UpdateVirtualMachine()       {}
+func (s *VirtualMachines) ShowVirtualMachineMetrics()  {}
+func (s *VirtualMachines) CreateVirtualMachineAction() {}
+func (s *VirtualMachines) DestroyNetworkAttachment()   {}
+func (s *VirtualMachines) unexportedShouldBeSkipped()  {}
+
+// SSHKeys reads a single key via Retrieve rather than Get.
+type SSHKeys struct {
+	rootSDK *Latitudesh
+}
+
+func (s *SSHKeys) List()              {}
+func (s *SSHKeys) Get()               {}
+func (s *SSHKeys) ListAll()           {}
+func (s *SSHKeys) Create()            {}
+func (s *SSHKeys) Retrieve()          {}
+func (s *SSHKeys) Update()            {}
+func (s *SSHKeys) Delete()            {}
+func (s *SSHKeys) ModifyProjectKey()  {}
+func (s *SSHKeys) RemoveFromProject() {}
+
+// BlockStorage names methods after HTTP verbs and has no update.
+type BlockStorage struct {
+	rootSDK *Latitudesh
+}
+
+func (s *BlockStorage) GetStorageVolumes()       {}
+func (s *BlockStorage) PostStorageVolumes()      {}
+func (s *BlockStorage) GetStorageVolume()        {}
+func (s *BlockStorage) DeleteStorageVolumes()    {}
+func (s *BlockStorage) PostStorageVolumesMount() {}
+
+// ElasticIps mixes "Ips" and "IP" casing within one group.
+type ElasticIps struct {
+	rootSDK *Latitudesh
+}
+
+func (s *ElasticIps) ListElasticIps()  {}
+func (s *ElasticIps) CreateElasticIP() {}
+func (s *ElasticIps) GetElasticIP()    {}
+func (s *ElasticIps) UpdateElasticIP() {}
+func (s *ElasticIps) DeleteElasticIP() {}
+
+// Tags is readable only through List — it has no Get at all.
+type Tags struct {
+	rootSDK *Latitudesh
+}
+
+func (s *Tags) List()   {}
+func (s *Tags) Create() {}
+func (s *Tags) Update() {}
+func (s *Tags) Delete() {}
+
+// VirtualNetworks is a delete-only fragment, not a resource owner.
+type VirtualNetworks struct {
+	rootSDK *Latitudesh
+}
+
+func (s *VirtualNetworks) Delete() {}
+
+// Events is read-only, which maps to a data source rather than a resource.
+type Events struct {
+	rootSDK *Latitudesh
+}
+
+func (s *Events) List() {}
+
+// Oddities carries a method name no prefix rule recognizes.
+type Oddities struct {
+	rootSDK *Latitudesh
+}
+
+func (s *Oddities) FrobnicateWidget() {}
+func (s *Oddities) Get()              {}

--- a/internal/sdkcoverage/testdata/minisdk/nested.go
+++ b/internal/sdkcoverage/testdata/minisdk/nested.go
@@ -1,0 +1,65 @@
+// Second file in the frozen mini SDK, exercising multi-file indexing and the two
+// nested-subgroup shapes the real SDK uses.
+package latitudeshgosdk
+
+// Firewalls nests a subgroup and also flattens some assignment methods onto
+// itself, exactly as the real SDK does.
+type Firewalls struct {
+	Assignments *Assignments
+
+	rootSDK *Latitudesh
+}
+
+func (s *Firewalls) List()                      {}
+func (s *Firewalls) Create()                    {}
+func (s *Firewalls) Get()                       {}
+func (s *Firewalls) Update()                    {}
+func (s *Firewalls) Delete()                    {}
+func (s *Firewalls) ListAssignments()           {}
+func (s *Firewalls) DeleteAssignment()          {}
+func (s *Firewalls) GetAllFirewallAssignments() {}
+
+type Assignments struct {
+	rootSDK *Latitudesh
+}
+
+func (s *Assignments) Create() {}
+
+// Projects nests a subgroup whose field name differs from its type name, so
+// methods must be resolved by type. This is the case that breaks any
+// field-name-based lookup.
+type Projects struct {
+	SSHKeys *LatitudeshProjectsSSHKeys
+
+	rootSDK *Latitudesh
+}
+
+func (s *Projects) List()   {}
+func (s *Projects) Create() {}
+func (s *Projects) Update() {}
+func (s *Projects) Delete() {}
+
+type LatitudeshProjectsSSHKeys struct {
+	rootSDK *Latitudesh
+}
+
+func (s *LatitudeshProjectsSSHKeys) PostProjectSSHKey() {}
+
+// Servers has clean CRUD plus a pile of action methods.
+type Servers struct {
+	rootSDK *Latitudesh
+}
+
+func (s *Servers) List()               {}
+func (s *Servers) Create()             {}
+func (s *Servers) Get()                {}
+func (s *Servers) Update()             {}
+func (s *Servers) Delete()             {}
+func (s *Servers) Lock()               {}
+func (s *Servers) Unlock()             {}
+func (s *Servers) RunAction()          {}
+func (s *Servers) StartRescueMode()    {}
+func (s *Servers) ExitRescueMode()     {}
+func (s *Servers) ScheduleDeletion()   {}
+func (s *Servers) UnscheduleDeletion() {}
+func (s *Servers) Reinstall()          {}

--- a/latitudesh/sdk_coverage_test.go
+++ b/latitudesh/sdk_coverage_test.go
@@ -16,10 +16,16 @@ import (
 // "TestProvider|TestFrameworkProvider"` — the name prefix is load-bearing, so
 // renaming this test would silently drop it from CI.
 //
-// The most valuable case it catches is an SDK bump that adds a service group:
-// that is the moment new platform capability becomes reachable from the provider,
-// and the failure lands in the bump's own PR rather than being noticed months
-// later.
+// It fails only on contradictions: a group the SDK no longer exposes, a Terraform
+// type the manifest does not claim (or claims under a name the provider does not
+// register), or a half-written exclusion. An SDK bump that adds a service group is
+// NOT a failure — an undeclared group is what triggers scaffolding, and failing
+// would block every bump on a product decision its author was never asked to make.
+// Those groups surface in the report instead (`make coverage-report`).
+//
+// It is also blind to changes *within* an already-covered group: only group and
+// method names are parsed, never model fields or signatures. A new field on an
+// existing resource is invisible here.
 func TestProviderSDKCoverage(t *testing.T) {
 	sdkDir, err := sdkcoverage.PinnedModuleDir(sdkcoverage.SDKModulePath)
 	if err != nil {

--- a/latitudesh/sdk_coverage_test.go
+++ b/latitudesh/sdk_coverage_test.go
@@ -1,0 +1,57 @@
+package latitudesh
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
+)
+
+// TestProviderSDKCoverage keeps sdk-coverage.yaml honest about the gap between
+// what latitudesh-go-sdk exposes and what this provider ships.
+//
+// It is a static check: no network, no API token, no TF_ACC. It runs on every PR
+// as part of the existing unit-test step, which matches `-run
+// "TestProvider|TestFrameworkProvider"` — the name prefix is load-bearing, so
+// renaming this test would silently drop it from CI.
+//
+// The most valuable case it catches is an SDK bump that adds a service group:
+// that is the moment new platform capability becomes reachable from the provider,
+// and the failure lands in the bump's own PR rather than being noticed months
+// later.
+func TestProviderSDKCoverage(t *testing.T) {
+	sdkDir, err := sdkcoverage.PinnedModuleDir(sdkcoverage.SDKModulePath)
+	if err != nil {
+		t.Fatalf("resolving the pinned SDK module: %v", err)
+	}
+
+	surface, err := sdkcoverage.ParseSurface(sdkDir)
+	if err != nil {
+		t.Fatalf("parsing the SDK surface at %s: %v", sdkDir, err)
+	}
+
+	manifestPath := filepath.Join("..", sdkcoverage.ManifestFile)
+	manifest, err := sdkcoverage.LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("loading %s: %v", manifestPath, err)
+	}
+
+	ctx := context.Background()
+	shipped := sdkcoverage.ShippedTypeNames(ctx, New("test")(), "latitudesh")
+	if len(shipped) == 0 {
+		t.Fatal("the provider registered no resources or data sources; introspection is broken")
+	}
+
+	report := sdkcoverage.Reconcile(surface, manifest, shipped)
+
+	for _, violation := range report.Violations {
+		t.Errorf("%s", violation)
+	}
+	if !report.OK() {
+		t.Logf("%d SDK service group(s) parsed from %s", len(surface.Groups), sdkDir)
+		t.Logf("%d Terraform type(s) registered by the provider", len(shipped))
+		t.Log("fix the mismatch by updating " + sdkcoverage.ManifestFile +
+			" (see the header comment there for what each status means)")
+	}
+}

--- a/sdk-coverage.yaml
+++ b/sdk-coverage.yaml
@@ -1,0 +1,212 @@
+# Coverage of latitudesh-go-sdk service groups by this Terraform provider.
+#
+# This is an EXCEPTION LIST, not a work queue. A group with no entry here is one we
+# intend to expose, and scaffolding is generated for it automatically. Nothing waits
+# on a human writing a line first.
+#
+# The flow:
+#
+#   1. The SDK exposes a group with no entry.
+#   2. Scaffolding is generated for it — a resource, a data source, or both,
+#      according to the CRUD shape derived from its method names.
+#   3. A draft PR opens. Reviewing real generated code is where the keep-or-drop
+#      decision actually gets made.
+#   4. Merge it and the agent's entry lands in `implemented_by` — the group is
+#      covered. Drop it and record why below, so it stops being regenerated.
+#
+# Derived automatically on every run, never stored here: each group's CRUD shape.
+# So the shapes cannot rot against the SDK.
+#
+# CAVEAT: those shapes come from the SDK, which is generated from the API's OpenAPI
+# spec. When the spec is incomplete the shape understates the real API — verified
+# cases are noted below. Read a shape as a floor, not a ceiling.
+#
+# ## Fields
+#
+# implemented_by  Terraform type names this group backs. Non-empty means covered.
+#                 There is no separate status field: two sources of truth for the
+#                 same fact are free to contradict each other.
+#
+# ceiling         caps how much gets generated. Only on exclusions — "generate
+#                 everything the shape supports" is expressed by having no entry.
+#   none             generate nothing
+#   datasource       a data source is fine, do not generate a resource
+#
+# rationale       why it is capped. Required whenever ceiling is set, and vice
+#                 versa: a cap without a reason is unauditable, a reason without a
+#                 cap does not say how much to stop.
+#   api_constraint    the API does not offer enough to go further
+#   product_decision  we do not want it, whatever the API offers
+#   deprecated        the upstream endpoint is going away
+#
+# notes           context for whoever reviews this group next. Valid on its own —
+#                 an entry with only notes still generates, it just arrives with the
+#                 reviewer already warned.
+#
+# Why rationale matters: it decides whether an exclusion expires. An api_constraint
+# is only true while the API stays put, so the report re-checks it every run and
+# flags groups that have outgrown their ceiling. That flag never fails CI — an API
+# that grew is an opportunity, and whoever bumps the SDK is not who decides product
+# scope. A product_decision is exempt from the check entirely.
+#
+# ## The gate
+#
+# `TestProviderSDKCoverage` fails only on contradictions:
+#   - an entry names a group the SDK no longer exposes (renamed or removed upstream)
+#   - implemented_by names a Terraform type the provider does not register
+#   - the provider registers a type no entry claims
+#   - a ceiling without a rationale, or a rationale without a ceiling
+#   - a covered group that still carries a ceiling or rationale
+#
+# A group with no entry is NOT a failure — that is the generation trigger.
+#
+# Regenerate the raw surface with: go run ./cmd/sdkcoverage groups
+# Render the coverage table with:  make coverage-report
+
+version: 1
+sdk_module: github.com/latitudesh/latitudesh-go-sdk
+
+groups:
+  # ---------------------------------------------------------------- covered ---
+
+  ElasticIps:
+    implemented_by: [latitudesh_elastic_ip]
+
+  Firewalls:
+    implemented_by: [latitudesh_firewall, latitudesh_firewall_assignment]
+    notes: >-
+      Assignment methods are flattened onto this group (ListAssignments,
+      DeleteAssignment) as well as living on Firewalls.Assignments.
+
+  Firewalls.Assignments:
+    implemented_by: [latitudesh_firewall_assignment]
+    notes: Only Create lives here; the read and delete paths are on the parent group.
+
+  Plans:
+    implemented_by: [latitudesh_plan]
+    notes: Data source. UpdateBandwidth is not wired up, hence the -RU- shape.
+
+  PrivateNetworks:
+    implemented_by: [latitudesh_virtual_network, latitudesh_vlan_assignment]
+    notes: >-
+      Owns CRUD for virtual networks and the assignment lifecycle. Neither
+      Terraform type is named private_network.
+
+  Projects:
+    implemented_by: [latitudesh_project]
+
+  Regions:
+    implemented_by: [latitudesh_region]
+    notes: Data source. Reads a single region via Fetch, not Get.
+
+  Roles:
+    implemented_by: [latitudesh_role]
+
+  SSHKeys:
+    implemented_by: [latitudesh_ssh_key]
+    notes: Ships as both a resource and a data source under the same type name.
+
+  Servers:
+    implemented_by: [latitudesh_server]
+    notes: >-
+      Lock/Unlock/Reinstall/GetDeployConfig are folded into the resource's create
+      and update paths rather than exposed separately. The remaining actions
+      (RunAction, rescue mode, IPMI, out-of-band, scheduled deletion) are
+      deliberately not exposed.
+
+  Tags:
+    implemented_by: [latitudesh_tag]
+    notes: Also read by the server and virtual-network resources.
+
+  TeamMembers:
+    implemented_by: [latitudesh_member]
+
+  Teams.Members:
+    implemented_by: [latitudesh_member]
+    notes: Supplies the read path for latitudesh_member via GetTeamMembers.
+
+  UserData:
+    implemented_by: [latitudesh_user_data]
+    notes: Also read by the server resource to hash user-data content.
+
+  VirtualMachines:
+    implemented_by: [latitudesh_virtual_machine]
+    notes: >-
+      Network attachments and metrics are not exposed. Note the update method is
+      UpdateVirtualMachine, not Update.
+
+  VirtualNetworks:
+    implemented_by: [latitudesh_virtual_network]
+    notes: >-
+      Delete-only fragment — PrivateNetworks owns the rest of the lifecycle. The
+      derived ---D shape is expected and is not a gap.
+
+  # --------------------------------------------------------------- excluded ---
+
+  Projects.SSHKeys:
+    ceiling: none
+    rationale: deprecated
+    notes: >-
+      PostProjectSSHKey is marked Deprecated in the SDK, and the API route
+      /projects/:project_id/ssh_keys is deprecated too. Project SSH keys are
+      managed through the SSHKeys group instead.
+
+  Teams:
+    ceiling: none
+    rationale: product_decision
+    notes: >-
+      Team management does not belong in Terraform, not even as a data source.
+      (The API also has no DELETE and no show, so a resource could not be
+      well-formed anyway — but the decision stands regardless of that.)
+
+  VpnSessions:
+    ceiling: none
+    rationale: product_decision
+    notes: >-
+      A VPN session is ephemeral; Terraform state would be stale the moment after
+      apply. Not a Terraform concern whatever the API offers.
+
+  # ------------------------------------------------------------ annotations ---
+  # No ceiling, so these still generate. The notes are here so whoever reviews the
+  # generated PR starts with the context already gathered.
+
+  ObjectStorage:
+    notes: >-
+      The CR-D shape UNDERSTATES the API: PATCH /storage/buckets/:id is routed and
+      implemented but missing from the spec, as are the lifecycle_rules
+      sub-resource, a metrics endpoint, and a bucket-exists check. Scoped
+      previously as PD-6063 and paused pending storage-team spec fixes. Expect the
+      generated resource to lack update support it could have had.
+
+  BlockStorage:
+    notes: >-
+      Methods are HTTP-verb prefixed (PostStorageVolumes, DeleteStorageVolumes) and
+      DeleteStorageVolumes deletes a single volume despite the plural. The API has
+      no volume update, so the CR-D shape is real and not a spec gap.
+
+  FilesystemStorage:
+    notes: >-
+      The API genuinely has no single-item read (confirmed against the routes), so
+      import support needs thought — an API limitation, not a spec gap.
+
+  KubernetesClusters:
+    notes: >-
+      Kubeconfig retrieval and available-version listing would likely want data
+      sources of their own. GET /kubernetes_clusters/plans exists in the API but is
+      absent from the spec, so the SDK has no method for it.
+
+  VirtualMachineBackups:
+    notes: >-
+      VERIFY FIRST: the API checkout reviewed (2026-06-22) has backup domain code
+      but no HTTP routes at all. The SDK exposing this group implies production does
+      have the endpoints, but confirm before merging generated code against them.
+
+  APIKeys:
+    notes: >-
+      Full CRUD, but managing API keys through Terraform means the key material
+      lands in state — weigh that when reviewing.
+
+  Traffic:
+    notes: >-
+      Read-only reporting. The API changes its response shape based on a project
+      feature flag, so a data source needs to handle both.


### PR DESCRIPTION
## Summary

Nothing in the repo connects what `latitudesh-go-sdk` exposes to what the provider
ships, so coverage gaps are only found when someone happens to notice one. This adds
that reconciliation and enforces it in CI.

`internal/sdkcoverage` parses the pinned SDK's service groups straight from the module
cache (`go/ast`, no network, no API token) and derives each group's CRUD shape from its
method names. It reconciles that against the provider's own `Resources()`/`DataSources()`
registration, read at runtime rather than grepped, using `sdk-coverage.yaml` as the
record of intent.

That manifest is an **exception list, not a work queue**. A group with no entry is one we
intend to expose; excluding one means recording a `ceiling` (`none` / `datasource`) and a
`rationale` (`api_constraint` / `product_decision` / `deprecated`). The rationale decides
whether the exclusion expires: an `api_constraint` is re-checked every run and reported
once the SDK grows past it, while a `product_decision` never is. Neither ever fails CI.

Current state: **16 of 33 groups covered, 14 uncovered, 3 excluded.**

`TestProviderSDKCoverage` is the gate. It runs offline in the existing `build` job and is
already picked up by the current `-run "TestProvider|..."` filter, so it needs no workflow
change. It fails only on contradictions — a group renamed or removed upstream, a resource
the manifest does not claim, a half-written exclusion. An undeclared group is *not* a
failure: that is future scaffolding's trigger, and failing would block every SDK bump on a
product decision its author was never asked to make.

### CI changes

- The e2e path filter was `**/*.go`, which meant tooling and docs triggered a suite that
  provisions real infrastructure. Narrowed to the packages that can actually change
  provider behaviour.
- e2e now skips draft PRs. This is about safety, not time: acceptance tests run against the
  live API (the recorder defaults to passthrough and CI never sets
  `LATITUDE_TEST_RECORDER`), so a draft carrying unreviewed code would provision real
  infrastructure. Marking the PR ready triggers it.
- Added an `e2e: skip` label escape hatch and `workflow_dispatch` for deliberate runs.
  Deliberately no scheduled run: the suite costs real money, and a cron would spend it to
  learn nothing on days nobody merged.
- Added a `go test ./internal/sdkcoverage` step. Neither existing test step covered that
  package, so its suite would never have run.

Groundwork for PD-6651, which generates scaffolding for the uncovered groups. No generation
happens here.

## Testing

Everything below is offline and needs no API token.

```sh
go build ./... && go vet ./... && gofmt -l .   # gofmt should list nothing
go test ./internal/sdkcoverage -v              # 59 tests
go test ./latitudesh -run "TestProvider|TestFrameworkProvider" -v   # the gate, as CI runs it
make coverage-report                           # coverage, uncovered groups, exclusions
```

Prove the gate actually fails — edit `sdk-coverage.yaml` and run `make coverage-check` after
each: drop an entry; point an `implemented_by` at a name the provider does not register; set
a `ceiling` with no `rationale`; misspell a key.

Replay it against real SDK history — the module cache holds several versions, and
`VirtualMachineBackups`/`VirtualMachineRestores` were genuinely added between v1.15.0 and
v1.16.13:

```sh
M=~/go/pkg/mod/github.com/latitudesh/latitudesh-go-sdk
go run ./cmd/sdkcoverage check -sdk-dir $M@v1.19.2   # clean
go run ./cmd/sdkcoverage check -sdk-dir $M@v1.9.0    # catches the Storage → Block/Object/Filesystem split
```

Note: `go test ./...` fails on `TestAccServer_ProjectSlugConsistency`, which calls
`testAccProjectSlug(t)` before any `TF_ACC` guard and so hits the live API. Pre-existing and
untouched here — #203 fixes it. CI is unaffected: the `build` job's `-run` filter does not
match it.

## Reviewer notes

- The `test.yml` changes have never executed on GitHub. YAML validity, an unchanged test
  list, and the new step were verified locally, but `if` semantics over `needs`/`github.event`
  only prove out on a real run — this PR is that run. Worth a specific pass over that file:
  a wrong path filter fails silently, by *not* running e2e on someone else's PR.
- Nothing here reaches provider users: no new resource, no schema change, and
  `internal/sdkcoverage` is not linked into the provider binary (`go list -deps .` does not
  include it). The only dependency change is promoting `gopkg.in/yaml.v3` from indirect to
  direct, which `go.sum` shows was already in the graph via `go-vcr`.

Refs PD-6650.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an offline SDK-to-provider coverage reconciliation gate and refines acceptance-test triggering.
- Parses the pinned Latitude.sh SDK service surface and classifies service groups by CRUD capabilities.
- Reconciles SDK groups with registered Terraform resources, data sources, and the coverage exception manifest.
- Adds CLI reporting, validation tests, contributor documentation, and CI enforcement.
- Limits acceptance tests to provider-affecting changes, skips drafts, and supports deliberate manual runs.
- Derives release labels from conventional-commit PR titles.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; both previously reported issues are resolved by removing the stale label-based opt-out and aligning the gate comment with reconciliation behavior.
</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SDK[Pinned SDK module cache] --> Parse[Parse service groups and methods]
    Parse --> Classify[Classify CRUD capabilities]
    Manifest[sdk-coverage.yaml] --> Reconcile[Reconcile coverage]
    Provider[Runtime provider registrations] --> Reconcile
    Classify --> Reconcile
    Reconcile --> Covered[Covered groups]
    Reconcile --> Pending[Pending or unshaped groups]
    Reconcile --> Excluded[Recorded exclusions]
    Reconcile --> Violations[Manifest contradictions]
    Violations --> Gate[TestProviderSDKCoverage]
    Gate --> CI[CI result]
```

<sub>Reviews (4): Last reviewed commit: ["ci: derive changelog labels from commit ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/c6a062211775ac5893ee68de8d280a754ef66649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48803546)</sub>

<!-- /greptile_comment -->