### PR TITLE
fix(scaffold): inline the example HCL in the manual-validation snippet

### DIFF
--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -878,15 +878,25 @@ jobs:
           # This PR's example, inlined so you can adjust names and values before
           # applying. It is gate-enforced to be self-contained; it may declare
           # helper resources it depends on, and apply creates those too.
-          cat > main.tf <<'EXAMPLE'
+          cat > main.tf <<'TF_EXAMPLE_EOF_9f3a'
           MANUAL_EOF
             # The example ships inline in the snippet — the reviewer should see and
             # tweak the HCL they are about to apply without opening the diff. Body
             # build runs after the scaffold commit, so this is byte-identical to
-            # the file on the branch.
-            cat "examples/$TF_NAME.tf"
+            # the file on the branch. A line equal to the terminator would end the
+            # reviewer's paste early and feed the remaining HCL to their shell —
+            # unreachable for real HCL, kept impossible anyway.
+            if grep -qxF 'TF_EXAMPLE_EOF_9f3a' "examples/$TF_NAME.tf"; then
+              # >&2: stdout is redirected into pr-body.md inside this group — an
+              # error printed there would be buried in the half-written body.
+              echo "examples/$TF_NAME.tf contains the snippet's heredoc terminator line" >&2
+              exit 1
+            fi
+            # awk, not cat: it terminates the final record even when the file lacks
+            # a trailing newline, so the terminator always sits on its own line.
+            awk '{ print }' "examples/$TF_NAME.tf"
             cat <<'MANUAL_EOF'
-          EXAMPLE
+          TF_EXAMPLE_EOF_9f3a
 
           terraform plan     # dev_overrides active: no init needed; expect the overrides warning
           terraform apply

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -830,7 +830,7 @@ jobs:
             # inner heredocs must reach the reviewer verbatim); the three
             # run-specific values are spliced by sed. The inner terminators are
             # EOF, which never collides with MANUAL_EOF.
-            cat <<'MANUAL_EOF' | sed -e "s|__BRANCH__|$branch|g" -e "s|__REPO__|$GH_REPO|g" -e "s|__EXAMPLE__|examples/$TF_NAME.tf|g"
+            cat <<'MANUAL_EOF' | sed -e "s|__BRANCH__|$branch|g" -e "s|__REPO__|$GH_REPO|g"
           The agent's acceptance tests run against a local mock — nothing in this PR touched the real API. The snippets below build this branch and exercise the resource end-to-end against the real API. Credentials are separate blocks so you can paste them independently.
 
           **1. Token:**
@@ -875,9 +875,18 @@ jobs:
             project = "$LATITUDESH_PROJECT"
           }
           EOF
-          cp "$workdir/provider/__EXAMPLE__" main.tf
-          # The example is gate-enforced to be self-contained; note it may declare
-          # helper resources it depends on, and apply will create those too.
+          # This PR's example, inlined so you can adjust names and values before
+          # applying. It is gate-enforced to be self-contained; it may declare
+          # helper resources it depends on, and apply creates those too.
+          cat > main.tf <<'EXAMPLE'
+          MANUAL_EOF
+            # The example ships inline in the snippet — the reviewer should see and
+            # tweak the HCL they are about to apply without opening the diff. Body
+            # build runs after the scaffold commit, so this is byte-identical to
+            # the file on the branch.
+            cat "examples/$TF_NAME.tf"
+            cat <<'MANUAL_EOF'
+          EXAMPLE
 
           terraform plan     # dev_overrides active: no init needed; expect the overrides warning
           terraform apply


### PR DESCRIPTION
### Summary

The manual-validation snippet in agent PR bodies copied the example out of the clone (`cp .../examples/<type>.tf main.tf`), so reviewers could not see or tweak the HCL they were about to apply without opening the diff. The snippet now inlines the example verbatim in a `cat > main.tf <<'EXAMPLE'` block — the body is built after the scaffold commit, so the inlined HCL is byte-identical to the file on the branch.

### Testing

Body builder executed locally with fake values (extracted from the workflow step): the snippet renders the inline `EXAMPLE` heredoc with the real HCL, followed by the terraform commands; branch/repo placeholders still substitute correctly.

Related to DX-126





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR hardens the manual-validation snippet that embeds example HCL in generated agent PR bodies.
- Emits the example through a quoted, dedicated heredoc.
- Rejects examples containing the exact heredoc terminator.
- Ensures the terminator starts on a new line even when the source file lacks a trailing newline.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(scaffold): harden the inline-example..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/02008d0b4775c43e9341d3b44d8b1a13fc01aef7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58002980)</sub>

<!-- /greptile_comment -->