### PR TITLE
feat(sdkcoverage): JSON delta report + weekly sdk-watch workflow

### DIFF
--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -1,0 +1,306 @@
+name: "SDK coverage watch"
+
+# Phase 1 of the auto-scaffolding pipeline: on a weekly cadence (or on demand),
+# reconcile the *latest* published latitudesh-go-sdk against what this provider
+# ships and keep a single tracking issue up to date with the groups that have no
+# coverage yet. This job never spends money and never writes code — detection is
+# the $0 path, and it stays that way by construction (no Anthropic key is present
+# in any job here). The scaffolding agent that turns a pending group into a draft
+# PR is added to this same file in a later PR.
+on:
+  # Weekly is enough: a new SDK service group is rare (2 in 29 releases), and the
+  # acceptance criterion is a delta surfaced within 7 days.
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      group:
+        description: "Single SDK group to scaffold (consumed by the scaffold job added later; ignored by detection)."
+        required: false
+        default: ""
+      dry_run:
+        description: "Render the tracking issue to the run summary without creating or editing anything."
+        required: false
+        type: boolean
+        default: false
+  # Inert until the SDK repository is wired to send this event (a later PR). It is
+  # declared now so turning it on there is a one-line change in the SDK repo, not
+  # an edit to this workflow.
+  repository_dispatch:
+    types: [sdk-release]
+
+# Read-only by default. The one job that needs to write issues elevates its own
+# permissions; keeping the default minimal means a new job cannot quietly gain
+# write access.
+permissions:
+  contents: read
+
+# Never run two of these at once (a manual dispatch on top of the cron), so the
+# tracking issue is not upserted twice concurrently. Do not cancel a run in
+# flight — a half-finished issue edit is worse than waiting.
+concurrency:
+  group: sdk-scaffold
+  cancel-in-progress: false
+
+jobs:
+  # Reconcile the latest SDK against the provider and emit the coverage report as
+  # JSON. No API token, no Anthropic key: this analyzes source in the module cache.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      pending: ${{ steps.report.outputs.pending }}
+      pinned: ${{ steps.resolve.outputs.pinned }}
+      latest: ${{ steps.resolve.outputs.latest }}
+      pinned_check_ok: ${{ steps.pinned_check.outputs.ok }}
+    steps:
+      # Every action here is pinned to an immutable commit SHA: this workflow's
+      # sibling job writes issues, so a mutable tag would let reviewed action code
+      # change underneath us without any change to this repository.
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "^1.23.0"
+
+      - name: Resolve pinned and latest SDK versions
+        id: resolve
+        env:
+          SDK_MODULE: github.com/latitudesh/latitudesh-go-sdk
+        run: |
+          set -euo pipefail
+          pinned=$(go list -m -f '{{.Version}}' "$SDK_MODULE")
+          latest=$(go list -m -versions -json "$SDK_MODULE" | jq -r '.Versions[-1] // empty')
+          if [ -z "$latest" ]; then
+            echo "::error::could not resolve the latest version of $SDK_MODULE"
+            exit 1
+          fi
+          echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "Pinned $pinned, latest $latest"
+
+      - name: Report coverage against the latest SDK
+        id: report
+        env:
+          SDK_MODULE: github.com/latitudesh/latitudesh-go-sdk
+          LATEST: ${{ steps.resolve.outputs.latest }}
+        run: |
+          set -euo pipefail
+          # Parse the latest SDK straight from the module cache. This never edits
+          # go.mod: the provider is still built against the pinned SDK, and only
+          # the surface parser reads the newer source via -sdk-dir. That is how a
+          # new group is detected without committing to the bump.
+          dir=$(go mod download -json "$SDK_MODULE@$LATEST" | jq -r '.Dir')
+          if [ -z "$dir" ] || [ "$dir" = "null" ]; then
+            echo "::error::could not download $SDK_MODULE@$LATEST"
+            exit 1
+          fi
+          go run ./cmd/sdkcoverage report -format json -sdk-dir "$dir" > report.json
+          pending=$(jq -r '.counts.pending' report.json)
+          echo "pending=$pending" >> "$GITHUB_OUTPUT"
+          echo "$pending group(s) pending against $LATEST"
+
+      - name: Check the pinned SDK for contradictions
+        id: pinned_check
+        # Advisory here, not fatal: a contradiction on the pinned SDK is already a
+        # unit-test failure on every PR, so failing this job would only suppress
+        # the tracking issue the run exists to publish. Surface it in the issue
+        # instead. (main has no required checks, so this weekly pass is a genuine
+        # backstop.)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if go run ./cmd/sdkcoverage check > pinned_check.txt 2>&1; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::pinned SDK has coverage contradictions; see the tracking issue"
+          fi
+          cat pinned_check.txt
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sdk-coverage-report
+          path: |
+            report.json
+            pinned_check.txt
+          retention-days: 14
+          # v4 artifacts are immutable per run (not per attempt): without this,
+          # "Re-run all jobs" hits a 409 on the attempt-1 artifact and the retry
+          # dies before reaching whatever actually failed.
+          overwrite: true
+
+  # Upsert one fixed tracking issue from the report. Separated from detect so the
+  # write-scoped token lives only where issues are actually edited.
+  issue:
+    needs: detect
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # This job never checks out the repo, so gh has no git remote to infer the
+      # repository from — without GH_REPO every gh call below fails.
+      GH_REPO: ${{ github.repository }}
+      TRACKING_LABEL: sdk-coverage
+      MARKER: "<!-- sdk-coverage-tracking -->"
+      PENDING: ${{ needs.detect.outputs.pending }}
+      PINNED: ${{ needs.detect.outputs.pinned }}
+      LATEST: ${{ needs.detect.outputs.latest }}
+      PINNED_CHECK_OK: ${{ needs.detect.outputs.pinned_check_ok }}
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sdk-coverage-report
+
+      - name: Build the issue body
+        run: |
+          set -euo pipefail
+          {
+            echo "$MARKER"
+            echo "# SDK coverage: ${PENDING} group(s) pending generation"
+            echo
+            echo "_Generated by \`.github/workflows/sdk-watch.yml\`. Edits are overwritten on the next run._"
+            echo
+            echo "Pinned SDK: \`${PINNED}\`. Latest published: \`${LATEST}\`."
+            echo
+            counts=$(jq -r '.counts | "\(.covered) of \(.total) service groups covered — \(.pending) pending, \(.excluded) excluded, \(.unshaped) too partial to generate."' report.json)
+            echo "$counts"
+
+            if [ "${PINNED_CHECK_OK}" = "false" ]; then
+              echo
+              echo "> [!WARNING]"
+              echo "> The pinned SDK (\`${PINNED}\`) has coverage contradictions. This normally fails a PR's unit tests; seeing it here means something reached \`main\` unchecked. Fix \`sdk-coverage.yaml\` and/or the provider registration."
+            fi
+
+            # Violations against the LATEST SDK never fail a PR (nothing pins that
+            # version yet), so this issue is the only place they surface. Ignoring
+            # them would present a renamed or removed group as ordinary pending work.
+            latest_violations=$(jq -r '.counts.violations' report.json)
+            if [ "$latest_violations" -gt 0 ]; then
+              echo
+              echo "> [!WARNING]"
+              echo "> Reconciling the latest SDK (\`${LATEST}\`) reports ${latest_violations} violation(s) — usually a group renamed or removed upstream. The pending list below may be incomplete or mislabeled until \`sdk-coverage.yaml\` catches up:"
+              echo
+              jq -r '.violations[] | "> - " + (if (.group // "") != "" then "`" + .group + "`: " else "" end) + .message' report.json
+            fi
+
+            echo
+            echo "## Pending generation"
+            echo
+            if [ "${PENDING}" -eq 0 ]; then
+              echo "None — every SDK service group is either covered or explicitly excluded. 🎉"
+            else
+              echo "Each group below is exposed by latitudesh-go-sdk but not by this provider. Scaffolding produces a resource, a data source, or both, per the derived CRUD shape. Reviewing that generated PR is where the keep-or-drop call is made; to drop one, record a \`ceiling\` + \`rationale\` for its group in \`sdk-coverage.yaml\`."
+              echo
+              jq -r '
+                .pending[]
+                | "- [ ] `\(.group)` → `\(.suggested_type_name)` — `\(.crud)`, generates \(.generates | join(" + "))"
+                  + (if (.notes // "") != "" then "\n  - " + (.notes | gsub("\\s+";" ") | ltrimstr(" ")) else "" end)
+              ' report.json
+            fi
+
+            revisit=$(jq -r '.counts.revisit' report.json)
+            if [ "$revisit" -gt 0 ]; then
+              echo
+              echo "## Worth revisiting"
+              echo
+              echo "Excluded on API grounds, but the SDK has since grown past the recorded ceiling. Not urgent — re-triage when convenient."
+              echo
+              jq -r '.revisit[] | "- `\(.group)` — recorded ceiling `\(.ceiling)`, now `\(.crud)`"' report.json
+            fi
+
+            echo
+            echo "## Open scaffold PRs"
+            echo
+            # A failed listing must not read as "None open." — that would claim a
+            # clean slate exactly when we know nothing.
+            if prs=$(gh pr list --label scaffold --state open --json number,title,url --jq '.[] | "- #\(.number) [\(.title)](\(.url))"'); then
+              if [ -n "$prs" ]; then
+                echo "$prs"
+              else
+                echo "None open."
+              fi
+            else
+              echo "_Could not list scaffold PRs — check the workflow run log._"
+            fi
+
+            echo
+            echo "## Housekeeping"
+            echo
+            echo "A scaffold PR closed without merging is parked until \`sdk-coverage.yaml\` records a \`ceiling\` + \`rationale\` for its group — otherwise the next run just regenerates it."
+          } > body.md
+
+          echo "----- issue body -----"
+          cat body.md
+          echo "----------------------"
+
+      - name: Render only (dry run)
+        if: env.DRY_RUN == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dry run — tracking issue not modified"
+            echo
+            cat body.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ensure the tracking label exists
+        if: env.DRY_RUN != 'true'
+        run: |
+          gh label create "$TRACKING_LABEL" \
+            --color 0e8a16 \
+            --description "Auto-scaffolding: SDK groups the provider does not yet cover" \
+            2>/dev/null || true
+
+      - name: Upsert the tracking issue
+        if: env.DRY_RUN != 'true'
+        run: |
+          set -euo pipefail
+          # Oldest marker-carrying issue wins: gh returns newest-first, so taking
+          # .[0] as-is would let any newer labeled issue displace the long-lived
+          # tracker and fragment its history.
+          existing=$(gh issue list --label "$TRACKING_LABEL" --state open --limit 100 \
+            --json number,body --jq \
+            "map(select(.body | contains(\"$MARKER\"))) | sort_by(.number) | .[0].number // empty")
+
+          title="SDK coverage: ${PENDING} group(s) pending generation"
+          violations=$(jq -r '.counts.violations' report.json)
+          if [ "$violations" -gt 0 ]; then
+            title="SDK coverage: ${PENDING} pending, ${violations} violation(s) against ${LATEST}"
+          fi
+          if [ "${PINNED_CHECK_OK}" != "true" ]; then
+            title="${title} — pinned SDK check failing"
+          fi
+
+          # Close only when there is truly nothing to report: zero pending, a
+          # clean latest reconcile, AND a passing pinned check. The pinned check
+          # is this run's backstop — main has no required status checks, so a
+          # contradiction that reached it unchecked surfaces nowhere else; closing
+          # over it would bury the one warning this workflow exists to keep
+          # visible. Anything but an explicit "true" (including an empty output
+          # from a broken step) keeps the issue open.
+          if [ "${PENDING}" -eq 0 ] && [ "$violations" -eq 0 ] && [ "${PINNED_CHECK_OK}" = "true" ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "All SDK service groups are now covered or excluded as of \`${LATEST}\`. Closing; a future run opens a fresh tracking issue if a coverage gap reappears."
+              gh issue close "$existing"
+              echo "Closed tracking issue #$existing"
+            else
+              echo "Nothing pending and no open tracking issue — done."
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --title "$title" --body-file body.md
+            echo "Updated tracking issue #$existing"
+          else
+            gh issue create --title "$title" --label "$TRACKING_LABEL" --body-file body.md
+            echo "Created a new tracking issue"
+          fi

--- a/cmd/sdkcoverage/main.go
+++ b/cmd/sdkcoverage/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/latitudesh"
@@ -44,7 +45,7 @@ func run(args []string) error {
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	manifestPath := flags.String("manifest", defaultManifestPath(), "path to the coverage manifest")
 	sdkDir := flags.String("sdk-dir", "", "SDK source directory (defaults to the pinned module in the module cache)")
-	format := flags.String("format", "", "report format: markdown or text (report only)")
+	format := flags.String("format", "", "report format: markdown, text, or json (report only)")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
 	}
@@ -72,7 +73,7 @@ func usage() {
 flags:
   -manifest path   coverage manifest (default: sdk-coverage.yaml at the repo root)
   -sdk-dir path    SDK source directory (default: pinned module in the module cache)
-  -format fmt      markdown (default) or text, for report
+  -format fmt      markdown (default), text, or json, for report
 `)
 }
 
@@ -115,10 +116,16 @@ func runReport(manifestPath, sdkDir, format string) error {
 		fmt.Print(report.Text(version))
 	case "", "markdown":
 		fmt.Print(report.Markdown(version))
+	case "json":
+		data, err := report.JSON(version, providerTypeName)
+		if err != nil {
+			return fmt.Errorf("sdkcoverage: rendering JSON report: %w", err)
+		}
+		fmt.Println(string(data))
 	default:
 		// Falling back to markdown here would hand automation a different format
 		// than it asked for, and report success while doing it.
-		return fmt.Errorf("unsupported report format %q (want markdown or text)", format)
+		return fmt.Errorf("unsupported report format %q (want markdown, text, or json)", format)
 	}
 	return nil
 }
@@ -163,7 +170,15 @@ func reconcile(manifestPath, sdkDir string) (sdkcoverage.Report, string, error) 
 	ctx := context.Background()
 	shipped := sdkcoverage.ShippedTypeNames(ctx, latitudesh.New("dev")(), providerTypeName)
 
-	return sdkcoverage.Reconcile(surface, manifest, shipped), filepath.Base(dir), nil
+	// Module-cache directories are named module@version; keep only the version so
+	// the reports show the same string `go list -m` prints and automation can
+	// compare it directly. A hand-picked -sdk-dir basename passes through as-is.
+	version := filepath.Base(dir)
+	if at := strings.LastIndex(version, "@"); at >= 0 {
+		version = version[at+1:]
+	}
+
+	return sdkcoverage.Reconcile(surface, manifest, shipped), version, nil
 }
 
 func loadSurface(sdkDir string) (sdkcoverage.Surface, string, error) {

--- a/cmd/sdkcoverage/main.go
+++ b/cmd/sdkcoverage/main.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/latitudesh"
@@ -170,15 +169,7 @@ func reconcile(manifestPath, sdkDir string) (sdkcoverage.Report, string, error) 
 	ctx := context.Background()
 	shipped := sdkcoverage.ShippedTypeNames(ctx, latitudesh.New("dev")(), providerTypeName)
 
-	// Module-cache directories are named module@version; keep only the version so
-	// the reports show the same string `go list -m` prints and automation can
-	// compare it directly. A hand-picked -sdk-dir basename passes through as-is.
-	version := filepath.Base(dir)
-	if at := strings.LastIndex(version, "@"); at >= 0 {
-		version = version[at+1:]
-	}
-
-	return sdkcoverage.Reconcile(surface, manifest, shipped), version, nil
+	return sdkcoverage.Reconcile(surface, manifest, shipped), sdkcoverage.VersionFromDir(dir), nil
 }
 
 func loadSurface(sdkDir string) (sdkcoverage.Surface, string, error) {

--- a/internal/sdkcoverage/json.go
+++ b/internal/sdkcoverage/json.go
@@ -1,0 +1,110 @@
+package sdkcoverage
+
+import "encoding/json"
+
+// jsonReport is the machine-readable coverage document. It is the contract the
+// sdk-watch workflow reads: `jq '.pending | length'` gates whether there is
+// anything to scaffold, and each pending entry carries the suggested Terraform
+// type name so the tracking issue and the scaffold job need no naming logic of
+// their own. Keep the field names stable — automation depends on them.
+type jsonReport struct {
+	SDKModule  string          `json:"sdk_module"`
+	SDKVersion string          `json:"sdk_version,omitempty"`
+	OK         bool            `json:"ok"`
+	Counts     jsonCounts      `json:"counts"`
+	Violations []jsonViolation `json:"violations"`
+
+	// Pending is the generation queue: groups with no manifest entry whose shape
+	// supports scaffolding. This is the array automation acts on.
+	Pending []jsonGroup `json:"pending"`
+
+	// Unshaped and Revisit are informational — surfaced so the tracking issue can
+	// report them, never acted on automatically.
+	Unshaped []jsonGroup `json:"unshaped"`
+	Revisit  []jsonGroup `json:"revisit"`
+}
+
+type jsonCounts struct {
+	Total      int `json:"total"`
+	Covered    int `json:"covered"`
+	Pending    int `json:"pending"`
+	Excluded   int `json:"excluded"`
+	Unshaped   int `json:"unshaped"`
+	Revisit    int `json:"revisit"`
+	Violations int `json:"violations"`
+}
+
+type jsonViolation struct {
+	// Group is empty for violations that concern a Terraform type with no owning
+	// group.
+	Group   string `json:"group,omitempty"`
+	Message string `json:"message"`
+}
+
+type jsonGroup struct {
+	Group             string   `json:"group"`
+	CRUD              string   `json:"crud"`
+	Generates         []string `json:"generates,omitempty"`
+	Methods           []string `json:"methods"`
+	SuggestedTypeName string   `json:"suggested_type_name"`
+	// Ceiling is set only on Revisit rows, where the recorded cap is what the SDK
+	// has now outgrown.
+	Ceiling string `json:"ceiling,omitempty"`
+	Notes   string `json:"notes,omitempty"`
+}
+
+// JSON renders the report as an indented JSON document. providerTypeName is the
+// prefix every suggested type name carries.
+func (r Report) JSON(sdkVersion, providerTypeName string) ([]byte, error) {
+	doc := jsonReport{
+		SDKModule:  SDKModulePath,
+		SDKVersion: sdkVersion,
+		OK:         r.OK(),
+		Counts: jsonCounts{
+			Total:      r.Total(),
+			Covered:    len(r.Covered),
+			Pending:    len(r.Pending),
+			Excluded:   len(r.Excluded),
+			Unshaped:   len(r.Unshaped),
+			Revisit:    len(r.Revisit),
+			Violations: len(r.Violations),
+		},
+		Violations: toJSONViolations(r.Violations),
+		Pending:    toJSONGroups(r.Pending, providerTypeName),
+		Unshaped:   toJSONGroups(r.Unshaped, providerTypeName),
+		Revisit:    toJSONGroups(r.Revisit, providerTypeName),
+	}
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+func toJSONViolations(violations []Violation) []jsonViolation {
+	// A non-nil empty slice so the JSON is a stable [] rather than null, which
+	// keeps jq filters simple on the consuming side.
+	out := make([]jsonViolation, 0, len(violations))
+	for _, v := range violations {
+		out = append(out, jsonViolation{Group: v.Group, Message: v.Message})
+	}
+	return out
+}
+
+func toJSONGroups(rows []GroupReport, providerTypeName string) []jsonGroup {
+	out := make([]jsonGroup, 0, len(rows))
+	for _, g := range rows {
+		// A methodless group has nil Methods; normalize so "arrays are never
+		// null" holds for every array in the document, not just the top-level ones.
+		methods := g.Methods
+		if methods == nil {
+			methods = []string{}
+		}
+		out = append(out, jsonGroup{
+			Group:             g.Name,
+			CRUD:              g.Capabilities.Summary(),
+			Generates:         g.Generates(),
+			Methods:           methods,
+			SuggestedTypeName: SuggestTypeName(g.Name, providerTypeName),
+			Ceiling:           string(g.Ceiling),
+			Notes:             g.Notes,
+		})
+	}
+	return out
+}

--- a/internal/sdkcoverage/json_test.go
+++ b/internal/sdkcoverage/json_test.go
@@ -1,0 +1,104 @@
+package sdkcoverage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestReportJSONContract pins the shape automation relies on: stable field names,
+// a suggested type name on every pending entry, counts that match the buckets,
+// and arrays that serialize as [] rather than null so jq filters stay simple.
+func TestReportJSONContract(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"Servers":         {"Create", "Get", "Delete"},
+		"ManagedDatabase": {"CreateDatabase", "GetDatabase", "DeleteDatabase"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {ImplementedBy: []string{"latitudesh_server"}},
+	}}
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	data, err := report.JSON("v1.2.3", "latitudesh")
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+
+	var doc struct {
+		SDKModule  string `json:"sdk_module"`
+		SDKVersion string `json:"sdk_version"`
+		OK         bool   `json:"ok"`
+		Counts     struct {
+			Total   int `json:"total"`
+			Covered int `json:"covered"`
+			Pending int `json:"pending"`
+		} `json:"counts"`
+		Violations []any `json:"violations"`
+		Pending    []struct {
+			Group             string   `json:"group"`
+			CRUD              string   `json:"crud"`
+			Generates         []string `json:"generates"`
+			Methods           []string `json:"methods"`
+			SuggestedTypeName string   `json:"suggested_type_name"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, data)
+	}
+
+	if doc.SDKModule != SDKModulePath {
+		t.Errorf("sdk_module = %q, want %q", doc.SDKModule, SDKModulePath)
+	}
+	if doc.SDKVersion != "v1.2.3" {
+		t.Errorf("sdk_version = %q, want v1.2.3", doc.SDKVersion)
+	}
+	if !doc.OK {
+		t.Errorf("ok = false, want true for a clean reconcile")
+	}
+	if doc.Counts.Total != 2 || doc.Counts.Covered != 1 || doc.Counts.Pending != 1 {
+		t.Errorf("counts = %+v, want total 2 / covered 1 / pending 1", doc.Counts)
+	}
+	if len(doc.Pending) != 1 {
+		t.Fatalf("pending has %d entries, want 1", len(doc.Pending))
+	}
+
+	got := doc.Pending[0]
+	if got.Group != "ManagedDatabase" {
+		t.Errorf("pending group = %q, want ManagedDatabase", got.Group)
+	}
+	if got.SuggestedTypeName != "latitudesh_managed_database" {
+		t.Errorf("suggested_type_name = %q, want latitudesh_managed_database", got.SuggestedTypeName)
+	}
+	if got.CRUD != "CR-D" {
+		t.Errorf("crud = %q, want CR-D", got.CRUD)
+	}
+}
+
+// A non-nil empty slice must marshal to [] so `jq '.pending | length'` never trips
+// over null on a fully covered SDK.
+func TestReportJSONEmptyArraysAreNotNull(t *testing.T) {
+	surface := surfaceOf(map[string][]string{
+		"Servers": {"Create", "Get", "Delete"},
+	})
+	manifest := Manifest{Groups: map[string]Entry{
+		"Servers": {ImplementedBy: []string{"latitudesh_server"}},
+	}}
+	report := Reconcile(surface, manifest, []string{"latitudesh_server"})
+
+	data, err := report.JSON("", "latitudesh")
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Require the key to be present AND exactly [] — a "not null" check alone
+	// would also pass if the field were dropped from the document entirely.
+	for _, key := range []string{"violations", "pending", "unshaped", "revisit"} {
+		got, ok := raw[key]
+		if !ok || string(got) != "[]" {
+			t.Errorf("%s = %q, want a present, empty []", key, got)
+		}
+	}
+}

--- a/internal/sdkcoverage/naming.go
+++ b/internal/sdkcoverage/naming.go
@@ -1,0 +1,110 @@
+package sdkcoverage
+
+import "strings"
+
+// SuggestTypeName proposes the Terraform type name for an SDK service group, e.g.
+// "APIKeys" -> "latitudesh_api_key". It is a starting point for the scaffolding
+// agent and the tracking issue, never the final word: the mapping is genuinely
+// many-to-many (PrivateNetworks backs two types, TeamMembers ships as
+// latitudesh_member), so a human editing the generated PR is where the real name
+// gets decided.
+//
+// The rule is mechanical and predictable: split the dotted path into segments,
+// split each segment into words (aware of acronym runs like API/IP/SSH),
+// singularize the last word of each segment, lowercase everything and join with
+// underscores, then prefix the provider name.
+func SuggestTypeName(groupName, providerTypeName string) string {
+	var words []string
+	for _, segment := range strings.Split(groupName, ".") {
+		segWords := splitWords(segment)
+		if len(segWords) > 0 {
+			last := len(segWords) - 1
+			segWords[last] = singularize(segWords[last])
+		}
+		words = append(words, segWords...)
+	}
+
+	for i, w := range words {
+		words[i] = strings.ToLower(w)
+	}
+
+	snake := strings.Join(words, "_")
+	if snake == "" {
+		return providerTypeName
+	}
+	return providerTypeName + "_" + snake
+}
+
+// splitWords breaks a CamelCase/PascalCase identifier into words, keeping runs of
+// uppercase letters together as a single acronym: "APIKeys" -> ["API", "Keys"],
+// "IPAddresses" -> ["IP", "Addresses"], "VpnSessions" -> ["Vpn", "Sessions"].
+func splitWords(s string) []string {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return nil
+	}
+
+	var words []string
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		prev, cur := runes[i-1], runes[i]
+		var next rune
+		if i+1 < len(runes) {
+			next = runes[i+1]
+		}
+
+		boundary := false
+		switch {
+		// A lowercase (or digit) followed by an uppercase starts a new word:
+		// the "I" in "elasticIps".
+		case !isUpper(prev) && isUpper(cur):
+			boundary = true
+		// The end of an acronym run: UPPER UPPER lower splits before the second
+		// uppercase, so "APIKeys" breaks into "API" and "Keys" rather than
+		// "APIK" and "eys".
+		case isUpper(prev) && isUpper(cur) && next != 0 && isLower(next):
+			boundary = true
+		}
+
+		if boundary {
+			words = append(words, string(runes[start:i]))
+			start = i
+		}
+	}
+	return append(words, string(runes[start:]))
+}
+
+// singularize turns the plural head noun of a group name into its singular form.
+// It handles just the patterns the SDK's group names actually use — this is a
+// naming hint, not a linguistics engine, so an odd result is corrected by the
+// reviewer, not worked around here.
+func singularize(word string) string {
+	lower := strings.ToLower(word)
+
+	switch {
+	case len(lower) > 3 && strings.HasSuffix(lower, "ies"):
+		// Policies -> Policy
+		return word[:len(word)-3] + "y"
+	case hasAnySuffix(lower, "sses", "shes", "ches", "xes", "zes", "ses"):
+		// Addresses -> Address, Boxes -> Box
+		return word[:len(word)-2]
+	case strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss"):
+		// Keys -> Key, Firewalls -> Firewall; "ss" endings (none today) stay put.
+		return word[:len(word)-1]
+	default:
+		// Data, Storage, Traffic, VM: no plural to strip.
+		return word
+	}
+}
+
+func hasAnySuffix(s string, suffixes ...string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(s, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isUpper(r rune) bool { return r >= 'A' && r <= 'Z' }
+func isLower(r rune) bool { return r >= 'a' && r <= 'z' }

--- a/internal/sdkcoverage/naming_test.go
+++ b/internal/sdkcoverage/naming_test.go
@@ -1,0 +1,65 @@
+package sdkcoverage
+
+import "testing"
+
+// TestSuggestTypeName pins the suggested name for every service group the pinned
+// SDK exposes today. These are hints, not the final names — several real
+// resources are deliberately named otherwise (TeamMembers ships as
+// latitudesh_member) — so this test guards the mechanical rule, not product
+// intent. If an SDK bump adds a group, add a row here.
+func TestSuggestTypeName(t *testing.T) {
+	cases := []struct {
+		group string
+		want  string
+	}{
+		{"APIKeys", "latitudesh_api_key"},
+		{"BaselinesPreview", "latitudesh_baselines_preview"},
+		{"Billing", "latitudesh_billing"},
+		{"BlockStorage", "latitudesh_block_storage"},
+		{"ElasticIps", "latitudesh_elastic_ip"},
+		{"Events", "latitudesh_event"},
+		{"FilesystemStorage", "latitudesh_filesystem_storage"},
+		{"Firewalls", "latitudesh_firewall"},
+		{"Firewalls.Assignments", "latitudesh_firewall_assignment"},
+		{"IPAddresses", "latitudesh_ip_address"},
+		{"KubernetesClusters", "latitudesh_kubernetes_cluster"},
+		{"ObjectStorage", "latitudesh_object_storage"},
+		{"OperatingSystems", "latitudesh_operating_system"},
+		{"Plans", "latitudesh_plan"},
+		{"Plans.VM", "latitudesh_plan_vm"},
+		{"PrivateNetworks", "latitudesh_private_network"},
+		{"Projects", "latitudesh_project"},
+		{"Projects.SSHKeys", "latitudesh_project_ssh_key"},
+		{"PublicNetworks", "latitudesh_public_network"},
+		{"Regions", "latitudesh_region"},
+		{"Roles", "latitudesh_role"},
+		{"SSHKeys", "latitudesh_ssh_key"},
+		{"Servers", "latitudesh_server"},
+		{"Tags", "latitudesh_tag"},
+		{"TeamMembers", "latitudesh_team_member"},
+		{"Teams", "latitudesh_team"},
+		{"Teams.Members", "latitudesh_team_member"},
+		{"Traffic", "latitudesh_traffic"},
+		{"UserData", "latitudesh_user_data"},
+		{"UserProfile", "latitudesh_user_profile"},
+		{"VirtualMachineBackups", "latitudesh_virtual_machine_backup"},
+		{"VirtualMachineRestores", "latitudesh_virtual_machine_restore"},
+		{"VirtualMachines", "latitudesh_virtual_machine"},
+		{"VirtualNetworks", "latitudesh_virtual_network"},
+		{"VpnSessions", "latitudesh_vpn_session"},
+	}
+
+	for _, tc := range cases {
+		if got := SuggestTypeName(tc.group, "latitudesh"); got != tc.want {
+			t.Errorf("SuggestTypeName(%q) = %q, want %q", tc.group, got, tc.want)
+		}
+	}
+}
+
+// The provider prefix is a parameter, not a constant baked into the name, so the
+// same rule serves a tool that reports for a differently named provider.
+func TestSuggestTypeNameHonorsProviderPrefix(t *testing.T) {
+	if got := SuggestTypeName("Servers", "example"); got != "example_server" {
+		t.Errorf("SuggestTypeName with custom prefix = %q, want example_server", got)
+	}
+}

--- a/internal/sdkcoverage/version.go
+++ b/internal/sdkcoverage/version.go
@@ -1,0 +1,23 @@
+package sdkcoverage
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// VersionFromDir derives the version string reports display from the SDK
+// source directory. Module-cache directories are named module@version, so the
+// suffix after "@" is kept only when it actually looks like one — Go module
+// versions always start with "v" followed by a digit. Any other basename,
+// including a hand-picked -sdk-dir that happens to contain "@" (or end with
+// it), passes through whole: truncating it would report something that was
+// never a version, and a trailing "@" would erase the metadata entirely.
+func VersionFromDir(dir string) string {
+	base := filepath.Base(dir)
+	if at := strings.LastIndex(base, "@"); at >= 0 {
+		if v := base[at+1:]; len(v) >= 2 && v[0] == 'v' && v[1] >= '0' && v[1] <= '9' {
+			return v
+		}
+	}
+	return base
+}

--- a/internal/sdkcoverage/version_test.go
+++ b/internal/sdkcoverage/version_test.go
@@ -1,0 +1,29 @@
+package sdkcoverage
+
+import "testing"
+
+func TestVersionFromDir(t *testing.T) {
+	cases := []struct {
+		dir  string
+		want string
+	}{
+		// Module-cache entries normalize to the bare version go list prints.
+		{"/home/u/go/pkg/mod/github.com/latitudesh/latitudesh-go-sdk@v1.19.12", "v1.19.12"},
+		{"latitudesh-go-sdk@v1.19.14-rc.1", "v1.19.14-rc.1"},
+		{"sdk@v2.0.0+incompatible", "v2.0.0+incompatible"},
+
+		// Hand-picked -sdk-dir basenames are not module-cache entries: never
+		// truncate them into something that was never a version, and never let a
+		// trailing "@" blank the field (markdown/text suppress an empty version
+		// and JSON omits sdk_version entirely).
+		{"/tmp/sdk@work", "sdk@work"},
+		{"/tmp/sdk@vendored", "sdk@vendored"},
+		{"/tmp/sdk@", "sdk@"},
+		{"/tmp/checkout", "checkout"},
+	}
+	for _, tc := range cases {
+		if got := VersionFromDir(tc.dir); got != tc.want {
+			t.Errorf("VersionFromDir(%q) = %q, want %q", tc.dir, got, tc.want)
+		}
+	}
+}

--- a/latitudesh/sdk_coverage_test.go
+++ b/latitudesh/sdk_coverage_test.go
@@ -12,9 +12,9 @@ import (
 // what latitudesh-go-sdk exposes and what this provider ships.
 //
 // It is a static check: no network, no API token, no TF_ACC. It runs on every PR
-// as part of the existing unit-test step, which matches `-run
-// "TestProvider|TestFrameworkProvider"` — the name prefix is load-bearing, so
-// renaming this test would silently drop it from CI.
+// in CI as part of `go test ./latitudesh` (the "Run Unit Tests" step, which no
+// longer filters by name), so the whole package is exercised and this test is
+// picked up automatically rather than by a load-bearing name prefix.
 //
 // It fails only on contradictions: a group the SDK no longer exposes, a Terraform
 // type the manifest does not claim (or claims under a name the provider does not


### PR DESCRIPTION
### Summary

Completes the coverage detector and adds the weekly SDK-watch workflow.

- `sdkcoverage report -format json`: stable machine-readable delta (counts, violations, `pending[]` with CRUD shape, methods, and a suggested Terraform type name).
- `SuggestTypeName`: acronym-aware snake_case + singularization (`APIKeys` → `latitudesh_api_key`), table-tested against every current SDK group.
- `.github/workflows/sdk-watch.yml`: weekly cron + `workflow_dispatch` (+ inert `repository_dispatch`). The `detect` job reconciles the latest published SDK against the provider without touching `go.mod` — no Anthropic key involved, so the no-delta path costs $0. The `issue` job upserts a single tracking issue with a per-group checklist. The scaffold job and the `repository_dispatch` wiring land in follow-ups (DX-23 / DX-24).
- Hardened per review: actions pinned to immutable SHAs; the tracking issue surfaces latest-SDK violations and only closes on a clean reconcile.

Fixes DX-22.

### Testing

```bash
go test ./internal/sdkcoverage ./latitudesh
go run ./cmd/sdkcoverage report -format json | jq .counts
```

Verified against the latest SDK (v1.19.14), which surfaces a real new group: `MarketplaceApps` → `latitudesh_marketplace_app`, with `go.mod` untouched.






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a stable JSON SDK-coverage report, type-name suggestions, version labeling, and a scheduled workflow that reconciles the latest SDK and maintains a tracking issue.
- Adds JSON report structures and contract tests.
- Adds acronym-aware naming and version-display helpers.
- Adds a weekly/manual SDK-watch workflow with pinned actions and issue reconciliation.
- Updates the provider coverage-test documentation for the current CI invocation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(sdkcoverage): keep explicit sdk-dir ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/268bd1e341698e2940fd22e52f66f08eb6e9175c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57162889)</sub>

<!-- /greptile_comment -->