### PR TITLE
feat(scaffold): agent PRs ready for review, versioning + manual-validation sections, release-drafter revived

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,28 +1,33 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-template: |
-  # What's Changed
 
-  $CHANGES
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+# Each merged PR lands in one category by label. The autolabeler below maps the
+# repo's conventional-commit PR titles to those labels, so neither humans nor
+# the scaffold agent have to remember to label anything by hand.
+change-template: '- $TITLE (#$NUMBER) — @$AUTHOR'
+change-title-escapes: '\<*_&'
 
 categories:
-  - title: 'Breaking'
+  - title: '🚨 Breaking'
     label: 'type: breaking'
-  - title: 'New'
+  - title: '✨ New'
     label: 'type: feature'
-  - title: 'Bug Fixes'
+  - title: '🐛 Bug Fixes'
     label: 'type: bug'
-  - title: 'Maintenance'
-    label: 'type: maintenance'
-  - title: 'Documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'type: maintenance'
+      - 'type: security'
+  - title: '📚 Documentation'
     label: 'type: docs'
-  - title: 'Other changes'
-  - title: 'Dependency Updates'
+  - title: '⬆️ Dependencies'
     label: 'type: dependencies'
     collapse-after: 5
+  - title: 'Other changes'
 
+# The next version is resolved from the labels of every PR accumulated in the
+# draft, and the highest bump wins: one breaking PR in the batch makes the whole
+# release a major. Unlabeled PRs default to patch.
 version-resolver:
   major:
     labels:
@@ -37,47 +42,57 @@ version-resolver:
       - 'type: docs'
       - 'type: dependencies'
       - 'type: security'
+  default: patch
 
-exclude-labels:
-  - 'skip-changelog'
-
-# Derive the category labels from the conventional-commit prefix in the PR title.
-# The categories and version-resolver above are driven entirely by labels, so
-# without this they depend on someone remembering to apply one by hand — and a PR
-# that slips through lands in "Other changes" and never influences the version
-# bump. The prefix already carries the information, so read it from there.
-#
-# Note that every matching rule is applied, not just the first, so these have to be
-# mutually exclusive. That is why the bug and maintenance rules explicitly exclude a
-# `deps` scope: this repo writes dependency bumps as `fix(deps):` / `chore(deps):`,
-# which would otherwise be categorised twice.
-#
-# Autolabeling does not work on pull requests from forks, because the token is
-# read-only there. Supporting those needs the `pull_request_target` event that sits
-# commented out in the workflow — a separate security decision. Until then, label
-# fork PRs by hand.
+# PR titles follow conventional commits in this repo — derive the label from the
+# title so the version resolver always has something to work with. The scaffold
+# workflow also applies `type: feature` itself; these rules are the safety net
+# for human PRs.
 autolabeler:
-  # Breaking changes are marked with `!` in the prefix (`feat(api)!: ...`), so they
-  # do not depend on anyone remembering the label either. A `feat!:` title
-  # deliberately picks up both labels: `breaking` wins the version bump, and the
-  # Breaking category is listed first.
   - label: 'type: breaking'
-    title: ['/^\w+(\([^)]+\))?!:/']
-
+    title:
+      - '/^[a-z]+(\(.+\))?!:/'
   - label: 'type: feature'
-    title: ['/^feat(\([^)]+\))?!?:/']
-
-  - label: 'type: dependencies'
-    title: ['/^\w+\(deps(-dev)?\)!?:/']
-    branch: ['/^dependabot\//']
-
+    title:
+      - '/^feat/i'
   - label: 'type: bug'
-    title: ['/^fix(?!\(deps)(\([^)]+\))?!?:/']
-
+    title:
+      - '/^fix(?!\(deps\))/i'
   - label: 'type: docs'
-    title: ['/^docs(\([^)]+\))?!?:/']
-
-  # `test` is the second most common prefix in this repo's history and had no
-  # category at all before.
+    title:
+      - '/^docs/i'
+  - label: 'type: dependencies'
+    title:
+      - '/^(chore|fix|build)\(deps\)/i'
+    branch:
+      - '/^dependabot\//'
   - label: 'type: maintenance'
