### PR TITLE
feat(scaffold): add the sdk-watch scaffold job (agent, gate, draft PR)

### DIFF
--- a/.github/prompts/scaffold-resource.md
+++ b/.github/prompts/scaffold-resource.md
@@ -1,5 +1,5 @@
 ---
-prompt-version: 2
+prompt-version: 5
 ---
 
 # Scaffold Terraform support for a latitudesh-go-sdk service group
@@ -34,6 +34,21 @@ different task with a different review.
 
 Notes of `none` mean nobody has looked at this group yet — not that it is clean.
 Derive the shape from the SDK and record what you find.
+
+## Turn budget
+
+You have a hard cap of {{MAX_TURNS}} turns; a clean pass fits well under it.
+Spend them like money:
+
+- Read only the exemplar files the conventions table points at for obligations
+  you actually have.
+- Batch independent `go doc` lookups instead of one call per symbol.
+- Run the full gate at most twice: once after your first complete draft, once
+  after fixing what it reported.
+- You cannot see a turn counter, so do not try to pace yourself — instead, keep
+  `/tmp/scaffold-handoff.md` current from your first draft onwards (see the
+  Finish section). A turn-capped session emits no final message; that file is
+  the only handoff that survives, and the gate decides whether the PR opens.
 
 ## Confirm every SDK symbol — never guess
 
@@ -129,6 +144,13 @@ only has to compile; a human runs it. Use the existing helpers:
 `testAccCheck<Name>Destroy` built on `newSDKClientFromEnv()`, and
 `testAccSharedServers(t, n)` if you need a server.
 
+**Plain `go test ./latitudesh` — no `TF_ACC`, no token — must stay green with
+your tests included; the gate runs exactly that.** Anything that could reach the
+API (`testAccSharedServers`, raw SDK clients, anything that provisions) belongs
+inside `resource.Test`'s callbacks — `PreCheck`, `Steps`, config funcs — which
+self-skip without `TF_ACC`. Never call it eagerly in the test function body: an
+eager call runs on every contributor's `go test` and fails the gate.
+
 Do not run acceptance tests and do not record cassettes. Cassettes live in
 `latitudesh/fixtures/<TestName>.yaml` and a human records them with
 `LATITUDE_TEST_RECORDER=record`; most newer resources have none and run live.
@@ -149,16 +171,24 @@ Do not run acceptance tests and do not record cassettes. Cassettes live in
 ## Hard rules
 
 - Touch only: `latitudesh/{resource,datasource,action}_*.go`, `latitudesh/*_test.go`,
-  `latitudesh/provider.go`, `sdk-coverage.yaml`, `templates/**`, `examples/**`, `docs/**`.
-  Not `go.mod`, not `cmd/`, not `internal/`, not `.github/`.
+  `latitudesh/provider.go`, `sdk-coverage.yaml`, `templates/**`, `examples/**`, `docs/**` —
+  plus the handoff file `/tmp/scaffold-handoff.md`, which is the one write allowed
+  outside the repository. Not `go.mod`, not `cmd/`, not `internal/`, not `.github/`.
 - Never add a `go:generate` directive.
 - Never reach the network, provision infrastructure, run acceptance tests, or record cassettes.
 - Never write a token, key, or secret anywhere.
 - Never hand-edit `docs/` — edit the template and regenerate.
 
-## Finish: gate, then handoff
+## Finish: handoff file, then gate
 
-Run the gate and fix what it reports:
+**As soon as your first complete draft builds, write the full handoff block
+(below) to `/tmp/scaffold-handoff.md` with the Write tool, and update the file
+whenever you learn something new.** This file is your insurance: a session that
+hits the turn cap emits no final message at all, and the pipeline then reads the
+handoff from this file. It lives outside the repo tree on purpose — never write
+it inside the repository.
+
+Then run the gate and fix what it reports:
 
 ```
 scripts/scaffold-validate.sh --group {{GROUP}} --type-name {{TF_NAME}} --kinds "{{KINDS}}"
@@ -169,9 +199,9 @@ is well-formed: gofmt, vet, build, offline tests, coverage reconcile, docs
 regenerate clean, and every requested kind registered with its file, template,
 example and tests.
 
-`PASS` does **not** mean correct. End your run with this block, filled in. Write
-"none" only where genuinely nothing applies — the reviewer reads this before the
-diff.
+`PASS` does **not** mean correct. End your final message with the same block,
+filled in. Write "none" only where genuinely nothing applies — the reviewer
+reads this before the diff.
 
 ```markdown
 ## Handoff — not verified offline

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -1,12 +1,12 @@
 name: "SDK coverage watch"
 
-# Phase 1 of the auto-scaffolding pipeline: on a weekly cadence (or on demand),
-# reconcile the *latest* published latitudesh-go-sdk against what this provider
-# ships and keep a single tracking issue up to date with the groups that have no
-# coverage yet. This job never spends money and never writes code — detection is
-# the $0 path, and it stays that way by construction (no Anthropic key is present
-# in any job here). The scaffolding agent that turns a pending group into a draft
-# PR is added to this same file in a later PR.
+# The auto-scaffolding pipeline: on a weekly cadence (or on demand), reconcile
+# the *latest* published latitudesh-go-sdk against what this provider ships,
+# keep a single tracking issue up to date with the groups that have no coverage
+# yet, and turn the top pending group into a draft PR through the scaffolding
+# agent. Detection is the $0 path and stays that way by construction: the
+# Anthropic key exists only in the scaffold job, which is skipped entirely when
+# there is nothing to scaffold.
 on:
   # Weekly is enough: a new SDK service group is rare (2 in 29 releases), and the
   # acceptance criterion is a delta surfaced within 7 days.
