### PR TITLE
feat(plan): expose specs.drives on latitudesh_plan and fix has_gpu false positive

### DIFF
--- a/docs/data-sources/plan.md
+++ b/docs/data-sources/plan.md
@@ -27,8 +27,18 @@ Plan data source - retrieve server plan information
 - `cpu_cores` (Number) Number of CPU cores
 - `cpu_count` (Number) Number of CPUs
 - `cpu_type` (String) CPU type
+- `drives` (Attributes List) Disk groups included in the plan. Sum each group's `count` to derive the total disk count for `latitudesh_server.disk_layout`. (see [below for nested schema](#nestedatt--drives))
 - `features` (List of String) List of plan features
 - `gpu_count` (Number) Number of GPUs if available
 - `gpu_type` (String) GPU type if available
 - `has_gpu` (Boolean) Whether the plan includes GPU
 - `memory` (Number) Total memory
+
+<a id="nestedatt--drives"></a>
+### Nested Schema for `drives`
+
+Read-Only:
+
+- `count` (Number) Number of disks in this group
+- `size` (String) Size of each disk in this group, as free-form text returned by the API (e.g. "1.9 TB", "480GB")
+- `type` (String) Disk type for this group (e.g. SSD, HDD, NVME)

--- a/latitudesh/datasource_plan.go
+++ b/latitudesh/datasource_plan.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
@@ -38,6 +40,58 @@ type PlanDataSourceModel struct {
 	HasGPU   types.Bool    `tfsdk:"has_gpu"`
 	GPUType  types.String  `tfsdk:"gpu_type"`
 	GPUCount types.Float64 `tfsdk:"gpu_count"`
+	Drives   types.List    `tfsdk:"drives"`
+}
+
+// PlanDriveModel is one disk group from a plan's specs.drives array. count is an
+// Int64 to align with latitudesh_server.disk_layout.count, where the value is destined.
+type PlanDriveModel struct {
+	Count types.Int64  `tfsdk:"count"`
+	Size  types.String `tfsdk:"size"`
+	Type  types.String `tfsdk:"type"`
+}
+
+// planDriveObjectType mirrors PlanDriveModel and is used to build the drives list value.
+var planDriveObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"count": types.Int64Type,
+		"size":  types.StringType,
+		"type":  types.StringType,
+	},
+}
+
+// planHasGPU reports whether a plan's specs describe a real GPU. The Plans API
+// returns "gpu":{} (an empty object, not null) for non-GPU plans, so a non-nil
+// *Gpu alone is not enough — at least one payload field must be present.
+func planHasGPU(gpu *components.Gpu) bool {
+	return gpu != nil && (gpu.Type != nil || gpu.Count != nil)
+}
+
+// planDrivesValue maps a plan's specs.drives into a Terraform list value. It
+// always returns a known (possibly empty) list, never null, so downstream
+// `for`/`sum` expressions never iterate over a null value. Count is converted
+// float64 -> int64 to align with latitudesh_server.disk_layout.count, and the
+// strict PlanDataAttributesType enum is rendered back to its string.
+func planDrivesValue(ctx context.Context, drives []components.Drives) (types.List, diag.Diagnostics) {
+	driveModels := make([]PlanDriveModel, 0, len(drives))
+	for _, d := range drives {
+		drive := PlanDriveModel{
+			Count: types.Int64Null(),
+			Size:  types.StringNull(),
+			Type:  types.StringNull(),
+		}
+		if d.Count != nil {
+			drive.Count = types.Int64Value(int64(*d.Count))
+		}
+		if d.Size != nil {
+			drive.Size = types.StringValue(*d.Size)
+		}
+		if d.Type != nil {
+			drive.Type = types.StringValue(string(*d.Type))
+		}
+		driveModels = append(driveModels, drive)
+	}
+	return types.ListValueFrom(ctx, planDriveObjectType, driveModels)
 }
 
 func (d *PlanDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -97,6 +151,26 @@ func (d *PlanDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			"gpu_count": schema.Float64Attribute{
 				MarkdownDescription: "Number of GPUs if available",
 				Computed:            true,
+			},
+			"drives": schema.ListNestedAttribute{
+				MarkdownDescription: "Disk groups included in the plan. Sum each group's `count` to derive the total disk count for `latitudesh_server.disk_layout`.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"count": schema.Int64Attribute{
+							MarkdownDescription: "Number of disks in this group",
+							Computed:            true,
+						},
+						"size": schema.StringAttribute{
+							MarkdownDescription: "Size of each disk in this group, as free-form text returned by the API (e.g. \"1.9 TB\", \"480GB\")",
+							Computed:            true,
+						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Disk type for this group (e.g. SSD, HDD, NVME)",
+							Computed:            true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -171,6 +245,10 @@ func (d *PlanDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.ID = types.StringValue(*plan.ID)
 	}
 
+	// drives defaults to an empty list so `for`/`sum` expressions over it never
+	// iterate a null value, even for plans the API returns without a drives group.
+	data.Drives = types.ListValueMust(planDriveObjectType, []attr.Value{})
+
 	if plan.Attributes != nil {
 		attrs := plan.Attributes
 
@@ -217,8 +295,9 @@ func (d *PlanDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 				data.Memory = types.Float64Value(*specs.Memory.Total)
 			}
 
-			// GPU information
-			if specs.Gpu != nil {
+			// GPU information. gate on planHasGPU because the API returns "gpu":{}
+			// (an empty object, not null) for plans without a GPU.
+			if planHasGPU(specs.Gpu) {
 				data.HasGPU = types.BoolValue(true)
 				if specs.Gpu.Type != nil {
 					data.GPUType = types.StringValue(*specs.Gpu.Type)
@@ -229,6 +308,15 @@ func (d *PlanDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			} else {
 				data.HasGPU = types.BoolValue(false)
 			}
+
+			// Drives (disk groups). Both lookup paths converge on `plan` before this
+			// block, so this single mapping covers lookup-by-id and lookup-by-slug.
+			drivesList, diags := planDrivesValue(ctx, specs.Drives)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			data.Drives = drivesList
 		}
 	}
 

--- a/latitudesh/datasource_plan_offline_test.go
+++ b/latitudesh/datasource_plan_offline_test.go
@@ -1,0 +1,112 @@
+package latitudesh
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+)
+
+// planSpecsGpuEmptyObject is a real GET /plans specs block (c3-large-x86,
+// captured 2026-07-31). The plan has no GPU, yet the API returns "gpu":{}
+// rather than null — the shape that made has_gpu report true for every
+// non-GPU plan (GitHub #205).
+const planSpecsGpuEmptyObject = `{"cpu":{"type":"AMD 7443P","clock":2.85,"cores":24,"count":1},
+  "memory":{"total":256},
+  "drives":[{"count":2,"size":"1.9 TB","type":"NVME"}],
+  "gpu":{}}`
+
+// planSpecsMultiGroupDrives is a real specs block (rs4-metal-xlarge) with two
+// disk groups, exercising the multi-group drive mapping and the float64->int64
+// count conversion.
+const planSpecsMultiGroupDrives = `{"drives":[{"count":2,"size":"480GB","type":"NVME"},{"count":4,"size":"8TB","type":"NVME"}]}`
+
+func TestPlanHasGPU(t *testing.T) {
+	gpuType := "H100"
+	gpuCount := 8.0
+	cases := []struct {
+		name string
+		gpu  *components.Gpu
+		want bool
+	}{
+		{"nil gpu", nil, false},
+		{"empty object (gpu:{})", &components.Gpu{}, false},
+		{"real gpu with type", &components.Gpu{Type: &gpuType}, true},
+		{"real gpu with count", &components.Gpu{Count: &gpuCount}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := planHasGPU(tc.gpu); got != tc.want {
+				t.Errorf("planHasGPU() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlanHasGPUEmptyObjectPayload is the offline regression for the #205
+// has_gpu false positive: the real "gpu":{} payload must unmarshal to a
+// non-nil *Gpu (documenting why the old pointer check was wrong) yet resolve
+// to has_gpu=false.
+func TestPlanHasGPUEmptyObjectPayload(t *testing.T) {
+	var specs components.Specs
+	if err := json.Unmarshal([]byte(planSpecsGpuEmptyObject), &specs); err != nil {
+		t.Fatalf("unmarshaling specs with gpu:{}: %s", err)
+	}
+	if specs.Gpu == nil {
+		t.Fatal("expected non-nil *Gpu for gpu:{} (the whole point of the bug); got nil")
+	}
+	if planHasGPU(specs.Gpu) {
+		t.Error("planHasGPU = true for a plan with gpu:{}; want false")
+	}
+}
+
+func TestPlanDrivesValueMultiGroup(t *testing.T) {
+	ctx := context.Background()
+	var specs components.Specs
+	if err := json.Unmarshal([]byte(planSpecsMultiGroupDrives), &specs); err != nil {
+		t.Fatalf("unmarshaling multi-group drives: %s", err)
+	}
+
+	list, diags := planDrivesValue(ctx, specs.Drives)
+	if diags.HasError() {
+		t.Fatalf("planDrivesValue diagnostics: %v", diags)
+	}
+	if list.IsNull() {
+		t.Fatal("drives list is null; want a known list")
+	}
+
+	var got []PlanDriveModel
+	if d := list.ElementsAs(ctx, &got, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 drive groups, got %d", len(got))
+	}
+	if got[0].Count.ValueInt64() != 2 {
+		t.Errorf("group 0 count = %d, want 2", got[0].Count.ValueInt64())
+	}
+	if got[0].Type.ValueString() != "NVME" {
+		t.Errorf("group 0 type = %q, want NVME", got[0].Type.ValueString())
+	}
+	if got[1].Count.ValueInt64() != 4 {
+		t.Errorf("group 1 count = %d, want 4", got[1].Count.ValueInt64())
+	}
+}
+
+// TestPlanDrivesValueNeverNull guards the "always a list, never null"
+// guarantee so the customer's sum([for d in ... : d.count]) never errors on a
+// null iteratee, even for a plan the API returns with no drives group.
+func TestPlanDrivesValueNeverNull(t *testing.T) {
+	ctx := context.Background()
+	list, diags := planDrivesValue(ctx, nil)
+	if diags.HasError() {
+		t.Fatalf("planDrivesValue(nil) diagnostics: %v", diags)
+	}
+	if list.IsNull() {
+		t.Fatal("planDrivesValue(nil) returned a null list; want an empty known list")
+	}
+	if n := len(list.Elements()); n != 0 {
+		t.Fatalf("planDrivesValue(nil) length = %d, want 0", n)
+	}
+}

--- a/latitudesh/datasource_plan_test.go
+++ b/latitudesh/datasource_plan_test.go
@@ -104,7 +104,15 @@ func TestAccDataSourcePlan(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.latitudesh_plan.slug_with_nvme", "cpu_clock"),
 					resource.TestCheckResourceAttrSet("data.latitudesh_plan.slug_with_nvme", "memory"),
 					resource.TestMatchResourceAttr("data.latitudesh_plan.slug_with_nvme", "features.#", regexp.MustCompile(`^[1-9]\d*$`)),
-					resource.TestCheckResourceAttrSet("data.latitudesh_plan.slug_with_nvme", "has_gpu"),
+					// f4-metal-medium is a metal storage plan with no GPU. Before the
+					// has_gpu fix the API's "gpu":{} made this report true; assert the
+					// explicit value so the regression can't return silently.
+					resource.TestCheckResourceAttr("data.latitudesh_plan.slug_with_nvme", "has_gpu", "false"),
+					// drives is exposed for #205. f4-metal-medium returns multiple disk
+					// groups, so this exercises the multi-group mapping too.
+					resource.TestMatchResourceAttr("data.latitudesh_plan.slug_with_nvme", "drives.#", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestMatchResourceAttr("data.latitudesh_plan.slug_with_nvme", "drives.0.count", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestCheckResourceAttrSet("data.latitudesh_plan.slug_with_nvme", "drives.0.type"),
 				),
 			},
 		},


### PR DESCRIPTION
### Summary

Exposes `specs.drives` on the `latitudesh_plan` data source (GitHub #205) and fixes a
`has_gpu` false positive found in the same code block.

- **`drives`** — computed `list(object({ count, size, type }))`. `count` is Int64 to align
  with `latitudesh_server.disk_layout.count`, its intended consumer. The list is always set
  (empty, never null) so `sum([for d in ... : d.count])` never errors on a null iteratee.
  This unblocks deriving `disk_layout` from a plan's real hardware instead of hardcoding
  slug→disk maps.
- **`has_gpu` fix** — the Plans API returns `"gpu":{}` (empty object, not null) for non-GPU
  plans, so the old `specs.Gpu != nil` check reported `has_gpu = true` for every plan. Now
  gated on the payload (`gpu.type`/`gpu.count`). The acceptance assertion is tightened from
  `TestCheckResourceAttrSet` (passed for both true and false) to an explicit value so the
  bug can't regress silently.

No SDK bump — latitudesh-go-sdk v1.19.x already models `Specs.Drives`. Docs regenerated via
`go generate`.

### Coverage blind spot

The group-level SDK coverage gate (PD-6650) marks `Plans` as covered by `latitudesh_plan`,
but it tracks SDK *methods*, not response *fields* — so an unmapped `specs.drives` never
tripped it. This is a customer-reported instance of that field-level blind spot, filed one
week after the gate shipped green. Field-level coverage remains a planned follow-up.

### Testing

Offline (no token):

```sh
go build ./... && go vet ./... && gofmt -l .
go test ./latitudesh -run 'TestPlanHasGPU|TestPlanDrivesValue|TestProvider|TestFrameworkProvider'
go generate ./... && git diff --exit-code docs/
```

Acceptance (token required) — passed against the live API:

```sh
TF_ACC=1 LATITUDESH_AUTH_TOKEN=... go test ./latitudesh -run 'TestAccDataSourcePlan$' -v -timeout 20m
```

Refs #205
Jira: https://megaportcloud.atlassian.net/browse/PD-6677

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR exposes plan drive groups as a known, computed nested list and corrects GPU detection for the API’s empty-object representation.

- Adds `specs.drives` mapping with integer counts, sizes, and drive types.
- Treats `gpu:{}` as a non-GPU plan while preserving populated GPU metadata.
- Adds offline and acceptance regression coverage and regenerates the data-source documentation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The new schema, Terraform model, object element types, API mapping, defaults, and regression tests are internally consistent, and the GPU predicate handles the demonstrated empty-object payload.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(plan): expose specs.drives on latit..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/335a1cf70982ee781da6df3471893cb6c5e52ba6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50120652)</sub>

<!-- /greptile_comment -->