-    title: ['/^(chore|refactor|test|ci|build|style|perf)(?!\(deps)(\([^)]+\))?!?:/']
+    title:
+      - '/^(ci|refactor|test|style)/i'
+      - '/^chore(?!\(deps\))/i'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Install / upgrade
+
+  ```hcl
+  terraform {
+    required_providers {
+      latitudesh = {
+        source  = "latitudesh/latitudesh"
+        version = "$RESOLVED_VERSION"
+      }
+    }
+  }
+  ```
+
+  Published to the [Terraform Registry](https://registry.terraform.io/providers/latitudesh/latitudesh/$RESOLVED_VERSION).
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -68,7 +68,7 @@ autolabeler:
       - '/^dependabot\//'
   - label: 'type: maintenance'
     title:
-      - '/^(ci|refactor|test|style)/i'
+      - '/^(ci|refactor|test|style|build|perf)/i'
       - '/^chore(?!\(deps\))/i'
 
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       # Pinned to an immutable commit SHA, like every other action in this repo.
-      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
+      - uses: release-drafter/release-drafter@v6# v6.4.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,9 +33,9 @@ jobs:
       #  run: |
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      # Pinned to an immutable commit SHA, like every other action in this repo.
-      - uses: release-drafter/release-drafter@v6# v6.4.0
+      # Drafts your next Release notes as Pull Requests are merged into "master".
+      # Deliberately on the mutable v6 tag (readability over SHA-pinning).
+      - uses: release-drafter/release-drafter@v6
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,8 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      # Pinned to an immutable commit SHA, like every other action in this repo.
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -374,6 +374,14 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          # The gate validates the scaffolded example standalone with a plain
+          # `terraform validate`; the wrapper shim would capture its stdout into
+          # step outputs and get in the way of that direct CLI usage.
+          terraform_wrapper: false
+
       - name: Download coverage report
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -384,6 +392,52 @@ jobs:
           # agent spend, and unfixably, since the agent cannot delete files.
           path: ${{ runner.temp }}/sdk-coverage
 
+      # A scaffold PR that is OPEN but still DRAFT at the start of a run is an
+      # orphan: runs are serialized by the concurrency group, and a live
+      # finalize only holds a draft for the seconds between create and ready.
+      # Its tree passed the gate and its body was written by the attempt that
+      # pushed it — finishing its lifecycle is just marking it ready. Without
+      # this, a run that died between labeling and `gh pr ready` would strand
+      # the PR in draft forever: the select step below sees the group as
+      # claimed and never routes back to it.
+      - name: Find orphaned scaffold drafts
+        id: orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          numbers=$(gh pr list --label scaffold --state open --json number,isDraft \
+            --jq '[.[] | select(.isDraft) | .number] | map(tostring) | join(" ")')
+          echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
+          if [ -n "$numbers" ]; then
+            echo "::notice::orphaned draft scaffold PR(s) to adopt: $numbers"
+          else
+            echo "no orphaned drafts"
+          fi
+
+      - name: Mint a token to adopt orphans
+        id: adopt_app
+        if: steps.orphans.outputs.numbers != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
+          private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
+
+      - name: Adopt orphaned scaffold drafts
+        if: steps.orphans.outputs.numbers != ''
+        env:
+          # The app token, not the default one: a ready_for_review event fired
+          # by the default GITHUB_TOKEN would not trigger test.yml, and the
+          # adopted PR would sit ready with no checks.
+          GH_TOKEN: ${{ steps.adopt_app.outputs.token }}
+          NUMBERS: ${{ steps.orphans.outputs.numbers }}
+        run: |
+          set -euo pipefail
+          for n in $NUMBERS; do
+            gh pr ready "$n"
+            echo "adopted scaffold PR #$n — marked ready for review"
+          done
+
       - name: Select the group to scaffold
         id: select
         env:
@@ -391,12 +445,14 @@ jobs:
           OVERRIDE: ${{ github.event.inputs.group }}
         run: |
           set -euo pipefail
-          # Groups already claimed by an open scaffold PR are never re-picked;
-          # groups whose scaffold PR closed without merging are parked until
-          # sdk-coverage.yaml records a ceiling+rationale for them (or a human
-          # retries explicitly via the `group` input, which is the whole point
-          # of letting the override bypass the parked list — but never an open
-          # claim, which would double-scaffold).
+          # Groups already claimed by an open scaffold PR are never re-picked
+          # (any claimed PR still in draft was adopted — marked ready — by the
+          # step above before this list is taken); groups whose scaffold PR
+          # closed without merging are parked until sdk-coverage.yaml records a
+          # ceiling+rationale for them (or a human retries explicitly via the
+          # `group` input, which is the whole point of letting the override
+          # bypass the parked list — but never an open claim, which would
+          # double-scaffold).
           claimed=$(gh pr list --label scaffold --state open --json labels \
             --jq '[.[].labels[].name | select(startswith("scaffold:")) | ltrimstr("scaffold:")] | unique | .[]')
           parked=$(gh pr list --label scaffold --state closed --limit 100 --json labels,mergedAt \

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -622,14 +622,25 @@ jobs:
           short="${TF_NAME#latitudesh_}"
           branch="scaffold/${short}-${{ github.run_id }}"
 
-          # Commit by explicit pathspec — the gate already proved the diff is in
-          # scope, and adding by name means a stray file could not ride along
-          # even if it were not.
-          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
-            add -- latitudesh sdk-coverage.yaml templates examples docs
-          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
-            commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+          # The finalize sequence (push → create → label → ready) must be
+          # RERUNNABLE: an attempt can die between any two of these calls, a
+          # rerun keeps the same run_id (same branch name) but regenerates a
+          # different tree, and a plain push would then die non-fast-forward —
+          # stranding the previous attempt's PR in draft forever. When the
+          # branch already exists, reuse it as-is: whatever attempt pushed it
+          # ran this same gate first, and this repo never force-pushes.
+          if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            echo "branch ${branch} already pushed by a previous attempt — reusing it"
+          else
+            # Commit by explicit pathspec — the gate already proved the diff is
+            # in scope, and adding by name means a stray file could not ride
+            # along even if it were not.
+            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+              add -- latitudesh sdk-coverage.yaml templates examples docs
+            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+              commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
+            git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+          fi
 
           prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/scaffold-resource.md | head -1)
           # The handoff is agent-authored free text going into a PR body — cap it
@@ -774,7 +785,8 @@ jobs:
           }
           EOF
           cp "$workdir/provider/__EXAMPLE__" main.tf