@@ -15,11 +15,11 @@ on:
   workflow_dispatch:
     inputs:
       group:
-        description: "Single SDK group to scaffold (consumed by the scaffold job added later; ignored by detection)."
+        description: "Single SDK group to scaffold, overriding top-of-queue selection (ignored by detection). Also the retry channel for a parked group."
         required: false
         default: ""
       dry_run:
-        description: "Render the tracking issue to the run summary without creating or editing anything."
+        description: "Render the tracking issue to the run summary without creating or editing anything, and skip the scaffold job."
         required: false
         type: boolean
         default: false
@@ -306,3 +306,467 @@ jobs:
             gh issue create --title "$title" --label "$TRACKING_LABEL" --body-file body.md
             echo "Created a new tracking issue"
           fi
+
+  # Turn ONE pending group into a draft PR. One group per run keeps prompts
+  # small, failures attributable, and manifest/provider.go conflicts between
+  # sibling scaffold PRs structurally rare; the open-PR cap keeps the reviewer's
+  # plate full without flooding. This is the only job that can see the Anthropic
+  # key, and it never runs on an empty queue — the $0-on-no-delta guarantee is
+  # structural, not behavioral.
+  scaffold:
+    needs: detect
+    # Real work only, on a sane pinned manifest, never on a dry run. A
+    # contradicted manifest means the coverage ledger is lying, and scaffolding
+    # on top of it risks double-implementing a group.
+    if: >-
+      github.event.inputs.dry_run != 'true' &&
+      needs.detect.outputs.pending != '0' &&
+      needs.detect.outputs.pinned_check_ok == 'true'
+    runs-on: ubuntu-latest
+    # 60, not 45: the agent step alone may take its full 30 and the Go
+    # builds/gate around it are not free. A job-level timeout is a cancellation,
+    # which skips every failure() handler — it must stay slack, the step
+    # timeouts are the real budget.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      # Dedupe reads PR labels with the default token. Pushing, opening the PR,
+      # and labeling it use the GitHub App token instead — a PR created with the
+      # default GITHUB_TOKEN would never trigger test.yml (so the draft would sit
+      # with no checks), and `gh pr edit --add-label` is a PR mutation the
+      # read-scoped default token cannot perform.
+      pull-requests: read
+      issues: write
+    env:
+      # Deliberately NOT job-level GH_TOKEN: the agent step inherits job env, and
+      # the allowlisted go commands compile and run code the agent just wrote —
+      # handing that step a GitHub token would gift-wrap it for exfiltration.
+      # Steps that call gh set GH_TOKEN in their own env instead.
+      GH_REPO: ${{ github.repository }}
+      SDK_MODULE: github.com/latitudesh/latitudesh-go-sdk
+      LATEST: ${{ needs.detect.outputs.latest }}
+      MAX_OPEN_SCAFFOLD_PRS: "2"
+      # Model policy (DX-23): claude-sonnet-5 default; escalate to opus manually
+      # (workflow_dispatch after a failed run) when a delta is structurally
+      # ambiguous.
+      SCAFFOLD_MODEL: claude-sonnet-5
+      # Keep in sync with MAX_TURNS in scripts/eval-scaffold.sh — the eval only
+      # predicts production while both grant the same budget. The cap is runaway
+      # protection, not a target: measured runs gate-greened by ~50-80 turns and
+      # the agent polishes until killed, so 200 makes truncation rare while the
+      # handoff file makes it harmless. The cost step warns above $6.
+      SCAFFOLD_MAX_TURNS: "200"
+      GIT_BOT_NAME: "latitudesh-sdk-watch[bot]"
+      GIT_BOT_EMAIL: "latitudesh-sdk-watch[bot]@users.noreply.github.com"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # Without this, checkout persists the default token as an
+          # http.extraheader in .git/config, which silently OVERRIDES the app
+          # token embedded in the push URL below — the push would run with the
+          # read-only default token and fail. It would also sit readable in the
+          # workspace during the agent step.
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sdk-coverage-report
+          # NEVER into the workspace: report.json/pinned_check.txt would sit
+          # there as untracked files, and the gate's diff-scope check (which
+          # scans untracked files too) would fail every single run — after the
+          # agent spend, and unfixably, since the agent cannot delete files.
+          path: ${{ runner.temp }}/sdk-coverage
+
+      - name: Select the group to scaffold
+        id: select
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERRIDE: ${{ github.event.inputs.group }}
+        run: |
+          set -euo pipefail
+          # Groups already claimed by an open scaffold PR are never re-picked;
+          # groups whose scaffold PR closed without merging are parked until
+          # sdk-coverage.yaml records a ceiling+rationale for them (or a human
+          # retries explicitly via the `group` input, which is the whole point
+          # of letting the override bypass the parked list — but never an open
+          # claim, which would double-scaffold).
+          claimed=$(gh pr list --label scaffold --state open --json labels \
+            --jq '[.[].labels[].name | select(startswith("scaffold:")) | ltrimstr("scaffold:")] | unique | .[]')
+          parked=$(gh pr list --label scaffold --state closed --limit 100 --json labels,mergedAt \
+            --jq '[.[] | select(.mergedAt == null) | .labels[].name | select(startswith("scaffold:")) | ltrimstr("scaffold:")] | unique | .[]')
+
+          report="$RUNNER_TEMP/sdk-coverage/report.json"
+          pick=""
+          if [ -n "$OVERRIDE" ]; then
+            if ! jq -e --arg g "$OVERRIDE" '.pending[] | select(.group==$g)' "$report" >/dev/null; then
+              echo "::error::requested group '$OVERRIDE' is not in the pending queue against $LATEST"
+              exit 1
+            fi
+            if printf '%s\n' "$claimed" | grep -Fxq "$OVERRIDE"; then
+              echo "::error::an open scaffold PR already claims '$OVERRIDE' — close it before re-running"
+              exit 1
+            fi
+            pick="$OVERRIDE"
+          else
+            open_count=$(gh pr list --label scaffold --state open --json number --jq 'length')
+            if [ "$open_count" -ge "$MAX_OPEN_SCAFFOLD_PRS" ]; then
+              echo "has_work=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::$open_count scaffold PR(s) already open (cap $MAX_OPEN_SCAFFOLD_PRS) — not scaffolding this run"
+              exit 0
+            fi
+            while read -r g; do
+              printf '%s\n' "$claimed" | grep -Fxq "$g" && continue
+              printf '%s\n' "$parked" | grep -Fxq "$g" && continue
+              pick="$g"
+              break
+            done < <(jq -r '.pending[].group' "$report")
+          fi
+
+          if [ -z "$pick" ]; then
+            echo "has_work=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::every pending group is claimed or parked — nothing to scaffold"
+            exit 0
+          fi
+          echo "has_work=true" >> "$GITHUB_OUTPUT"
+          echo "group=$pick" >> "$GITHUB_OUTPUT"
+          echo "Selected: $pick"
+
+      - name: Bump the SDK when the pinned surface lacks the group
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -euo pipefail
+          # Capture first, test second: piping `go run` straight into `jq -e`
+          # would read a crashed report as "group not pending" and bump on top
+          # of a broken tool.
+          pinned_report=$(go run ./cmd/sdkcoverage report -format json)
+          if echo "$pinned_report" | jq -e --arg g "$GROUP" '.pending[] | select(.group==$g)' >/dev/null; then
+            echo "pinned SDK already exposes $GROUP — no bump needed"
+            exit 0
+          fi
+          # The group only exists in the newer SDK. The bump belongs in the
+          # scaffold branch, reviewed together with the code that needs it; the
+          # agent itself is forbidden from touching go.mod, so the workflow
+          # commits the bump first and the gate diffs the agent's work against
+          # that commit.
+          echo "pinned SDK lacks $GROUP — bumping to $LATEST"
+          go get "$SDK_MODULE@$LATEST"
+          go mod tidy
+          # A bump that breaks the build is human work, not agent work: stop
+          # before spending a single token.
+          go build ./...
+          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            commit -m "chore(deps): bump latitudesh-go-sdk to $LATEST" -- go.mod go.sum
+
+      - name: Render the scaffold prompt
+        id: render
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -euo pipefail
+          report=$(go run ./cmd/sdkcoverage report -format json)
+          group_json=$(echo "$report" | jq -c --arg g "$GROUP" '.pending[] | select(.group==$g)')
+          if [ -z "$group_json" ]; then
+            echo "::error::$GROUP is still not pending against the pinned SDK after the bump step"
+            exit 1
+          fi
+          TF_NAME=$(echo "$group_json" | jq -r '.suggested_type_name')
+          KINDS=$(echo "$group_json" | jq -r '.generates | join(", ")')
+          METHODS=$(echo "$group_json" | jq -r '.methods | join(", ")')
+          NOTES=$(echo "$group_json" | jq -r 'if (.notes // "") == "" then "none" else (.notes | gsub("\\s+";" ")) end')
+          SDK_VERSION=$(echo "$report" | jq -r '.sdk_version')
+
+          # A stale handoff from a previous process must never masquerade as this
+          # run's — the PR-body fallback reads this exact path.
+          rm -f /tmp/scaffold-handoff.md
+
+          GROUP="$GROUP" KINDS="$KINDS" TF_NAME="$TF_NAME" METHODS="$METHODS" \
+            NOTES="$NOTES" SDK_VERSION="$SDK_VERSION" MAX_TURNS="$SCAFFOLD_MAX_TURNS" \
+            scripts/render-scaffold-prompt.sh > /tmp/scaffold-prompt.md
+
+          {
+            echo "prompt<<SCAFFOLD_PROMPT_EOF"
+            cat /tmp/scaffold-prompt.md
+            echo "SCAFFOLD_PROMPT_EOF"
+            echo "tf_name=$TF_NAME"
+            echo "kinds=$KINDS"
+            echo "methods=$METHODS"
+            echo "crud=$(echo "$group_json" | jq -r '.crud')"
+            echo "sdk_version=$SDK_VERSION"
+            echo "covered_before=$(echo "$report" | jq -r '.counts.covered')"
+            echo "pending_before=$(echo "$report" | jq -r '.counts.pending')"
+            echo "total_groups=$(echo "$report" | jq -r '.counts.total')"
+            echo "notes<<SCAFFOLD_NOTES_EOF"
+            echo "$NOTES"
+            echo "SCAFFOLD_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run the scaffolding agent
+        id: agent
+        if: steps.select.outputs.has_work == 'true'
+        timeout-minutes: 30
+        # The gate below is the arbiter, not the agent's exit code: an agent
+        # that hits the turn cap after finishing the tree (measured: it happens)
+        # should still ship its draft, and an agent that died early leaves a
+        # tree the gate fails on its own.
+        continue-on-error: true
+        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1.0.207
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Without an explicit token the action's prepare phase falls back to a
+          # GitHub OIDC exchange that needs `id-token: write` plus the Claude
+          # GitHub App, and fails at startup before a single Claude turn. The
+          # deliberately read-scoped default token is enough: agent mode on
+          # schedule/workflow_dispatch performs no comment or branch writes.
+          github_token: ${{ github.token }}
+          prompt: ${{ steps.render.outputs.prompt }}
+          # The allowlist mirrors scripts/eval-scaffold.sh exactly — the eval is
+          # only evidence about production if both grant the same tools. No gh,
+          # no git writes, no network, no free shell: commits and the PR are made
+          # by the deterministic steps below, never by the agent.
+          claude_args: >-
+            --model ${{ env.SCAFFOLD_MODEL }}
+            --max-turns ${{ env.SCAFFOLD_MAX_TURNS }}
+            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
+
+      - name: Report agent cost
+        id: cost
+        if: always() && steps.agent.outcome != 'skipped' && steps.agent.outputs.execution_file != ''
+        env:
+          EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+          # The execution file is either a single result object or an array of
+          # transcript records whose last "result" entry carries the totals.
+          cost=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .total_cost_usd // empty) else (.total_cost_usd // empty) end' "$EXEC_FILE" 2>/dev/null || true)
+          turns=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .num_turns // empty) else (.num_turns // empty) end' "$EXEC_FILE" 2>/dev/null || true)
+          cost=${cost:-unknown}
+          turns=${turns:-unknown}
+          echo "cost=$cost" >> "$GITHUB_OUTPUT"
+          echo "turns=$turns" >> "$GITHUB_OUTPUT"
+          echo "## Scaffold agent: \$${cost}, ${turns} turn(s)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$cost" != "unknown" ] && awk "BEGIN { exit !($cost > 6) }"; then
+            echo "::warning::agent run cost \$${cost} — above the \$6 watermark, review the transcript for thrash"
+          fi
+
+      - name: Validate the scaffold
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+          TF_NAME: ${{ steps.render.outputs.tf_name }}
+          KINDS: ${{ steps.render.outputs.kinds }}
+        run: |
+          set -euo pipefail
+          bash scripts/scaffold-validate.sh --group "$GROUP" --type-name "$TF_NAME" --kinds "$KINDS" --base HEAD
+
+      - name: Mint the installation token
+        id: app
+        if: steps.select.outputs.has_work == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
+          private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
+
+      - name: Push the branch and open the draft PR
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+          TF_NAME: ${{ steps.render.outputs.tf_name }}
+          KINDS: ${{ steps.render.outputs.kinds }}
+          METHODS: ${{ steps.render.outputs.methods }}
+          CRUD: ${{ steps.render.outputs.crud }}
+          SDK_VERSION: ${{ steps.render.outputs.sdk_version }}
+          COVERED_BEFORE: ${{ steps.render.outputs.covered_before }}
+          PENDING_BEFORE: ${{ steps.render.outputs.pending_before }}
+          TOTAL_GROUPS: ${{ steps.render.outputs.total_groups }}
+          NOTES: ${{ steps.render.outputs.notes }}
+          COST: ${{ steps.cost.outputs.cost }}
+          TURNS: ${{ steps.cost.outputs.turns }}
+          EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          short="${TF_NAME#latitudesh_}"
+          branch="scaffold/${short}-${{ github.run_id }}"
+
+          # Commit by explicit pathspec — the gate already proved the diff is in
+          # scope, and adding by name means a stray file could not ride along
+          # even if it were not.
+          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            add -- latitudesh sdk-coverage.yaml templates examples docs
+          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+
+          prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/scaffold-resource.md | head -1)
+          # The handoff is agent-authored free text going into a PR body — cap it
+          # so a runaway or adversarial block cannot balloon the PR description.
+          # It is written via --body-file, never through a shell eval. A
+          # turn-capped session emits no final message, so fall back to the
+          # handoff FILE the prompt has the agent maintain from its first draft.
+          handoff=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .result // "") else (.result // "") end' "$EXEC_FILE" 2>/dev/null | awk '/^## Handoff/{found=1} found' | head -c 8000 || true)
+          if [ -z "$handoff" ] && [ -f /tmp/scaffold-handoff.md ]; then
+            handoff=$(head -c 8000 /tmp/scaffold-handoff.md)
+          fi
+          if [ -z "$handoff" ]; then
+            handoff="_The agent did not emit a handoff block — read the transcript in the run artifacts before reviewing._"
+          fi
+
+          # The tree now carries the scaffold, so a fresh report gives the
+          # after-merge coverage numbers for the summary.
+          after=$(go run ./cmd/sdkcoverage report -format json)
+          covered_after=$(echo "$after" | jq -r '.counts.covered')
+          pending_after=$(echo "$after" | jq -r '.counts.pending')
+
+          methods_md=$(printf '%s' "$METHODS" | sed 's/, /`, `/g; s/^/`/; s/$/`/')
+
+          # Body structure mirrors the Speakeasy generation PRs on
+          # latitudesh-go-sdk (e.g. #130): summary + coverage bump up top, a
+          # keep-or-drop callout, surface changes as bullets, a facts table,
+          # verbose material folded into <details>, attribution footer.
+          {
+            echo "# Provider scaffold"
+            echo
+            echo "## Coverage"
+            echo
+            echo "Coverage Bump: [${COVERED_BEFORE} → ${covered_after} of ${TOTAL_GROUPS} SDK service groups] - 🤖 (automated)"
+            echo
+            echo "> [!TIP]"
+            echo "> Reviewing this draft is where the keep-or-drop decision is made. **Keep it** — merge, and \`$GROUP\` is covered. **Drop it** — close this PR **and** record a \`ceiling\` + \`rationale\` under \`$GROUP\` in \`sdk-coverage.yaml\`, so it stops being regenerated."
+            echo
+            echo "## Provider Changes:"
+            echo
+            echo "* \`$TF_NAME\` — **New** ($KINDS) for SDK group \`$GROUP\`, CRUD shape \`$CRUD\`"
+            echo "* SDK methods on the group: $methods_md"
+            echo "* Registered in \`latitudesh/provider.go\`, with docs template, example, and tests"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| SDK version | \`$SDK_VERSION\` |"
+            echo "| Pending groups | ${PENDING_BEFORE} → ${pending_after} |"
+            echo "| Prompt | \`.github/prompts/scaffold-resource.md\` v${prompt_version:-?} |"
+            echo "| Agent | \`$SCAFFOLD_MODEL\`, ${TURNS:-?} turn(s), \$${COST:-?} |"
+            echo
+            echo "<details>"
+            echo "<summary>Manifest notes</summary>"
+            echo
+            echo "> $NOTES"
+            echo
+            echo "</details>"
+            echo
+            echo "<details>"
+            echo "<summary>Agent handoff — not verified offline</summary>"
+            echo
+            echo "$handoff"
+            echo
+            echo "</details>"
+            echo
+            echo "<details>"
+            echo "<summary>Validation report</summary>"
+            echo
+            echo "Every gate step passed before this PR was opened: diff scope, forbidden-content grep, gofmt, go vet, go build, unit tests (incl. \`TestProviderSDKCoverage\`), coverage reconcile, docs regeneration, per-kind registration and deliverables."
+            echo
+            echo "The gate proves the scaffold is well-formed, **not that it is correct** — that is what the checklist below is for."
+            echo
+            echo "</details>"
+            echo
+            echo "## Reviewer checklist"
+            echo
+            echo "- [ ] Endpoints verified against production (mandatory when the manifest notes flag spec gaps)"
+            echo "- [ ] Schema reviewed: types, required vs optional, sensitive fields that would land in state"
+            echo "- [ ] Acceptance test exercised — record a cassette (\`LATITUDE_TEST_RECORDER=record\`) or note why it runs live-only"
+            echo "- [ ] Docs and example read sensibly, not just generated-correct"
+            echo "- [ ] Mark ready for review so e2e runs (drafts never run acceptance)"
+            echo
+            echo "---"
+            echo
+            echo "Generated from [\`latitudesh-go-sdk\`](https://github.com/latitudesh/latitudesh-go-sdk) \`$SDK_VERSION\` by the [sdk-watch workflow]($RUN_URL)."
+            echo
+            echo "<!-- scaffold:$GROUP -->"
+          } > pr-body.md
+
+          # Label creation is an issues-API write (default token, issues: write);
+          # attaching labels to the PR is a PR mutation, which the read-scoped
+          # default token cannot do — that goes through the app token. The labels
+          # MUST land: dedupe, the open-PR cap, and parking all key off them.
+          GH_TOKEN="${{ github.token }}" gh label create scaffold --color 5319e7 \
+            --description "Agent-scaffolded SDK coverage PR" 2>/dev/null || true
+          GH_TOKEN="${{ github.token }}" gh label create "scaffold:${GROUP}" --color 5319e7 \
+            --description "Scaffold PR for SDK group ${GROUP}" 2>/dev/null || true
+
+          url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
+            --head "$branch" \
+            --title "feat(${short}): 🤖 scaffold ${TF_NAME} from SDK group ${GROUP}" \
+            --body-file pr-body.md)
+          GH_TOKEN="$APP_TOKEN" gh pr edit "$url" --add-label scaffold --add-label "scaffold:${GROUP}"
+          echo "Draft PR: $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the transcript
+        if: steps.select.outputs.has_work == 'true' && steps.agent.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scaffold-transcript
+          path: ${{ steps.agent.outputs.execution_file }}
+          retention-days: 14
+          overwrite: true
+          if-no-files-found: ignore
+
+      # A failed run must stay loud and inspectable: the tree the agent left
+      # behind and its transcript go up as artifacts, the tracking issue gets a
+      # note, and the job exits red — a silent green failure is the one outcome
+      # this pipeline is not allowed to produce. These live at the END of the job
+      # so they also cover mint/push/PR failures: a failure() step earlier in the
+      # list would already have been skipped-as-success by the time those run.
+      - name: Capture the failed tree
+        if: failure() && steps.select.outputs.has_work == 'true'
+        run: |
+          set -uo pipefail
+          git add -A
+          git diff --cached HEAD > scaffold-failure.patch || true
+          git status --porcelain > scaffold-failure-status.txt || true
+          # Artifacts on a public repo are publicly downloadable. The gate greps
+          # the diff for key material and FAILS on a hit — which is exactly when
+          # this path runs — so the same patterns must gate what gets uploaded,
+          # or the failure artifact would publish the very secret the gate caught.
+          if grep -Eq 'sk-ant-|ANTHROPIC_API_KEY|BEGIN[ A-Z]*PRIVATE KEY' scaffold-failure.patch; then
+            echo "patch withheld: it matches a key-material pattern; inspect the run log instead" > scaffold-failure.patch
+            echo "::warning::failure patch withheld — key-material pattern detected in the agent's tree"
+          fi
+
+      - name: Upload failure artifacts
+        if: failure() && steps.select.outputs.has_work == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scaffold-failure
+          path: |
+            /tmp/scaffold-prompt.md
+            ${{ steps.agent.outputs.execution_file }}
+            scaffold-failure.patch
+            scaffold-failure-status.txt
+          retention-days: 14
+          overwrite: true
+          if-no-files-found: ignore
+
+      - name: Note the failure on the tracking issue
+        if: failure() && steps.select.outputs.has_work == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GROUP: ${{ steps.select.outputs.group }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          existing=$(gh issue list --label sdk-coverage --state open --limit 100 \
+            --json number,body --jq \
+            'map(select(.body | contains("<!-- sdk-coverage-tracking -->"))) | sort_by(.number) | .[0].number // empty')
+          [ -n "$existing" ] || exit 0
+          gh issue comment "$existing" --body "Scaffold run for \`$GROUP\` failed — no PR was opened. Transcript and diff: $RUN_URL"

--- a/scripts/eval-scaffold.sh
+++ b/scripts/eval-scaffold.sh
@@ -27,7 +27,12 @@ set -euo pipefail
 
 CASE=""
 MODEL="claude-sonnet-5"
-MAX_TURNS="50"
+# The cap is runaway protection, not a target: measured runs gate-greened by
+# ~50-80 turns and the agent then polishes until killed (it cannot see a turn
+# counter), so 200 makes truncation rare while the handoff file (prompt v5)
+# makes it harmless. Cost scales with turns — the workflow warns above $6.
+# Keep in sync with SCAFFOLD_MAX_TURNS in .github/workflows/sdk-watch.yml.
+MAX_TURNS="200"
 DRY_RUN="false"
 KEEP="false"
 
@@ -142,34 +147,12 @@ SDK_VERSION=$(echo "$report" | jq -r '.sdk_version')
 
 echo "  group=$GROUP  type=$TF_NAME  kinds=[$KINDS]"
 
-# Render the prompt by substituting placeholders. Values go through the
-# environment, and the splice uses index/substr rather than gsub: a gsub
-# replacement string treats '&' and '\' specially, so a note containing either
-# would silently corrupt the rendered prompt.
-render_prompt() {
-	GROUP="$GROUP" KINDS="$KINDS" TF_NAME="$TF_NAME" METHODS="$METHODS" \
-		NOTES="$NOTES" SDK_VERSION="$SDK_VERSION" \
-		awk '
-		function subst(line, token, value,    out, i) {
-			out = ""
-			while ((i = index(line, token)) > 0) {
-				out = out substr(line, 1, i - 1) value
-				line = substr(line, i + length(token))
-			}
-			return out line
-		}
-		{
-			line = $0
-			line = subst(line, "{{GROUP}}", ENVIRON["GROUP"])
-			line = subst(line, "{{KINDS}}", ENVIRON["KINDS"])
-			line = subst(line, "{{TF_NAME}}", ENVIRON["TF_NAME"])
-			line = subst(line, "{{METHODS}}", ENVIRON["METHODS"])
-			line = subst(line, "{{NOTES}}", ENVIRON["NOTES"])
-			line = subst(line, "{{SDK_VERSION}}", ENVIRON["SDK_VERSION"])
-			print line
-		}' "$PROMPT_TEMPLATE"
-}
-render_prompt > "$ART_DIR/prompt.txt"
+# Render through the shared script — the same one the scaffold job uses in CI —
+# via $ROOT so a renderer fix under review is what actually gets exercised (the
+# worktree only carries HEAD). The template itself is read from the worktree.
+GROUP="$GROUP" KINDS="$KINDS" TF_NAME="$TF_NAME" METHODS="$METHODS" \
+	NOTES="$NOTES" SDK_VERSION="$SDK_VERSION" MAX_TURNS="$MAX_TURNS" \
+	"$ROOT/scripts/render-scaffold-prompt.sh" "$PROMPT_TEMPLATE" > "$ART_DIR/prompt.txt"
 
 if [ "$DRY_RUN" = "true" ]; then
 	echo
@@ -190,12 +173,19 @@ ALLOWED_TOOLS="Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:
 
 echo
 echo "== running the agent (model=$MODEL, max-turns=$MAX_TURNS) =="
+# A stale handoff from a previous run must never score as this run's — the
+# prompt has the agent maintain this exact path from its first draft onwards.
+rm -f /tmp/scaffold-handoff.md
 set +e
-claude -p "$(cat "$ART_DIR/prompt.txt")" \
+# The prompt goes through stdin, never as an argument: it starts with the
+# template's `---` frontmatter, and the CLI's option parser rejects a leading
+# dash as an unknown flag before print mode ever sees it.
+claude -p \
 	--model "$MODEL" \
 	--max-turns "$MAX_TURNS" \
 	--allowedTools "$ALLOWED_TOOLS" \
-	--output-format json >"$ART_DIR/claude-out.json" 2>"$ART_DIR/claude-err.txt"
+	--output-format json \
+	<"$ART_DIR/prompt.txt" >"$ART_DIR/claude-out.json" 2>"$ART_DIR/claude-err.txt"
 agent_status=$?
 set -e
 
@@ -213,6 +203,13 @@ bash scripts/scaffold-validate.sh --group "$GROUP" --type-name "$TF_NAME" --kind
 score=$?
 set -e
 
+if [ -f /tmp/scaffold-handoff.md ]; then
+	handoff_state="file present ($(wc -c < /tmp/scaffold-handoff.md | tr -d ' ') bytes)"
+	cp /tmp/scaffold-handoff.md "$ART_DIR/scaffold-handoff.md"
+else
+	handoff_state="MISSING — a turn-capped session then ships no handoff at all"
+fi
+
 echo
 echo "======================= eval result ======================="
 echo "  case:      $CASE ($GROUP -> $TF_NAME)"
@@ -220,6 +217,7 @@ echo "  model:     $MODEL"
 echo "  cost:      \$$cost"
 echo "  turns:     $turns"
 echo "  agent:     exit $agent_status"
+echo "  handoff:   $handoff_state"
 if [ "$score" -eq 0 ]; then
 	echo "  gate:      PASS"
 else
@@ -228,11 +226,14 @@ fi
 echo "  artifacts: $ART_DIR"
 echo "==========================================================="
 
-# A crashed agent is a failed eval even when the tree it left behind happens to
-# validate — otherwise a prompt change that makes the agent die at the finish
-# line would still score green.
-if [ "$agent_status" -ne 0 ]; then
-	echo "RESULT: FAIL — the agent process exited $agent_status (gate outcome above is informational)"
-	exit 1
+# The gate is the arbiter here exactly as in the scaffold job: production opens
+# the PR whenever the gate passes, whatever the agent's exit status, so scoring
+# a stricter bar would block prompt iterations production happily ships. A
+# non-zero agent exit still prints loudly — it usually means the turn cap fired,
+# which costs the reviewer handoff and flags prompt inefficiency — but it does
+# not flip a green gate red. An agent that died early leaves a tree the gate
+# fails on its own.
+if [ "$agent_status" -ne 0 ] && [ "$score" -eq 0 ]; then
+	echo "RESULT: PASS with a caveat — the agent exited $agent_status (turn cap?), so no handoff was emitted; review prompt efficiency before shipping this prompt version"
 fi
 exit "$score"

--- a/scripts/render-scaffold-prompt.sh
+++ b/scripts/render-scaffold-prompt.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# render-scaffold-prompt.sh — substitute the {{...}} placeholders in the scaffold
+# prompt template and print the result. Shared by the eval harness and the
+# sdk-watch scaffold job so the agent always receives an identically rendered
+# prompt; if the two ever rendered differently, the eval would no longer measure
+# what production runs.
+#
+# Inputs come through the environment (GROUP, KINDS, TF_NAME, METHODS, NOTES,
+# SDK_VERSION), never argv: values are free text from the coverage report and
+# argv would invite quoting bugs. The splice uses index/substr rather than gsub:
+# a gsub replacement string treats '&' and '\' specially, so a note containing
+# either would silently corrupt the rendered prompt.
+#
+# Usage:
+#   GROUP=... KINDS=... TF_NAME=... METHODS=... NOTES=... SDK_VERSION=... \
+#     scripts/render-scaffold-prompt.sh [template]
+set -euo pipefail
+
+TEMPLATE="${1:-.github/prompts/scaffold-resource.md}"
+[ -f "$TEMPLATE" ] || { echo "render-scaffold-prompt.sh: no such template: $TEMPLATE" >&2; exit 2; }
+
+for v in GROUP KINDS TF_NAME METHODS NOTES SDK_VERSION MAX_TURNS; do
+	if [ -z "${!v:-}" ]; then
+		echo "render-scaffold-prompt.sh: $v must be set (and non-empty) in the environment" >&2
+		exit 2
+	fi
+done
+
+awk '
+	function subst(line, token, value,    out, i) {
+		out = ""
+		while ((i = index(line, token)) > 0) {
+			out = out substr(line, 1, i - 1) value
+			line = substr(line, i + length(token))
+		}
+		return out line
+	}
+	{
+		line = $0
+		line = subst(line, "{{GROUP}}", ENVIRON["GROUP"])
+		line = subst(line, "{{KINDS}}", ENVIRON["KINDS"])
+		line = subst(line, "{{TF_NAME}}", ENVIRON["TF_NAME"])
+		line = subst(line, "{{METHODS}}", ENVIRON["METHODS"])
+		line = subst(line, "{{NOTES}}", ENVIRON["NOTES"])
+		line = subst(line, "{{SDK_VERSION}}", ENVIRON["SDK_VERSION"])
+		line = subst(line, "{{MAX_TURNS}}", ENVIRON["MAX_TURNS"])
+		print line
+	}' "$TEMPLATE"

--- a/scripts/scaffold-validate.sh
+++ b/scripts/scaffold-validate.sh
@@ -188,9 +188,13 @@ echo "ok: builds"
 
 # ------------------------------------------------------------------ 6. tests --
 # The offline unit tests, which include TestProviderSDKCoverage. TF_ACC is
-# explicitly unset so no acceptance test tries to reach the live API.
+# explicitly unset so no acceptance test tries to reach the live API, and so is
+# LATITUDESH_AUTH_TOKEN: a stray token in the caller's shell would let a test
+# that eagerly touches the shared fixture reach the real API from what is
+# supposed to be the offline tier — the gate must behave identically on a dev
+# machine and in CI.
 step "6/9 unit tests"
-env -u TF_ACC go test ./latitudesh ./internal/... || fail "unit tests failed"
+env -u TF_ACC -u LATITUDESH_AUTH_TOKEN go test ./latitudesh ./internal/... || fail "unit tests failed"
 echo "ok: unit tests pass"
 
 # ------------------------------------------------------- 7. coverage reconciles --


### PR DESCRIPTION
### Summary

Completes the auto-scaffolding pipeline: `sdk-watch.yml` gains a `scaffold` job that turns the top pending SDK group into a draft PR, instead of stopping at the tracking issue.

- One group per run, at most 2 open scaffold PRs, dedupe/parking via `scaffold:<group>` labels; the SDK bump is committed on the scaffold branch when the group only exists in a newer release.
- The shared 9-step validation gate is the arbiter: it passes → the workflow (never the agent) commits by explicit pathspec and opens a Speakeasy-style draft PR via the `latitudesh-sdk-watch` GitHub App token; it fails → no PR, red run, transcript + scrubbed diff artifacts, and a note on the tracking issue.
- Agent guardrails: action pinned by SHA, restricted tool allowlist (no git/gh/network), `--max-turns 200` runaway ceiling, no job-level tokens reachable from the agent step, `persist-credentials: false` on checkout.
- Prompt v5, rendered by the new shared `scripts/render-scaffold-prompt.sh` (eval and CI render identically): turn-budget guidance plus a handoff file maintained from the first draft — a turn-capped session emits no final message, so the PR body falls back to the file.
- Eval/gate fixes: the prompt is fed via stdin (a leading `---` frontmatter was parsed as a CLI flag), the unit-test tier scrubs `LATITUDESH_AUTH_TOKEN`, and the gate is the arbiter in the eval exactly as in CI.

### Eval (required for prompt/gate changes)

`make eval-scaffold-agent CASE=elastic_ip` — prompt v5, `claude-sonnet-5`: gate **PASS** (9/9), agent exit 0, **60 turns**, **$2.56**, handoff file present (6.5 KB).

Iteration history on the same case: v2 hit 51/50 turns and failed the gate on an eager fixture call; v3 passed the gate at 81/80; v4 passed at 101/100 but lost the handoff to the turn cap; v5 finished clean at 60/200.

### Testing

```bash
make coverage-check
make scaffold-validate GROUP=... TYPE=... KINDS=...   # same gate the workflow runs
make eval-scaffold-agent CASE=elastic_ip              # paid; needs the claude CLI
```

After merge, first controlled live run:

```bash
gh workflow run sdk-watch.yml -f group=MarketplaceApps
```

Fixes DX-23


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR completes the SDK coverage automation by adding a guarded scaffold job that selects one pending SDK group, optionally updates the SDK, runs an agent, validates its output, and opens a labeled draft PR.
- Adds selection, deduplication, parking, open-PR limits, branch creation, and failure reporting.
- Shares prompt rendering between CI and the local evaluation harness and raises the agent turn ceiling.
- Strengthens offline validation by removing API credentials from the unit-test environment.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects established in the changed paths.

The workflow preserves the intended bump-before-validation ordering, validates the complete resulting tree, restricts committed scaffold paths, and keeps failure reporting explicit.
</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Trigger as Schedule / Manual Dispatch
    participant Detect as detect job
    participant Scaffold as scaffold job
    participant Agent as scaffolding agent
    participant Gate as validation gate
    participant GitHub as GitHub API

    Trigger->>Detect: Reconcile latest SDK coverage
    Detect-->>Scaffold: Pending groups and SDK version
    alt Dry run, empty queue, or invalid pinned manifest
        Scaffold-->>Trigger: Skip scaffold work
    else Eligible run
        Scaffold->>GitHub: Read claimed and parked groups
        Scaffold->>Scaffold: Select one group
        opt Pinned SDK lacks group
            Scaffold->>Scaffold: Update and commit go.mod/go.sum
        end
        Scaffold->>Agent: Rendered prompt and restricted tools
        Agent-->>Scaffold: Generated tree, transcript, handoff
        Scaffold->>Gate: Validate scope, build, tests, coverage, docs
        alt Gate passes
            Scaffold->>GitHub: Push branch and open labeled draft PR
        else Gate fails
            Scaffold->>GitHub: Upload failure artifacts and comment on tracking issue
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(scaffold): add the sdk-watch scaffo..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/81499a4d41d730ac09d25aa0f9c94efd047829a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57648353)</sub>

<!-- /greptile_comment -->