### PR TITLE
fix(server): stable interface ordering to prevent inconsistent-result error

### DIFF
--- a/latitudesh/helpers_server.go
+++ b/latitudesh/helpers_server.go
@@ -26,14 +26,6 @@ func listIfaces(vals []attr.Value) (types.List, diag.Diagnostics) {
 	return types.ListValue(ifaceType, vals)
 }
 
-// buildInterfacesList converts the API interface slice into a Terraform list
-// with a canonical, deterministic order. The API does not guarantee a stable
-// ordering between reads, and `interfaces` is a Computed list, so an unsorted
-// list makes index positions meaningless: on the next apply Terraform compares
-// interfaces[N] from state against a possibly-reshuffled read and raises
-// "Provider produced inconsistent result after apply" on interfaces[N].mac_address.
-// Sorting by (name, mac_address, description) pins each interface to a stable
-// position regardless of how the API returns them.
 func buildInterfacesList(ifaces []components.Interfaces) (types.List, diag.Diagnostics) {
 	if len(ifaces) == 0 {
 		return emptyIfaces(), nil
@@ -61,9 +53,6 @@ func buildInterfacesList(ifaces []components.Interfaces) (types.List, diag.Diagn
 	return listIfaces(objs)
 }
 
-// ifaceSortKey builds a total-order key from the interface fields. The NUL
-// separator keeps the fields from bleeding into each other (e.g. so "ab"+"c"
-// and "a"+"bc" sort distinctly).
 func ifaceSortKey(iface components.Interfaces) string {
 	return derefString(iface.Name) + "\x00" + derefString(iface.MacAddress) + "\x00" + derefString(iface.Description)
 }

--- a/latitudesh/helpers_server.go
+++ b/latitudesh/helpers_server.go
@@ -1,9 +1,12 @@
 package latitudesh
 
 import (
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 )
 
 var ifaceType = types.ObjectType{
@@ -21,6 +24,55 @@ func emptyIfaces() types.List {
 
 func listIfaces(vals []attr.Value) (types.List, diag.Diagnostics) {
 	return types.ListValue(ifaceType, vals)
+}
+
+// buildInterfacesList converts the API interface slice into a Terraform list
+// with a canonical, deterministic order. The API does not guarantee a stable
+// ordering between reads, and `interfaces` is a Computed list, so an unsorted
+// list makes index positions meaningless: on the next apply Terraform compares
+// interfaces[N] from state against a possibly-reshuffled read and raises
+// "Provider produced inconsistent result after apply" on interfaces[N].mac_address.
+// Sorting by (name, mac_address, description) pins each interface to a stable
+// position regardless of how the API returns them.
+func buildInterfacesList(ifaces []components.Interfaces) (types.List, diag.Diagnostics) {
+	if len(ifaces) == 0 {
+		return emptyIfaces(), nil
+	}
+
+	sorted := make([]components.Interfaces, len(ifaces))
+	copy(sorted, ifaces)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return ifaceSortKey(sorted[i]) < ifaceSortKey(sorted[j])
+	})
+
+	objs := make([]attr.Value, 0, len(sorted))
+	for _, iface := range sorted {
+		obj, diags := types.ObjectValue(ifaceType.AttrTypes, map[string]attr.Value{
+			"name":        optionalString(iface.Name),
+			"mac_address": optionalString(iface.MacAddress),
+			"description": optionalString(iface.Description),
+		})
+		if diags.HasError() {
+			return types.ListNull(ifaceType), diags
+		}
+		objs = append(objs, obj)
+	}
+
+	return listIfaces(objs)
+}
+
+// ifaceSortKey builds a total-order key from the interface fields. The NUL
+// separator keeps the fields from bleeding into each other (e.g. so "ab"+"c"
+// and "a"+"bc" sort distinctly).
+func ifaceSortKey(iface components.Interfaces) string {
+	return derefString(iface.Name) + "\x00" + derefString(iface.MacAddress) + "\x00" + derefString(iface.Description)
+}
+
+func derefString(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+	return *ptr
 }
 
 func optionalString(ptr *string) types.String {

--- a/latitudesh/helpers_server_test.go
+++ b/latitudesh/helpers_server_test.go
@@ -1,0 +1,45 @@
+package latitudesh
+
+import (
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+)
+
+func strPtr(s string) *string { return &s }
+
+// buildInterfacesList must produce a stable, deterministic ordering regardless
+// of the order the API returns the interfaces in. Without a canonical sort the
+// provider raises "Provider produced inconsistent result after apply" on
+// .interfaces[N].mac_address whenever any update re-reads the server and the
+// API happens to reshuffle the list.
+func TestBuildInterfacesList_StableOrderRegardlessOfInput(t *testing.T) {
+	a := components.Interfaces{Name: strPtr("eth0"), MacAddress: strPtr("90:5a:08:16:db:04")}
+	b := components.Interfaces{Name: strPtr("eth1"), MacAddress: strPtr("90:5a:08:2d:d6:8b")}
+
+	forward, diags := buildInterfacesList([]components.Interfaces{a, b})
+	if diags.HasError() {
+		t.Fatalf("forward build errored: %v", diags)
+	}
+	reversed, diags := buildInterfacesList([]components.Interfaces{b, a})
+	if diags.HasError() {
+		t.Fatalf("reversed build errored: %v", diags)
+	}
+
+	if !forward.Equal(reversed) {
+		t.Fatalf("interface ordering is not stable across input orders:\n forward=%s\nreversed=%s", forward, reversed)
+	}
+}
+
+func TestBuildInterfacesList_Empty(t *testing.T) {
+	list, diags := buildInterfacesList(nil)
+	if diags.HasError() {
+		t.Fatalf("nil build errored: %v", diags)
+	}
+	if list.IsNull() || list.IsUnknown() {
+		t.Fatalf("expected a known empty list, got null/unknown")
+	}
+	if len(list.Elements()) != 0 {
+		t.Fatalf("expected 0 elements, got %d", len(list.Elements()))
+	}
+}

--- a/latitudesh/helpers_server_test.go
+++ b/latitudesh/helpers_server_test.go
@@ -8,11 +8,6 @@ import (
 
 func strPtr(s string) *string { return &s }
 
-// buildInterfacesList must produce a stable, deterministic ordering regardless
-// of the order the API returns the interfaces in. Without a canonical sort the
-// provider raises "Provider produced inconsistent result after apply" on
-// .interfaces[N].mac_address whenever any update re-reads the server and the
-// API happens to reshuffle the list.
 func TestBuildInterfacesList_StableOrderRegardlessOfInput(t *testing.T) {
 	a := components.Interfaces{Name: strPtr("eth0"), MacAddress: strPtr("90:5a:08:16:db:04")}
 	b := components.Interfaces{Name: strPtr("eth1"), MacAddress: strPtr("90:5a:08:2d:d6:8b")}

--- a/latitudesh/helpers_server_test.go
+++ b/latitudesh/helpers_server_test.go
@@ -3,10 +3,52 @@ package latitudesh
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 )
 
 func strPtr(s string) *string { return &s }
+
+// buildInterfacesListUnsorted reproduces the pre-fix behavior: build the list in
+// raw API order with no sort. Used only to prove the bug existed.
+func buildInterfacesListUnsorted(ifaces []components.Interfaces) types.List {
+	objs := make([]attr.Value, 0, len(ifaces))
+	for _, iface := range ifaces {
+		obj, _ := types.ObjectValue(ifaceType.AttrTypes, map[string]attr.Value{
+			"name":        optionalString(iface.Name),
+			"mac_address": optionalString(iface.MacAddress),
+			"description": optionalString(iface.Description),
+		})
+		objs = append(objs, obj)
+	}
+	list, _ := listIfaces(objs)
+	return list
+}
+
+// TestBuildInterfacesList_BeforeAfter shows the same interfaces returned in two
+// different orders. The old unsorted build produces different lists (which is
+// what triggers "inconsistent result after apply"); the fixed build does not.
+func TestBuildInterfacesList_BeforeAfter(t *testing.T) {
+	a := components.Interfaces{Name: strPtr("eth0"), MacAddress: strPtr("90:5a:08:16:db:04")}
+	b := components.Interfaces{Name: strPtr("eth1"), MacAddress: strPtr("90:5a:08:2d:d6:8b")}
+
+	forwardIn := []components.Interfaces{a, b}
+	reversedIn := []components.Interfaces{b, a}
+
+	// Before: raw API order — the two reads disagree, so interfaces[1].mac_address
+	// flips between applies.
+	if buildInterfacesListUnsorted(forwardIn).Equal(buildInterfacesListUnsorted(reversedIn)) {
+		t.Fatal("before: expected unsorted builds to differ across input orders, but they matched")
+	}
+
+	// After: sorted — the two reads agree, so no inconsistency.
+	fwd, _ := buildInterfacesList(forwardIn)
+	rev, _ := buildInterfacesList(reversedIn)
+	if !fwd.Equal(rev) {
+		t.Fatalf("after: expected sorted builds to match, but they differ:\n forward=%s\nreversed=%s", fwd, rev)
+	}
+}
 
 func TestBuildInterfacesList_StableOrderRegardlessOfInput(t *testing.T) {
 	a := components.Interfaces{Name: strPtr("eth0"), MacAddress: strPtr("90:5a:08:16:db:04")}

--- a/latitudesh/resource_server.go
+++ b/latitudesh/resource_server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -1416,31 +1415,7 @@ func (r *ServerResource) readServer(ctx context.Context, data *ServerResourceMod
 		}
 
 		if attrs.Interfaces != nil {
-			var ifaceObjs []attr.Value
-
-			for _, iface := range attrs.Interfaces {
-				var nameVal, macVal, descVal attr.Value
-
-				nameVal = optionalString(iface.Name)
-				macVal = optionalString(iface.MacAddress)
-				descVal = optionalString(iface.Description)
-
-				obj, _ := types.ObjectValue(
-					map[string]attr.Type{
-						"name":        types.StringType,
-						"mac_address": types.StringType,
-						"description": types.StringType,
-					},
-					map[string]attr.Value{
-						"name":        nameVal,
-						"mac_address": macVal,
-						"description": descVal,
-					},
-				)
-				ifaceObjs = append(ifaceObjs, obj)
-			}
-
-			list, diags2 := listIfaces(ifaceObjs)
+			list, diags2 := buildInterfacesList(attrs.Interfaces)
 			diags.Append(diags2...)
 			data.Interfaces = list
 		} else {


### PR DESCRIPTION
## Problem

Users hit this on any `latitudesh_server` update (e.g. renaming a tag `env:prod` → `env_prod`):

```
Error: Provider produced inconsistent result after apply
... .interfaces[1].mac_address: was cty.StringVal("90:5a:08:16:db:04"),
    but now cty.StringVal("90:5a:08:2d:d6:8b").
```

It clears on a re-run, which is the tell-tale sign of non-deterministic list ordering.

## Root cause

`interfaces` is a `Computed` list with the `UseStateForUnknown` plan modifier, so at **plan** time Terraform reuses the interface list from prior state. At **apply** time the provider re-read the server and rebuilt the list by ranging over `attrs.Interfaces` **in raw API order** — the API does not guarantee a stable order between reads. When the order shifts, `interfaces[N]` maps to a different physical NIC than it did in state, so its `mac_address` differs and Terraform rejects the apply.

The trigger is unrelated to interfaces — *any* update forces an apply that re-reads them, which is why a tag rename reproduces it.

## Fix

Extract the interface-building logic into `buildInterfacesList` and sort by `(name, mac_address, description)` before constructing the list, pinning each interface to a stable index regardless of API return order. Plan and post-apply now agree.

## Tests

- `TestBuildInterfacesList_StableOrderRegardlessOfInput` — same interfaces in reversed input order produce an identical list (reproduces the bug; fails without the sort).
- `TestBuildInterfacesList_Empty` — nil/empty input yields a known empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR canonicalizes server interface ordering before writing API responses into Terraform state, preventing nondeterministic API ordering from causing inconsistent post-apply results.
- Extracts interface conversion into `buildInterfacesList`.
- Sorts interfaces by name, MAC address, and description without mutating the API response slice.
- Adds coverage for reversed API input and empty interface collections.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security failures identified.

The server read path now converts interfaces through a deterministic ordering helper, preserving the computed-list state contract across API responses returned in different orders.
</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Latitude API interfaces] --> COPY[Copy interface slice]
  COPY --> SORT[Sort by name, MAC, description]
  SORT --> VALUES[Build Terraform objects]
  VALUES --> STATE[Write deterministic interface list to state]
```

<sub>Reviews (1): Last reviewed commit: ["fix(server): sort interfaces for stable ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/90008ac2b7e7eff7a5f246492846d012f83284ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56815002)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Dedicated server resource lifecycle](https://app.greptile.com/latitude-sh/-/custom-context/knowledge-base/latitudesh/terraform-provider-latitudesh/-/docs/server-resource.md)
- Knowledge Base — [Compute provisioning and lifecycle](https://app.greptile.com/latitude-sh/-/custom-context/knowledge-base/latitudesh/terraform-provider-latitudesh/-/docs/compute-lifecycle.md)
- Knowledge Base — [Restore consistent server status and rate-limit handling](https://app.greptile.com/latitude-sh/-/custom-context/knowledge-base/latitudesh/terraform-provider-latitudesh/-/reverts/incident-mitigation_181-20260509-status-retry-985e51f.md)
</details>


<!-- /greptile_comment -->