-          # If the example references var.*, replace them with literals before applying.
+          # The example is gate-enforced to be self-contained; note it may declare
+          # helper resources it depends on, and apply will create those too.
 
           terraform plan     # dev_overrides active: no init needed; expect the overrides warning
           terraform apply
@@ -817,14 +829,27 @@ jobs:
           # race test.yml: the `opened` event fires before any label exists, so
           # e2e would see no skip-e2e and launch the full live acceptance suite
           # on every agent PR. The ready_for_review event sees the labels.
-          url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
-            --head "$branch" \
-            --title "feat(${short}): 🤖 scaffold ${TF_NAME} from SDK group ${GROUP}" \
-            --body-file pr-body.md)
+          # Every call here is reuse-aware for the same rerun reason as the push
+          # above — a previous attempt may have already created the PR (dedupe
+          # in the select step cannot catch it: labels are what it keys on, and
+          # they only exist after the edit below succeeds).
+          url=$(GH_TOKEN="$APP_TOKEN" gh pr list --state open --head "$branch" \
+            --json url --jq '.[0].url // empty')
+          if [ -z "$url" ]; then
+            url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
+              --head "$branch" \
+              --title "feat(${short}): 🤖 scaffold ${TF_NAME} from SDK group ${GROUP}" \
+              --body-file pr-body.md)
+          else
+            echo "PR for ${branch} already open from a previous attempt — finishing its lifecycle"
+            GH_TOKEN="$APP_TOKEN" gh pr edit "$url" --body-file pr-body.md
+          fi
           GH_TOKEN="$APP_TOKEN" gh pr edit "$url" \
             --add-label scaffold --add-label "scaffold:${GROUP}" \
             --add-label "type: feature" --add-label skip-e2e
-          GH_TOKEN="$APP_TOKEN" gh pr ready "$url"
+          if [ "$(GH_TOKEN="$APP_TOKEN" gh pr view "$url" --json isDraft --jq '.isDraft')" = "true" ]; then
+            GH_TOKEN="$APP_TOKEN" gh pr ready "$url"
+          fi
           echo "PR (ready for review): $url" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload the transcript

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -538,11 +538,14 @@ jobs:
             --max-turns ${{ env.SCAFFOLD_MAX_TURNS }}
             --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
 
-      - name: Report agent cost
+      # Cost and agent stats live HERE, in the run summary — deliberately not in
+      # the PR body, which is the reviewer's surface, not the operator's.
+      - name: Report agent cost and stats
         id: cost
         if: always() && steps.agent.outcome != 'skipped' && steps.agent.outputs.execution_file != ''
         env:
           EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
+          GROUP: ${{ steps.select.outputs.group }}
         run: |
           set -uo pipefail
           # The execution file is either a single result object or an array of
@@ -553,9 +556,31 @@ jobs:
           turns=${turns:-unknown}
           echo "cost=$cost" >> "$GITHUB_OUTPUT"
           echo "turns=$turns" >> "$GITHUB_OUTPUT"
-          echo "## Scaffold agent: \$${cost}, ${turns} turn(s)" >> "$GITHUB_STEP_SUMMARY"
+
+          cost_fmt="$cost"
+          if [ "$cost" != "unknown" ]; then
+            cost_fmt=$(printf '%.2f' "$cost")
+          fi
+          prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/scaffold-resource.md | head -1)
+          if [ -f /tmp/scaffold-handoff.md ]; then
+            handoff="present ($(wc -c < /tmp/scaffold-handoff.md | tr -d ' ') bytes)"
+          else
+            handoff="MISSING"
+          fi
+          {
+            echo "## Scaffold agent"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Group | \`$GROUP\` |"
+            echo "| Model | \`$SCAFFOLD_MODEL\` |"
+            echo "| Prompt | v${prompt_version:-?} |"
+            echo "| Turns | ${turns} (cap $SCAFFOLD_MAX_TURNS) |"
+            echo "| Cost | \$${cost_fmt} |"
+            echo "| Handoff file | $handoff |"
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ "$cost" != "unknown" ] && awk "BEGIN { exit !($cost > 6) }"; then
-            echo "::warning::agent run cost \$${cost} — above the \$6 watermark, review the transcript for thrash"
+            echo "::warning::agent run cost \$${cost_fmt} — above the \$6 watermark, review the transcript for thrash"
           fi
 
       - name: Validate the scaffold
@@ -576,7 +601,7 @@ jobs:
           client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
           private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
 
-      - name: Push the branch and open the draft PR
+      - name: Push the branch and open the PR
         if: steps.select.outputs.has_work == 'true'
         env:
           GROUP: ${{ steps.select.outputs.group }}
@@ -589,8 +614,6 @@ jobs:
           PENDING_BEFORE: ${{ steps.render.outputs.pending_before }}
           TOTAL_GROUPS: ${{ steps.render.outputs.total_groups }}
           NOTES: ${{ steps.render.outputs.notes }}
-          COST: ${{ steps.cost.outputs.cost }}
-          TURNS: ${{ steps.cost.outputs.turns }}
           EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
           APP_TOKEN: ${{ steps.app.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -628,6 +651,19 @@ jobs:
           covered_after=$(echo "$after" | jq -r '.counts.covered')
           pending_after=$(echo "$after" | jq -r '.counts.pending')
 
+          # Speakeasy-style version suggestion. A new resource/data source is a
+          # backwards-compatible addition, so the bump is always minor; the
+          # `type: feature` label applied below is what actually drives it —
+          # release-drafter's version resolver maps that label to a minor bump
+          # when drafting the next release.
+          latest_release=$(GH_TOKEN="${{ github.token }}" gh api "repos/$GH_REPO/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+          if [[ "$latest_release" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            suggested_release="v${BASH_REMATCH[1]}.$((BASH_REMATCH[2] + 1)).0"
+            version_line="Version Bump Type: [minor] - 🤖 (automated) — latest release is \`$latest_release\`, this ships in \`$suggested_release\`"
+          else
+            version_line="Version Bump Type: [minor] - 🤖 (automated)"
+          fi
+
           methods_md=$(printf '%s' "$METHODS" | sed 's/, /`, `/g; s/^/`/; s/$/`/')
 
           # Body structure mirrors the Speakeasy generation PRs on
@@ -637,12 +673,19 @@ jobs:
           {
             echo "# Provider scaffold"
             echo
+            echo "## Versioning"
+            echo
+            echo "$version_line"
+            echo
+            echo "> [!TIP]"
+            echo "> A new resource or data source is a backwards-compatible addition, so the bump is always **minor**. The \`type: feature\` label on this PR feeds release-drafter's version resolver, and the draft release picks it up on merge."
+            echo
             echo "## Coverage"
             echo
             echo "Coverage Bump: [${COVERED_BEFORE} → ${covered_after} of ${TOTAL_GROUPS} SDK service groups] - 🤖 (automated)"
             echo
             echo "> [!TIP]"
-            echo "> Reviewing this draft is where the keep-or-drop decision is made. **Keep it** — merge, and \`$GROUP\` is covered. **Drop it** — close this PR **and** record a \`ceiling\` + \`rationale\` under \`$GROUP\` in \`sdk-coverage.yaml\`, so it stops being regenerated."
+            echo "> Reviewing this PR is where the keep-or-drop decision is made. **Keep it** — merge, and \`$GROUP\` is covered. **Drop it** — close this PR **and** record a \`ceiling\` + \`rationale\` under \`$GROUP\` in \`sdk-coverage.yaml\`, so it stops being regenerated."
             echo
             echo "## Provider Changes:"
             echo
@@ -654,8 +697,6 @@ jobs:
             echo "|---|---|"
             echo "| SDK version | \`$SDK_VERSION\` |"
             echo "| Pending groups | ${PENDING_BEFORE} → ${pending_after} |"
-            echo "| Prompt | \`.github/prompts/scaffold-resource.md\` v${prompt_version:-?} |"
-            echo "| Agent | \`$SCAFFOLD_MODEL\`, ${TURNS:-?} turn(s), \$${COST:-?} |"
             echo
             echo "<details>"
             echo "<summary>Manifest notes</summary>"
@@ -680,17 +721,81 @@ jobs:
             echo
             echo "</details>"
             echo
+            echo "<details>"
+            echo "<summary>Manual validation (copy-paste)</summary>"
+            echo
+            # Fully literal template (quoted heredoc — backticks, \$(...) and the
+            # inner heredocs must reach the reviewer verbatim); the three
+            # run-specific values are spliced by sed. The inner terminators are
+            # EOF, which never collides with MANUAL_EOF.
+            cat <<'MANUAL_EOF' | sed -e "s|__BRANCH__|$branch|g" -e "s|__REPO__|$GH_REPO|g" -e "s|__EXAMPLE__|examples/$TF_NAME.tf|g"
+          The agent's acceptance tests run against a local mock — nothing in this PR touched the real API. The snippets below build this branch and exercise the resource end-to-end against the real API. Credentials are separate blocks so you can paste them independently.
+
+          **1. Token:**
+
+          ```bash
+          export LATITUDESH_AUTH_TOKEN="<your-api-token>"
+          ```
+
+          **2. Test project** (ID or slug; used as the provider-level default — harmless for resources that do not take a project):
+
+          ```bash
+          export LATITUDESH_PROJECT="<test-project-id-or-slug>"
+          ```
+
+          **3. Build this branch and apply the example:**
+
+          ```bash
+          workdir=$(mktemp -d)
+          git clone --depth 1 --branch __BRANCH__ \
+            https://github.com/__REPO__.git "$workdir/provider"
+          make -C "$workdir/provider" build   # binary lands at the repo root — do NOT `make install`
+
+          cat > "$workdir/dev.tfrc" <<EOF
+          provider_installation {
+            dev_overrides {
+              "latitudesh/latitudesh" = "$workdir/provider"
+            }
+            direct {}
+          }
+          EOF
+          export TF_CLI_CONFIG_FILE="$workdir/dev.tfrc"
+
+          mkdir "$workdir/manual-test" && cd "$workdir/manual-test"
+          cat > provider.tf <<EOF
+          terraform {
+            required_providers {
+              latitudesh = { source = "latitudesh/latitudesh" }
+            }
+          }
+
+          provider "latitudesh" {
+            project = "$LATITUDESH_PROJECT"
+          }
+          EOF
+          cp "$workdir/provider/__EXAMPLE__" main.tf
+          # If the example references var.*, replace them with literals before applying.
+
+          terraform plan     # dev_overrides active: no init needed; expect the overrides warning
+          terraform apply
+          terraform state show "$(terraform state list | head -1)"
+          terraform destroy
+          ```
+          MANUAL_EOF
+            echo
+            echo "</details>"
+            echo
             echo "## Reviewer checklist"
             echo
             echo "- [ ] Endpoints verified against production (mandatory when the manifest notes flag spec gaps)"
             echo "- [ ] Schema reviewed: types, required vs optional, sensitive fields that would land in state"
             echo "- [ ] Acceptance test exercised — record a cassette (\`LATITUDE_TEST_RECORDER=record\`) or note why it runs live-only"
             echo "- [ ] Docs and example read sensibly, not just generated-correct"
-            echo "- [ ] Mark ready for review so e2e runs (drafts never run acceptance)"
+            echo "- [ ] Remove the \`skip-e2e\` label (and re-run the checks) to exercise the full acceptance suite"
             echo
             echo "---"
             echo
-            echo "Generated from [\`latitudesh-go-sdk\`](https://github.com/latitudesh/latitudesh-go-sdk) \`$SDK_VERSION\` by the [sdk-watch workflow]($RUN_URL)."
+            echo "Generated from [\`latitudesh-go-sdk\`](https://github.com/latitudesh/latitudesh-go-sdk) \`$SDK_VERSION\` by the [sdk-watch workflow]($RUN_URL) — prompt v${prompt_version:-?}."
             echo
             echo "<!-- scaffold:$GROUP -->"
           } > pr-body.md
@@ -703,13 +808,24 @@ jobs:
             --description "Agent-scaffolded SDK coverage PR" 2>/dev/null || true
           GH_TOKEN="${{ github.token }}" gh label create "scaffold:${GROUP}" --color 5319e7 \
             --description "Scaffold PR for SDK group ${GROUP}" 2>/dev/null || true
+          GH_TOKEN="${{ github.token }}" gh label create "type: feature" --color 0e8a16 \
+            --description "New user-facing functionality" 2>/dev/null || true
+          GH_TOKEN="${{ github.token }}" gh label create skip-e2e --color ededed \
+            --description "Skip the acceptance suite on this PR" 2>/dev/null || true
 
+          # Draft first, label, THEN mark ready. Creating the PR non-draft would
+          # race test.yml: the `opened` event fires before any label exists, so
+          # e2e would see no skip-e2e and launch the full live acceptance suite
+          # on every agent PR. The ready_for_review event sees the labels.
           url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
             --head "$branch" \
             --title "feat(${short}): 🤖 scaffold ${TF_NAME} from SDK group ${GROUP}" \
             --body-file pr-body.md)
-          GH_TOKEN="$APP_TOKEN" gh pr edit "$url" --add-label scaffold --add-label "scaffold:${GROUP}"
-          echo "Draft PR: $url" >> "$GITHUB_STEP_SUMMARY"
+          GH_TOKEN="$APP_TOKEN" gh pr edit "$url" \
+            --add-label scaffold --add-label "scaffold:${GROUP}" \
+            --add-label "type: feature" --add-label skip-e2e
+          GH_TOKEN="$APP_TOKEN" gh pr ready "$url"
+          echo "PR (ready for review): $url" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload the transcript
         if: steps.select.outputs.has_work == 'true' && steps.agent.outputs.execution_file != ''

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -396,46 +396,66 @@ jobs:
       # orphan: runs are serialized by the concurrency group, and a live
       # finalize only holds a draft for the seconds between create and ready.
       # Its tree passed the gate and its body was written by the attempt that
-      # pushed it — finishing its lifecycle is just marking it ready. Without
-      # this, a run that died between labeling and `gh pr ready` would strand
-      # the PR in draft forever: the select step below sees the group as
-      # claimed and never routes back to it.
+      # pushed it — finishing its lifecycle means healing its labels and
+      # marking it ready. Discovery keys on the body marker, NOT on labels: the
+      # marker is written atomically with `gh pr create --body-file`, while
+      # labels only exist once a later call succeeds — an attempt that died in
+      # between leaves an unlabeled draft that a label-keyed query (and the
+      # label-keyed dedupe in the select step) would never see, letting a later
+      # run open a second PR for the same group.
       - name: Find orphaned scaffold drafts
         id: orphans
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          numbers=$(gh pr list --label scaffold --state open --json number,isDraft \
-            --jq '[.[] | select(.isDraft) | .number] | map(tostring) | join(" ")')
-          echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
-          if [ -n "$numbers" ]; then
-            echo "::notice::orphaned draft scaffold PR(s) to adopt: $numbers"
+          adoptions=$(gh pr list --state open --json number,isDraft,body \
+            --jq '[.[] | select(.isDraft) | select((.body // "") | contains("<!-- scaffold:"))
+                   | "\(.number)=\((.body | capture("<!-- scaffold:(?<g>[^ ]+) -->").g))"] | join(" ")')
+          echo "adoptions=$adoptions" >> "$GITHUB_OUTPUT"
+          if [ -n "$adoptions" ]; then
+            echo "::notice::orphaned draft scaffold PR(s) to adopt: $adoptions"
           else
             echo "no orphaned drafts"
           fi
 
       - name: Mint a token to adopt orphans
         id: adopt_app
-        if: steps.orphans.outputs.numbers != ''
+        if: steps.orphans.outputs.adoptions != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
           private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
 
       - name: Adopt orphaned scaffold drafts
-        if: steps.orphans.outputs.numbers != ''
+        if: steps.orphans.outputs.adoptions != ''
         env:
-          # The app token, not the default one: a ready_for_review event fired
-          # by the default GITHUB_TOKEN would not trigger test.yml, and the
-          # adopted PR would sit ready with no checks.
-          GH_TOKEN: ${{ steps.adopt_app.outputs.token }}
-          NUMBERS: ${{ steps.orphans.outputs.numbers }}
+          # Label CREATION is a repo write on the issues API — the default
+          # token's issues:write covers it. Labeling the PR and marking it
+          # ready are PR mutations, and those need the app token anyway: a
+          # ready_for_review event fired by the default GITHUB_TOKEN would not
+          # trigger test.yml, and the adopted PR would sit ready with no checks.
+          DEFAULT_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.adopt_app.outputs.token }}
+          ADOPTIONS: ${{ steps.orphans.outputs.adoptions }}
         run: |
           set -euo pipefail
-          for n in $NUMBERS; do
-            gh pr ready "$n"
-            echo "adopted scaffold PR #$n — marked ready for review"
+          for adoption in $ADOPTIONS; do
+            n="${adoption%%=*}"
+            g="${adoption#*=}"
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create scaffold --color 5319e7 \
+              --description "Agent-scaffolded SDK coverage PR" 2>/dev/null || true
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create "scaffold:${g}" --color 5319e7 \
+              --description "Scaffold PR for SDK group ${g}" 2>/dev/null || true
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create "type: feature" --color 0e8a16 \
+              --description "New user-facing functionality" 2>/dev/null || true
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create skip-e2e --color ededed \
+              --description "Skip the acceptance suite on this PR" 2>/dev/null || true
+            GH_TOKEN="$APP_TOKEN" gh pr edit "$n" \
+              --add-label scaffold --add-label "scaffold:${g}" \
+              --add-label "type: feature" --add-label skip-e2e
+            GH_TOKEN="$APP_TOKEN" gh pr ready "$n"
+            echo "adopted scaffold PR #$n (group ${g}) — labels healed, marked ready"
           done
 
       - name: Select the group to scaffold

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -625,13 +625,28 @@ jobs:
           # The finalize sequence (push → create → label → ready) must be
           # RERUNNABLE: an attempt can die between any two of these calls, a
           # rerun keeps the same run_id (same branch name) but regenerates a
-          # different tree, and a plain push would then die non-fast-forward —
-          # stranding the previous attempt's PR in draft forever. When the
-          # branch already exists, reuse it as-is: whatever attempt pushed it
-          # ran this same gate first, and this repo never force-pushes.
+          # different tree, and this repo never force-pushes. Whatever happens,
+          # the PR body must describe the commit under review:
+          #   - branch AND its PR exist → reuse both, body untouched — the body
+          #     written by the attempt that pushed the branch describes that
+          #     tree; overwriting it with this attempt's metadata (handoff, SDK
+          #     version) would describe a tree nobody is reviewing;
+          #   - branch exists with NO PR → nobody references it; delete the
+          #     orphan ref and push this attempt's tree, so body and commit
+          #     match by construction;
+          #   - neither exists → the ordinary path.
+          reuse_pr=""
           if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
-            echo "branch ${branch} already pushed by a previous attempt — reusing it"
-          else
+            reuse_pr=$(GH_TOKEN="${{ github.token }}" gh pr list --state open --head "$branch" \
+              --json url --jq '.[0].url // empty')
+            if [ -n "$reuse_pr" ]; then
+              echo "branch ${branch} and its PR survive from a previous attempt — finishing their lifecycle"
+            else
+              echo "branch ${branch} is an orphan with no PR — replacing it with this attempt's tree"
+              git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
+            fi
+          fi
+          if [ -z "$reuse_pr" ]; then
             # Commit by explicit pathspec — the gate already proved the diff is
             # in scope, and adding by name means a stray file could not ride
             # along even if it were not.
@@ -829,20 +844,15 @@ jobs:
           # race test.yml: the `opened` event fires before any label exists, so
           # e2e would see no skip-e2e and launch the full live acceptance suite
           # on every agent PR. The ready_for_review event sees the labels.
-          # Every call here is reuse-aware for the same rerun reason as the push
-          # above — a previous attempt may have already created the PR (dedupe
-          # in the select step cannot catch it: labels are what it keys on, and
-          # they only exist after the edit below succeeds).
-          url=$(GH_TOKEN="$APP_TOKEN" gh pr list --state open --head "$branch" \
-            --json url --jq '.[0].url // empty')
+          # Labeling and readying are idempotent, so a reused PR from a previous
+          # attempt just gets its lifecycle finished here — its body stays as
+          # written by the attempt whose tree is actually on the branch.
+          url="$reuse_pr"
           if [ -z "$url" ]; then
             url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
               --head "$branch" \
               --title "feat(${short}): 🤖 scaffold ${TF_NAME} from SDK group ${GROUP}" \
               --body-file pr-body.md)
-          else
-            echo "PR for ${branch} already open from a previous attempt — finishing its lifecycle"
-            GH_TOKEN="$APP_TOKEN" gh pr edit "$url" --body-file pr-body.md
           fi
           GH_TOKEN="$APP_TOKEN" gh pr edit "$url" \
             --add-label scaffold --add-label "scaffold:${GROUP}" \

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -53,6 +53,11 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  # The release notes are authored by release-drafter and published by a human;
+  # goreleaser only attaches the build artifacts. keep-existing is already the
+  # default — made explicit so a goreleaser upgrade cannot silently start
+  # rewriting the notes.
+  mode: keep-existing
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/scripts/scaffold-validate.sh
+++ b/scripts/scaffold-validate.sh
@@ -274,18 +274,38 @@ case " ${kinds[*]} " in
 *" resource "* | *" datasource "*)
 	[ -f "examples/${TYPE_NAME}.tf" ] || fail "missing examples/${TYPE_NAME}.tf"
 	# The example must be SELF-CONTAINED: the PR's manual-validation snippet
-	# copies it alone into a scratch directory, so a var.* reference (those
-	# are declared only in the shared examples/variables.tf) turns the
-	# advertised `terraform plan` into an undeclared-reference error instead
-	# of exercising the provider. Use literal placeholders, or declare any
-	# helper resource the example depends on in the same file. Two greps, not
-	# one alternated pattern: `(^|...)var\.` is not portable across the grep
-	# implementations this gate runs under (GNU in CI, whatever aliases grep
-	# on a dev machine running the eval).
-	if grep -qE '[^a-zA-Z0-9_.]var\.' "examples/${TYPE_NAME}.tf" ||
-		grep -qE '^var\.' "examples/${TYPE_NAME}.tf"; then
-		fail "examples/${TYPE_NAME}.tf references var.* — the example must be self-contained (inline literals or declare helper resources in-file)"
+	# copies it alone into a scratch directory, so any reference satisfied only
+	# by a sibling file — a var.*, another example's resource, a local, a
+	# module — turns the advertised `terraform plan` into an undeclared-
+	# reference error instead of exercising the provider. Validate it exactly
+	# the way the snippet consumes it: alone, against this very build, through
+	# a throwaway dev_overrides. No init, no credentials, no network.
+	command -v terraform >/dev/null || fail "the terraform CLI is required: the gate validates examples/${TYPE_NAME}.tf standalone"
+	tfscratch=$(mktemp -d)
+	go build -o "$tfscratch/terraform-provider-latitudesh" . ||
+		{ rm -rf "$tfscratch"; fail "could not build the provider binary for standalone example validation"; }
+	cat >"$tfscratch/dev.tfrc" <<-TFRC
+		provider_installation {
+		  dev_overrides {
+		    "latitudesh/latitudesh" = "$tfscratch"
+		  }
+		  direct {}
+		}
+	TFRC
+	mkdir "$tfscratch/example"
+	cp "examples/${TYPE_NAME}.tf" "$tfscratch/example/main.tf"
+	cat >"$tfscratch/example/provider.tf" <<-'TFPROVIDER'
+		terraform {
+		  required_providers {
+		    latitudesh = { source = "latitudesh/latitudesh" }
+		  }
+		}
+	TFPROVIDER
+	if ! (cd "$tfscratch/example" && TF_CLI_CONFIG_FILE="$tfscratch/dev.tfrc" terraform validate -no-color); then
+		rm -rf "$tfscratch"
+		fail "examples/${TYPE_NAME}.tf does not validate standalone — it must be self-contained: no var.*, no references to resources declared elsewhere; declare helper resources in the same file"
 	fi
+	rm -rf "$tfscratch"
 	;;
 esac
 case " ${kinds[*]} " in

--- a/scripts/scaffold-validate.sh
+++ b/scripts/scaffold-validate.sh
@@ -273,6 +273,19 @@ done
 case " ${kinds[*]} " in
 *" resource "* | *" datasource "*)
 	[ -f "examples/${TYPE_NAME}.tf" ] || fail "missing examples/${TYPE_NAME}.tf"
+	# The example must be SELF-CONTAINED: the PR's manual-validation snippet
+	# copies it alone into a scratch directory, so a var.* reference (those
+	# are declared only in the shared examples/variables.tf) turns the
+	# advertised `terraform plan` into an undeclared-reference error instead
+	# of exercising the provider. Use literal placeholders, or declare any
+	# helper resource the example depends on in the same file. Two greps, not
+	# one alternated pattern: `(^|...)var\.` is not portable across the grep
+	# implementations this gate runs under (GNU in CI, whatever aliases grep
+	# on a dev machine running the eval).
+	if grep -qE '[^a-zA-Z0-9_.]var\.' "examples/${TYPE_NAME}.tf" ||
+		grep -qE '^var\.' "examples/${TYPE_NAME}.tf"; then
+		fail "examples/${TYPE_NAME}.tf references var.* — the example must be self-contained (inline literals or declare helper resources in-file)"
+	fi
 	;;
 esac
 case " ${kinds[*]} " in


### PR DESCRIPTION
### Summary

Follow-ups from the first live agent PR (#223), polishing the generated PR surface and the release flow:

- **Agent PRs now open ready for review** via a draft → labels → `gh pr ready` sequence. Creating them non-draft would race `test.yml` (the `opened` event fires before labels exist), launching the full acceptance suite on every agent PR; instead `skip-e2e` is applied before the `ready_for_review` event, keeping acceptance opt-in (remove the label to run it).
- **Versioning section** in the PR body, Speakeasy-style: bump type (always minor for new coverage) plus a concrete suggestion computed from the latest published release (`v4.1.3 → v4.2.0`), with graceful fallback when no release exists.
- **Manual validation section** in the PR body: copy-paste snippets — token and test project as separate blocks — that clone the PR branch, `make build` the provider, point Terraform at it through an ephemeral `dev_overrides` (`TF_CLI_CONFIG_FILE`, never touching `~/.terraformrc`), and apply the shipped example against the real API.
- **Agent cost/stats moved out of the PR body** into the workflow step summary (group, model, prompt version, turns, rounded cost, handoff-file presence). The body footer keeps only the prompt version for traceability.
- **Release-drafter revived**: autolabeler maps conventional-commit PR titles to `type:` labels so the version resolver always has input (`default: patch`); richer release template (categorized changes with emojis, install/upgrade HCL snippet pinned to `$RESOLVED_VERSION`, Terraform Registry link, contributors); action pinned by SHA; `goreleaser` `release.mode: keep-existing` made explicit so publishing the drafted notes never gets overwritten by the tag build.

The scaffold prompt is deliberately untouched, so no fresh eval is required by the repo convention.

### Testing

```bash
ruby -ryaml -e 'YAML.load_file(".github/workflows/sdk-watch.yml")'   # + the other 3 YAML files
```

- Body builder executed locally with fake values (extracted from the workflow step): Versioning, Coverage, Manual-validation, checklist, and footer render correctly; `$workdir`/`$LATITUDESH_PROJECT` stay literal while branch/example/repo are substituted.
- The manual-validation snippet was executed verbatim against PR #223's branch up to `terraform plan`: clone → `make build` → `dev_overrides` → example copied → valid plan (`1 to add`), including `token = (sensitive value)`.

After merge: `gh workflow enable release-drafter.yml` (it is currently `disabled_manually`), then the next scaffold run exercises the new body end to end.

Fixes DX-126










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR polishes scaffold-generated pull requests and restores the release-drafting flow.
- Adds recovery for interrupted draft creation and makes scaffold PRs ready only after applying labels.
- Adds standalone Terraform example validation and copy-paste manual validation instructions.
- Expands release-note categorization, version resolution, and installation guidance.
- Preserves release-drafter notes when GoReleaser attaches artifacts.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Generate scaffold] --> B[Validate standalone example]
  B --> C[Push scaffold branch]
  C --> D[Create draft PR]
  D --> E[Apply scaffold and skip-e2e labels]
  E --> F[Mark ready for review]
  D -. interrupted run .-> G[Discover orphan draft]
  G --> E
```

<sub>Reviews (5): Last reviewed commit: ["fix(scaffold): discover orphaned drafts ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/8417cfb48f54b0c261766f1600dd8dfa982f4945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57945884)</sub>

<!-- /greptile_comment -->