### PR TITLE
feat(coverage): detect and auto-fix field-level SDK drift on covered groups

### DIFF
--- a/.github/prompts/fix-field-drift.md
+++ b/.github/prompts/fix-field-drift.md
@@ -1,0 +1,150 @@
+---
+prompt-version: 1
+---
+
+# Map field drift on covered latitudesh-go-sdk service group(s)
+
+You are producing a **draft PR** that reconciles already-covered SDK service
+group(s) with what their Terraform types actually map, after the SDK's models
+moved. A human reviews it, exercises it against the live API, and merges. You
+never reach the network.
+
+`{{GROUP}}` may name several comma-separated groups: when drift is breaking,
+every breaking group rides in one PR, because the gate checks the whole surface
+and could never go green one group at a time.
+
+This is NOT scaffolding: the resource exists, users hold state written by it,
+and your edits change what future plans and applies do to that state. The
+validation gate proves your change is well-formed, not that it is correct —
+reviewers rely on your handoff (last section) for everything you could not
+verify offline.
+
+## 0. Verify the premise before writing anything
+
+```
+go run ./cmd/sdkcoverage drift -format text
+```
+
+No row naming any of `{{GROUP}}` means the drift is already reconciled — **stop
+and say so**. Someone else's PR got there first; do not "improve" the existing
+mapping, that is a different task with a different review.
+
+## The target
+
+- SDK group(s): `{{GROUP}}`
+- Terraform types that own the mapping: {{IMPLEMENTED_BY}}
+- Pinned SDK version: `{{SDK_VERSION}}`
+- The drift, verbatim from the detector:
+
+```json
+{{DRIFT_JSON}}
+```
+
+Every row is yours to close, one way or the other: map it, or deliberately omit
+it and say why. `breaking: true` rows are failing `TestProviderSDKFieldDrift`
+on this branch right now — the gate stays red until you resolve them.
+
+## Turn budget
+
+Hard cap of {{MAX_TURNS}} turns; a clean pass fits well under it. Keep
+`/tmp/drift-handoff.md` current from your first edit onwards (see Finish) — a
+turn-capped session emits no final message, and that file is the only handoff
+that survives.
+
+## How to treat each drift kind
+
+**`field_added`** — expose it. The Terraform attribute name is the SDK's json
+tag verbatim (the detector's `suggested_attribute` already says it). New
+attributes are **Optional + Computed** — never Required — unless the field is a
+required member of a *create request body*, in which case flag the
+config-breaking consequence in the handoff instead of deciding it yourself.
+Read the SDK field's doc comment before mapping: it carries semantics the type
+cannot (nullable-during-provisioning, mode-dependent requirements). A field the
+provider deliberately should NOT expose (server-side seeding artifacts,
+lazy-loaded extras) is omitted by syncing the lock and recording why — see
+Finish.
+
+**`enum_value_added` / `enum_value_removed`** — find every site that validates
+or coerces the enum's values, not just the schema. The canonical trap:
+`resource_firewall.go` coerces unknown protocols in a `switch` — adding a value
+to a validator without touching the coercion fixes nothing. Name the exact
+sites you changed (file and function) in the handoff.
+
+**`field_type_changed` / `field_required_changed`** — adjust the mapping to the
+new shape. If the old type can still appear in existing state files, say what a
+plan against old state does after your change; if you cannot tell offline, that
+is a handoff item, not a guess.
+
+**`field_removed` / `method_removed` / `method_signature_changed`** — remove or
+rewrite the dead mapping. If an attribute loses its API backing entirely, do
+NOT silently delete a user-visible attribute: keep it with a deprecation note in
+the schema description and flag the removal decision for the reviewer.
+
+**`deprecated` / `doc_changed` / `default_changed`** — read the new doc text in
+the SDK source and decide whether the mapping or the resource documentation
+must change. Often the whole fix is syncing the lock; the handoff says what you
+read and why nothing else moved.
+
+**`group_unlocked` / `model_added` / `model_removed` / `method_added`** —
+usually no code change: sync the lock (Finish) and note anything a reviewer
+should pick up later. A new *method* on a covered group may deserve its own
+resource — name it in the handoff and in `notes:` under `{{GROUP}}` in
+`sdk-coverage.yaml`; do not build it here.
+
+## Hard rules
+
+- **Never add or change plan modifiers** (`RequiresReplace`, defaults on
+  existing attributes) and never flip an existing attribute's Required/Optional/
+  Computed — those are API-behavior judgments no syntax reveals. If one seems
+  needed, write it in the handoff for the reviewer.
+- Touch only: `latitudesh/{resource,datasource,action}_*.go`,
+  `latitudesh/*_test.go`, `latitudesh/provider.go`, `sdk-coverage.yaml`,
+  `sdk-fields.lock.yaml` (via the sync command only), `templates/**`,
+  `examples/**`, `docs/**` — plus `/tmp/drift-handoff.md`, the one write allowed
+  outside the repository. Not `go.mod`, not `cmd/`, not `internal/`, not
+  `.github/`.
+- Sync the lock **only** with
+  `go run ./cmd/sdkcoverage fields -write -group {{GROUP}}` — never hand-edit
+  it, and never a full `fields -write`: that would silently accept every other
+  group's drift in a PR reviewed for this one.
+- Follow the house conventions of the files you edit — nil-check every SDK
+  pointer to `types.XNull()`, reuse the existing diagnostics vocabulary, keep
+  attribute docs in the schema `Description` fields.
+- Every schema change needs test coverage: extend the type's existing
+  `*_test.go` (offline tier at minimum — plain `go test ./latitudesh` must stay
+  green, no TF_ACC, no token).
+- Never add a `go:generate` directive, never reach the network, never write a
+  token or key anywhere, never hand-edit `docs/` — edit the template and let the
+  gate regenerate.
+
+## Finish: lock, handoff, gate
+
+1. Sync the target lock entries (and ONLY those — the command takes the exact
+   comma-separated list): `go run ./cmd/sdkcoverage fields -write -group {{GROUP}}`.
+   The lock's git diff is the record of what this PR accepted — every deliberate
+   omission must also be explained in `notes:` under its group in
+   `sdk-coverage.yaml`. The gate verifies the lock changed nowhere else.
+2. **Write the handoff block below to `/tmp/drift-handoff.md` as soon as your
+   first edit builds, and keep it current.**
+3. Run the gate and fix what it reports:
+
+```
+scripts/scaffold-validate.sh --mode drift --group {{GROUP}}
+```
+
+`PASS` means well-formed: build, vet, offline tests, docs regenerated, zero
+remaining drift for `{{GROUP}}`, coverage still reconciles. It does not mean
+correct. End your final message with the same block, filled in — write "none"
+only where genuinely nothing applies.
+
+```markdown
+## Handoff — not verified offline
+
+**Drift rows closed by mapping:** attribute ↔ SDK field, per row
+**Drift rows closed by deliberate omission:** which, and the why recorded in notes
+**Breaking rows:** what the old mapping did, what the new one does, what happens to existing state
+**Enum/coercion sites touched:** file and function, per enum
+**Plan-modifier questions for the reviewer:** RequiresReplace / defaults you did NOT add
+**State-compatibility assumptions:** …
+**Open questions for the reviewer:** …
+```

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -52,6 +52,10 @@ jobs:
       pinned: ${{ steps.resolve.outputs.pinned }}
       latest: ${{ steps.resolve.outputs.latest }}
       pinned_check_ok: ${{ steps.pinned_check.outputs.ok }}
+      pinned_group_ok: ${{ steps.pinned_check.outputs.group_ok }}
+      drift_breaking: ${{ steps.drift.outputs.breaking }}
+      drift_new: ${{ steps.drift.outputs.informational }}
+      drift_data_ok: ${{ steps.drift.outputs.data_ok }}
     steps:
       # Every action here is pinned to an immutable commit SHA: this workflow's
       # sibling job writes issues, so a mutable tag would let reviewed action code
@@ -103,6 +107,36 @@ jobs:
           echo "pending=$pending" >> "$GITHUB_OUTPUT"
           echo "$pending group(s) pending against $LATEST"
 
+      - name: Report field drift against the latest SDK
+        id: drift
+        env:
+          SDK_MODULE: github.com/latitudesh/latitudesh-go-sdk
+          LATEST: ${{ steps.resolve.outputs.latest }}
+        run: |
+          set -euo pipefail
+          # Field drift on covered groups: the committed sdk-fields.lock.yaml vs
+          # the latest SDK's models. Informational here by design — the gate that
+          # fails on breaking drift runs against the PINNED SDK on every PR; this
+          # channel is the early warning that feeds the tracking issue and the
+          # drift-fix job. It must never sink detect: no drift data beats no
+          # tracking issue.
+          dir=$(go mod download -json "$SDK_MODULE@$LATEST" | jq -r '.Dir')
+          # A missing lock is NOT a failure here — the tool exits 0 with a
+          # lock_missing document. A nonzero exit is a genuine crash (corrupt
+          # lock, parse error), and the one thing a crash must not do is
+          # fabricate a healthy zero-drift document: mark the data unusable and
+          # let the issue say so, instead of closing over drift nobody measured.
+          if go run ./cmd/sdkcoverage drift -format json -sdk-dir "$dir" > drift.json; then
+            echo "data_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::field drift report failed — drift status is unknown this run"
+            echo '{"sdk_module":"'"$SDK_MODULE"'","lock_missing":false,"ok":false,"counts":{"total":0,"breaking":0,"informational":0},"drift":[]}' > drift.json
+            echo "data_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "breaking=$(jq -r '.counts.breaking' drift.json)" >> "$GITHUB_OUTPUT"
+          echo "informational=$(jq -r '.counts.informational' drift.json)" >> "$GITHUB_OUTPUT"
+          echo "$(jq -r '.counts.total' drift.json) field drift row(s) against $LATEST ($(jq -r '.counts.breaking' drift.json) breaking)"
+
       - name: Check the pinned SDK for contradictions
         id: pinned_check
         # Advisory here, not fatal: a contradiction on the pinned SDK is already a
@@ -117,9 +151,14 @@ jobs:
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::pinned SDK has coverage contradictions; see the tracking issue"
+            echo "::warning::pinned SDK has coverage contradictions or breaking field drift; see the tracking issue"
           fi
           cat pinned_check.txt
+          # check now covers two ledgers (group contradictions AND breaking
+          # field drift vs the lock). The drift-fix job must still run when the
+          # ONLY problem is drift — it is the automation that fixes exactly that
+          # — so record the group-level verdict separately for its gate.
+          echo "group_ok=$(go run ./cmd/sdkcoverage report -format json | jq -r '.ok')" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -127,6 +166,7 @@ jobs:
           name: sdk-coverage-report
           path: |
             report.json
+            drift.json
             pinned_check.txt
           retention-days: 14
           # v4 artifacts are immutable per run (not per attempt): without this,
@@ -154,6 +194,9 @@ jobs:
       PINNED: ${{ needs.detect.outputs.pinned }}
       LATEST: ${{ needs.detect.outputs.latest }}
       PINNED_CHECK_OK: ${{ needs.detect.outputs.pinned_check_ok }}
+      DRIFT_BREAKING: ${{ needs.detect.outputs.drift_breaking }}
+      DRIFT_NEW: ${{ needs.detect.outputs.drift_new }}
+      DRIFT_DATA_OK: ${{ needs.detect.outputs.drift_data_ok }}
       DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
       - name: Download coverage report
@@ -178,7 +221,7 @@ jobs:
             if [ "${PINNED_CHECK_OK}" = "false" ]; then
               echo
               echo "> [!WARNING]"
-              echo "> The pinned SDK (\`${PINNED}\`) has coverage contradictions. This normally fails a PR's unit tests; seeing it here means something reached \`main\` unchecked. Fix \`sdk-coverage.yaml\` and/or the provider registration."
+              echo "> The pinned SDK (\`${PINNED}\`) has coverage contradictions or breaking field drift against the lock. This normally fails a PR's unit tests; seeing it here means something reached \`main\` unchecked. Fix \`sdk-coverage.yaml\` / the provider registration, or reconcile \`sdk-fields.lock.yaml\` (\`make drift-report\`)."
             fi
 
             # Violations against the LATEST SDK never fail a PR (nothing pins that
@@ -216,6 +259,61 @@ jobs:
               echo "Excluded on API grounds, but the SDK has since grown past the recorded ceiling. Not urgent — re-triage when convenient."
               echo
               jq -r '.revisit[] | "- `\(.group)` — recorded ceiling `\(.ceiling)`, now `\(.crud)`"' report.json
+            fi
+
+            # Field drift on covered groups: the committed lock vs the latest
+            # SDK's models. Breaking rows get the warning treatment — they will
+            # fail the gate on whatever PR bumps the SDK; additions are the
+            # drift-fix job's queue. Rows are deduped by (kind, model, field):
+            # a shared component drifts once per covered group in drift.json
+            # (attribution), but reads better here as one line naming them all.
+            drift_total=$(jq -r '.counts.total' drift.json)
+            lock_missing=$(jq -r '.lock_missing' drift.json)
+            if [ "${DRIFT_DATA_OK}" != "true" ]; then
+              echo
+              echo "## Field drift on covered groups"
+              echo
+              echo "> [!WARNING]"
+              echo "> The field drift report crashed this run — drift status is **unknown**, not clean. Check the workflow logs."
+            elif [ "$lock_missing" = "true" ]; then
+              echo
+              echo "## Field drift on covered groups"
+              echo
+              echo "_No \`sdk-fields.lock.yaml\` — field drift is not being tracked. Seed it with \`make fields-sync\`._"
+            elif [ "$drift_total" -gt 0 ]; then
+              echo
+              echo "## Field drift on covered groups"
+              echo
+              echo "The SDK's models moved under groups the provider already covers (lock \`$(jq -r '.lock_sdk_version // "?"' drift.json)\` vs \`${LATEST}\`). The drift-fix job turns these into draft PRs; accepting a change deliberately means regenerating \`sdk-fields.lock.yaml\` in a reviewed PR."
+              if [ "${DRIFT_BREAKING}" -gt 0 ]; then
+                echo
+                echo "> [!WARNING]"
+                echo "> ${DRIFT_BREAKING} breaking change(s): the provider's compiled-in mappings assume a shape the SDK no longer has. These fail the field-drift gate on whatever PR bumps the SDK."
+                echo ">"
+                jq -r '
+                  [.drift[] | select(.breaking)]
+                  | group_by([.kind, .model, .field, .detail]) | .[] | .[0] as $d
+                  | (map(.group) | unique | map("`"+.+"`") | join(", ")) as $groups
+                  | "> - " + $groups
+                    + (if ($d.model // "") != "" then " `\($d.model)`" else "" end)
+                    + (if ($d.field // "") != "" then " `\($d.field)`" else "" end)
+                    + " — \($d.kind): \($d.detail)"
+                    + (if ($d.implemented_by | length) > 0 then " (fix in " + ($d.implemented_by | map("`"+.+"`") | join(", ")) + ")" else "" end)
+                ' drift.json
+              fi
+              if [ "${DRIFT_NEW}" -gt 0 ]; then
+                echo
+                jq -r '
+                  [.drift[] | select(.breaking | not)]
+                  | group_by([.kind, .model, .field, .detail]) | .[] | .[0] as $d
+                  | (map(.group) | unique | map("`"+.+"`") | join(", ")) as $groups
+                  | "- [ ] " + $groups
+                    + (if ($d.model // "") != "" then " `\($d.model)`" else "" end)
+                    + (if ($d.field // "") != "" then " `\($d.field)`" else "" end)
+                    + " — \($d.kind): \($d.detail)"
+                    + (if ($d.suggested_attribute // "") != "" then " → suggested attribute `\($d.suggested_attribute)`" else "" end)
+                ' drift.json
+              fi
             fi
 
             echo
@@ -277,18 +375,26 @@ jobs:
           if [ "$violations" -gt 0 ]; then
             title="SDK coverage: ${PENDING} pending, ${violations} violation(s) against ${LATEST}"
           fi
+          drift_total=$(( ${DRIFT_BREAKING:-0} + ${DRIFT_NEW:-0} ))
+          if [ "${DRIFT_BREAKING:-0}" -gt 0 ]; then
+            title="${title}, ${drift_total} field drift (${DRIFT_BREAKING} breaking)"
+          elif [ "$drift_total" -gt 0 ]; then
+            title="${title}, ${drift_total} field drift"
+          fi
           if [ "${PINNED_CHECK_OK}" != "true" ]; then
             title="${title} — pinned SDK check failing"
           fi
 
           # Close only when there is truly nothing to report: zero pending, a
-          # clean latest reconcile, AND a passing pinned check. The pinned check
-          # is this run's backstop — main has no required status checks, so a
-          # contradiction that reached it unchecked surfaces nowhere else; closing
-          # over it would bury the one warning this workflow exists to keep
-          # visible. Anything but an explicit "true" (including an empty output
-          # from a broken step) keeps the issue open.
-          if [ "${PENDING}" -eq 0 ] && [ "$violations" -eq 0 ] && [ "${PINNED_CHECK_OK}" = "true" ]; then
+          # clean latest reconcile, a passing pinned check, AND zero field drift.
+          # The pinned check is this run's backstop — main has no required status
+          # checks, so a contradiction that reached it unchecked surfaces nowhere
+          # else; closing over it would bury the one warning this workflow exists
+          # to keep visible. Field drift counts too: a drift-only week closing
+          # the tracker would hide the exact section the drift-fix pipeline works
+          # from. Anything but an explicit "true" (including an empty output from
+          # a broken step) keeps the issue open.
+          if [ "${PENDING}" -eq 0 ] && [ "$violations" -eq 0 ] && [ "${PINNED_CHECK_OK}" = "true" ] && [ "$drift_total" -eq 0 ] && [ "${DRIFT_DATA_OK}" = "true" ]; then
             if [ -n "$existing" ]; then
               gh issue comment "$existing" --body "All SDK service groups are now covered or excluded as of \`${LATEST}\`. Closing; a future run opens a fresh tracking issue if a coverage gap reappears."
               gh issue close "$existing"
@@ -307,18 +413,562 @@ jobs:
             echo "Created a new tracking issue"
           fi
 
+  # Turn field drift on ONE covered group into a draft PR. The scaffold job's
+  # sibling with a different unit of work: not a new type, but the reconciliation
+  # of an existing group's mapping after the SDK's models moved. It handles every
+  # drift kind — breaking included, with a warning block in the PR body — because
+  # the reviewer of real code is the arbiter here, exactly as in scaffolding. It
+  # runs BEFORE scaffold (scaffold `needs` it): breaking drift gets its fix PR
+  # opened ahead of new-group work, and the scaffold bump guard refuses to ride
+  # over what this job has not yet reconciled.
+  driftfix:
+    name: drift-fix
+    needs: detect
+    # Never on a dry run, never when a human is retrying a specific scaffold
+    # group, never on GROUP-LEVEL contradictions (a lying ledger), and only
+    # when there is drift. Deliberately pinned_group_ok rather than the full
+    # pinned check: the full check also fails on breaking field drift, and
+    # suppressing this job on that would deadlock the one automation that
+    # fixes it. A missing lock reports zero drift, so this job stays skipped
+    # until the lock is seeded — the $0-on-no-drift guarantee is structural.
+    if: >-
+      github.event.inputs.dry_run != 'true' &&
+      github.event.inputs.group == '' &&
+      needs.detect.outputs.pinned_group_ok == 'true' &&
+      (needs.detect.outputs.drift_breaking != '0' || needs.detect.outputs.drift_new != '0')
+    runs-on: ubuntu-latest
+    # Same slack as scaffold, same reason: a job-level timeout is a cancellation
+    # and skips every failure() handler; the step timeouts are the real budget.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    env:
+      # Same token discipline as scaffold: no job-level GH_TOKEN, because the
+      # agent step inherits job env and runs code it just wrote.
+      GH_REPO: ${{ github.repository }}
+      SDK_MODULE: github.com/latitudesh/latitudesh-go-sdk
+      LATEST: ${{ needs.detect.outputs.latest }}
+      # One open drift PR at a time: drift PRs edit existing resources, so two
+      # in flight would conflict on the same files far more readily than two
+      # scaffolds do.
+      MAX_OPEN_DRIFT_PRS: "1"
+      DRIFT_MODEL: claude-sonnet-5
+      # Keep in sync with SCAFFOLD_MAX_TURNS: same budget rationale.
+      DRIFT_MAX_TURNS: "200"
+      GIT_BOT_NAME: "latitudesh-sdk-watch[bot]"
+      GIT_BOT_EMAIL: "latitudesh-sdk-watch[bot]@users.noreply.github.com"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # Same as scaffold: never let the default token shadow the app token
+          # in .git/config, never leave it readable during the agent step.
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sdk-coverage-report
+          # NEVER into the workspace — the gate's diff-scope check scans
+          # untracked files (see the scaffold job's identical step).
+          path: ${{ runner.temp }}/sdk-coverage
+
+      # Same orphan semantics as scaffold, keyed on this job's own body marker:
+      # an open draft with a `<!-- drift:... -->` marker at the start of a run
+      # was pushed by an attempt that died before finishing its lifecycle.
+      - name: Find orphaned drift drafts
+        id: orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body \
+            --jq '[.[] | select(.isDraft) | select((.body // "") | contains("<!-- drift:"))
+                   | "\(.number)=\((.body | capture("<!-- drift:(?<g>[^ ]+) -->").g))"] | join(" ")')
+          echo "adoptions=$adoptions" >> "$GITHUB_OUTPUT"
+          if [ -n "$adoptions" ]; then
+            echo "::notice::orphaned draft drift PR(s) to adopt: $adoptions"
+          else
+            echo "no orphaned drafts"
+          fi
+
+      - name: Mint a token to adopt orphans
+        id: adopt_app
+        if: steps.orphans.outputs.adoptions != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
+          private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
+
+      - name: Adopt orphaned drift drafts
+        if: steps.orphans.outputs.adoptions != ''
+        env:
+          DEFAULT_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.adopt_app.outputs.token }}
+          ADOPTIONS: ${{ steps.orphans.outputs.adoptions }}
+        run: |
+          set -euo pipefail
+          for adoption in $ADOPTIONS; do
+            n="${adoption%%=*}"
+            g="${adoption#*=}"
+            # The marker carries a comma-separated set when the PR reconciled
+            # several breaking groups at once — one drift:<group> label each.
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create drift --color b60205 \
+              --description "Agent PR reconciling SDK field drift on a covered group" 2>/dev/null || true
+            group_label_args=""
+            for one in ${g//,/ }; do
+              GH_TOKEN="$DEFAULT_TOKEN" gh label create "drift:${one}" --color b60205 \
+                --description "Drift PR for SDK group ${one}" 2>/dev/null || true
+              group_label_args="$group_label_args --add-label drift:${one}"
+            done
+            GH_TOKEN="$DEFAULT_TOKEN" gh label create skip-e2e --color ededed \
+              --description "Skip the acceptance suite on this PR" 2>/dev/null || true
+            # shellcheck disable=SC2086 — group_label_args is a flag list on purpose
+            GH_TOKEN="$APP_TOKEN" gh pr edit "$n" \
+              --add-label drift $group_label_args --add-label skip-e2e
+            GH_TOKEN="$APP_TOKEN" gh pr ready "$n"
+            echo "adopted drift PR #$n (group(s) ${g}) — labels healed, marked ready"
+          done
+
+      - name: Select the group to reconcile
+        id: select
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Same claim/park discipline as scaffold, in this job's own label
+          # namespace: an open drift PR claims its group; a drift PR closed
+          # without merging parks the group until a human decides (re-triggering
+          # is a manual sync or a workflow_dispatch after the park is resolved).
+          claimed=$(gh pr list --label drift --state open --json labels \
+            --jq '[.[].labels[].name | select(startswith("drift:")) | ltrimstr("drift:")] | unique | .[]')
+          parked=$(gh pr list --label drift --state closed --limit 100 --json labels,mergedAt \
+            --jq '[.[] | select(.mergedAt == null) | .labels[].name | select(startswith("drift:")) | ltrimstr("drift:")] | unique | .[]')
+
+          open_count=$(gh pr list --label drift --state open --json number --jq 'length')
+          if [ "$open_count" -ge "$MAX_OPEN_DRIFT_PRS" ]; then
+            echo "has_work=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$open_count drift PR(s) already open (cap $MAX_OPEN_DRIFT_PRS) — not reconciling this run"
+            exit 0
+          fi
+
+          # group_stale rows (a group that left coverage but still sits in the
+          # lock) are excluded: their fix is the human PR that changed coverage,
+          # not a per-group resync — `fields -write -group` cannot even name a
+          # group the manifest no longer covers.
+          drift_json="$RUNNER_TEMP/sdk-coverage/drift.json"
+          breaking_groups=$(jq -r '[.drift[] | select(.breaking) | .group] | unique | .[]' "$drift_json")
+
+          if [ -n "$breaking_groups" ]; then
+            # Breaking drift is all-or-nothing per SDK bump: the gate checks the
+            # whole surface against the bumped tree, so a PR fixing one breaking
+            # group would still be red on the others and could never merge. One
+            # PR carries every breaking group; a parked breaking group therefore
+            # blocks the set and needs a human decision first — fail loudly
+            # BEFORE spending agent tokens.
+            blocked=$(printf '%s\n' "$breaking_groups" | grep -Fxf <(printf '%s\n' "$parked") || true)
+            if [ -n "$blocked" ]; then
+              echo "::error::breaking drift includes parked group(s): $(echo "$blocked" | tr '\n' ' ')— resolve their closed drift PR decision (or sync the lock in a reviewed PR) before this job can proceed"
+              exit 1
+            fi
+            pick=$(printf '%s\n' "$breaking_groups" | paste -sd, -)
+          else
+            # Informational-only drift: one group per run, most-moved first,
+            # name for determinism, claimed/parked skipped.
+            pick=""
+            while read -r g; do
+              printf '%s\n' "$claimed" | grep -Fxq "$g" && continue
+              printf '%s\n' "$parked" | grep -Fxq "$g" && continue
+              pick="$g"
+              break
+            done < <(jq -r '
+              [.drift[] | select(.kind != "group_stale") | {group}] | group_by(.group)
+              | map({group: .[0].group, total: length})
+              | sort_by([-.total, .group])
+              | .[].group
+            ' "$drift_json")
+          fi
+
+          if [ -z "$pick" ]; then
+            echo "has_work=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::every drifted group is claimed, parked, or stale-only — nothing to reconcile"
+            exit 0
+          fi
+          echo "has_work=true" >> "$GITHUB_OUTPUT"
+          echo "group=$pick" >> "$GITHUB_OUTPUT"
+          echo "Selected: $pick"
+
+      - name: Bump the SDK to the latest release
+        if: steps.select.outputs.has_work == 'true'
+        run: |
+          set -euo pipefail
+          # Drift is measured against the latest published SDK, so the fix must
+          # compile against it. Same division of labor as scaffold: the workflow
+          # owns go.mod, the agent is forbidden from touching it. No drift guard
+          # here, deliberately — this is the job that RESOLVES the drift the
+          # scaffold bump guard refuses to ride over.
+          pinned=$(go list -m -f '{{.Version}}' "$SDK_MODULE")
+          if [ "$pinned" = "$LATEST" ]; then
+            echo "pinned SDK already at $LATEST — no bump needed"
+            exit 0
+          fi
+          go get "$SDK_MODULE@$LATEST"
+          go mod tidy
+          # A bump that breaks the build is human work, not agent work.
+          go build ./...
+          git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            commit -m "chore(deps): bump latitudesh-go-sdk to $LATEST" -- go.mod go.sum
+
+      - name: Render the drift prompt
+        id: render
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -euo pipefail
+          # Recompute in-branch rather than trusting the artifact: the bump just
+          # made pinned == latest, and the agent must see exactly the rows the
+          # gate on this branch will hold it to. GROUP may be a comma-separated
+          # set (every breaking group rides in one PR — see the select step).
+          drift=$(go run ./cmd/sdkcoverage drift -format json)
+          groups_json=$(printf '%s' "$GROUP" | jq -R 'split(",")')
+          group_drift=$(echo "$drift" | jq --argjson gs "$groups_json" '[.drift[] | select(.group as $g | $gs | index($g))]')
+          rows=$(echo "$group_drift" | jq 'length')
+          if [ "$rows" -eq 0 ]; then
+            echo "::error::$GROUP no longer drifts against the pinned SDK after the bump — stale selection"
+            exit 1
+          fi
+          breaking=$(echo "$group_drift" | jq '[.[] | select(.breaking)] | length')
+          additions=$(echo "$group_drift" | jq '[.[] | select(.kind == "field_added" or .kind == "enum_value_added" or .kind == "method_added" or .kind == "model_added")] | length')
+          implemented_by=$(echo "$group_drift" | jq -r '[.[].implemented_by[]] | unique | map("`"+.+"`") | join(", ")')
+          sdk_version=$(go run ./cmd/sdkcoverage report -format json | jq -r '.sdk_version')
+
+          # A stale handoff from a previous process must never masquerade as
+          # this run's.
+          rm -f /tmp/drift-handoff.md
+
+          GROUP="$GROUP" DRIFT_JSON="$group_drift" IMPLEMENTED_BY="${implemented_by:-unknown}" \
+            SDK_VERSION="$sdk_version" MAX_TURNS="$DRIFT_MAX_TURNS" \
+            scripts/render-scaffold-prompt.sh .github/prompts/fix-field-drift.md > /tmp/drift-prompt.md
+
+          {
+            echo "prompt<<DRIFT_PROMPT_EOF"
+            cat /tmp/drift-prompt.md
+            echo "DRIFT_PROMPT_EOF"
+            echo "rows=$rows"
+            echo "breaking=$breaking"
+            echo "additions=$additions"
+            echo "implemented_by=$implemented_by"
+            echo "sdk_version=$sdk_version"
+            echo "group_drift<<DRIFT_JSON_EOF"
+            echo "$group_drift"
+            echo "DRIFT_JSON_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run the drift-fix agent
+        id: agent
+        if: steps.select.outputs.has_work == 'true'
+        timeout-minutes: 30
+        # The gate below is the arbiter, not the agent's exit code — same
+        # rationale as scaffold.
+        continue-on-error: true
+        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1.0.207
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          prompt: ${{ steps.render.outputs.prompt }}
+          # Identical allowlist to scaffold: no gh, no git writes, no network,
+          # no free shell.
+          claude_args: >-
+            --model ${{ env.DRIFT_MODEL }}
+            --max-turns ${{ env.DRIFT_MAX_TURNS }}
+            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
+
+      - name: Report agent cost and stats
+        id: cost
+        if: always() && steps.agent.outcome != 'skipped' && steps.agent.outputs.execution_file != ''
+        env:
+          EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -uo pipefail
+          cost=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .total_cost_usd // empty) else (.total_cost_usd // empty) end' "$EXEC_FILE" 2>/dev/null || true)
+          turns=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .num_turns // empty) else (.num_turns // empty) end' "$EXEC_FILE" 2>/dev/null || true)
+          cost=${cost:-unknown}
+          turns=${turns:-unknown}
+
+          cost_fmt="$cost"
+          if [ "$cost" != "unknown" ]; then
+            cost_fmt=$(printf '%.2f' "$cost")
+          fi
+          prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/fix-field-drift.md | head -1)
+          if [ -f /tmp/drift-handoff.md ]; then
+            handoff="present ($(wc -c < /tmp/drift-handoff.md | tr -d ' ') bytes)"
+          else
+            handoff="MISSING"
+          fi
+          {
+            echo "## Drift-fix agent"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Group | \`$GROUP\` |"
+            echo "| Model | \`$DRIFT_MODEL\` |"
+            echo "| Prompt | v${prompt_version:-?} |"
+            echo "| Turns | ${turns} (cap $DRIFT_MAX_TURNS) |"
+            echo "| Cost | \$${cost_fmt} |"
+            echo "| Handoff file | $handoff |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$cost" != "unknown" ] && awk "BEGIN { exit !($cost > 6) }"; then
+            echo "::warning::agent run cost \$${cost_fmt} — above the \$6 watermark, review the transcript for thrash"
+          fi
+
+      - name: Validate the reconciliation
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -euo pipefail
+          bash scripts/scaffold-validate.sh --mode drift --group "$GROUP" --base HEAD
+
+      - name: Mint the installation token
+        id: app
+        if: steps.select.outputs.has_work == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SDK_WATCH_CLIENT_ID }}
+          private-key: ${{ secrets.SDK_WATCH_APP_PRIVATE_KEY }}
+
+      - name: Push the branch and open the PR
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+          ROWS: ${{ steps.render.outputs.rows }}
+          BREAKING: ${{ steps.render.outputs.breaking }}
+          ADDITIONS: ${{ steps.render.outputs.additions }}
+          IMPLEMENTED_BY: ${{ steps.render.outputs.implemented_by }}
+          SDK_VERSION: ${{ steps.render.outputs.sdk_version }}
+          GROUP_DRIFT: ${{ steps.render.outputs.group_drift }}
+          EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          slug=$(printf '%s' "$GROUP" | tr '[:upper:]' '[:lower:]' | tr '.,' '--')
+          branch="drift/${slug}-${{ github.run_id }}"
+
+          # feat + `type: feature` (minor) when the drift includes additions;
+          # fix + `type: bug` (patch) for a pure breaking/notes reconciliation —
+          # release-drafter's version resolver keys off exactly these labels,
+          # and the branch commit below uses the same prefix so the two never
+          # disagree.
+          if [ "${ADDITIONS:-0}" -gt 0 ]; then
+            prefix="feat"
+            type_label="type: feature"
+          else
+            prefix="fix"
+            type_label="type: bug"
+          fi
+
+          # Same rerunnable finalize as scaffold: reuse a surviving branch+PR
+          # pair untouched, replace an orphan branch, otherwise push fresh.
+          reuse_pr=""
+          if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            reuse_pr=$(GH_TOKEN="${{ github.token }}" gh pr list --state open --head "$branch" \
+              --json url --jq '.[0].url // empty')
+            if [ -n "$reuse_pr" ]; then
+              echo "branch ${branch} and its PR survive from a previous attempt — finishing their lifecycle"
+            else
+              echo "branch ${branch} is an orphan with no PR — replacing it with this attempt's tree"
+              git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
+            fi
+          fi
+          if [ -z "$reuse_pr" ]; then
+            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+              add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
+            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+              commit -m "${prefix}(coverage): reconcile field drift on SDK group ${GROUP}"
+            git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+          fi
+
+          prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/fix-field-drift.md | head -1)
+          handoff=$(jq -r 'if type=="array" then (map(select(.type? == "result")) | last | .result // "") else (.result // "") end' "$EXEC_FILE" 2>/dev/null | awk '/^## Handoff/{found=1} found' | head -c 8000 || true)
+          if [ -z "$handoff" ] && [ -f /tmp/drift-handoff.md ]; then
+            handoff=$(head -c 8000 /tmp/drift-handoff.md)
+          fi
+          if [ -z "$handoff" ]; then
+            handoff="_The agent did not emit a handoff block — read the transcript in the run artifacts before reviewing._"
+          fi
+
+          {
+            echo "# Field drift reconciliation"
+            echo
+            echo "SDK group \`$GROUP\` moved under the provider's feet; this PR reconciles the mapping owned by ${IMPLEMENTED_BY:-\`?\`} and accepts the new shape into \`sdk-fields.lock.yaml\` — the lock diff in this PR **is** the acceptance record."
+            echo
+            if [ "${BREAKING:-0}" -gt 0 ]; then
+              echo "> [!WARNING]"
+              echo "> ${BREAKING} of the ${ROWS} drift row(s) below are **breaking**: the SDK no longer has a shape the provider's mappings assumed. Until this PR merges, \`TestProviderSDKFieldDrift\` fails on any branch that bumps the SDK. Review what happens to existing state especially carefully."
+              echo
+            fi
+            echo "## Versioning"
+            echo
+            if [ "$prefix" = "feat" ]; then
+              echo "Version Bump Type: [minor] - 🤖 (automated) — the drift includes new capability (fields/enum values) now exposed"
+            else
+              echo "Version Bump Type: [patch] - 🤖 (automated) — mapping reconciliation only, no new capability"
+            fi
+            echo
+            echo "## The drift"
+            echo
+            echo "Lock vs \`$SDK_VERSION\` at the time this PR was generated:"
+            echo
+            echo "| Group | Kind | Where | Detail | Breaking |"
+            echo "|---|---|---|---|---|"
+            echo "$GROUP_DRIFT" | jq -r '.[] | ((.model // "") as $m | (.field // "") as $f | "| `\(.group)` | `\(.kind)` | \(if $m != "" then "`"+$m+"`" else "" end)\(if $f != "" then " `"+$f+"`" else "" end) | \(.detail) | \(if .breaking then "⚠️ yes" else "no" end) |")'
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| SDK version | \`$SDK_VERSION\` |"
+            echo "| Owning types | ${IMPLEMENTED_BY:-?} |"
+            echo
+            echo "<details>"
+            echo "<summary>Agent handoff — not verified offline</summary>"
+            echo
+            echo "$handoff"
+            echo
+            echo "</details>"
+            echo
+            echo "<details>"
+            echo "<summary>Validation report</summary>"
+            echo
+            echo "Every gate step passed before this PR was opened (drift mode): diff scope, forbidden-content grep, gofmt, go vet, go build, unit tests (incl. \`TestProviderSDKCoverage\` and \`TestProviderSDKFieldDrift\`), zero remaining drift for \`$GROUP\`, docs regeneration, lock accepted."
+            echo
+            echo "The gate proves the change is well-formed, **not that it is correct** — that is what the checklist below is for."
+            echo
+            echo "</details>"
+            echo
+            echo "## Reviewer checklist"
+            echo
+            echo "- [ ] Every drift row is either mapped or deliberately omitted with the why in \`sdk-coverage.yaml\` \`notes:\`"
+            echo "- [ ] New attributes are Optional+Computed; nothing existing changed Required/Optional or gained a plan modifier"
+            echo "- [ ] Breaking rows: checked what a plan against existing state does after this change"
+            echo "- [ ] Enum changes: every validation AND coercion site touched (see handoff)"
+            echo "- [ ] Remove the \`skip-e2e\` label (and re-run the checks) to exercise the full acceptance suite"
+            echo
+            echo "---"
+            echo
+            echo "Generated from [\`latitudesh-go-sdk\`](https://github.com/latitudesh/latitudesh-go-sdk) \`$SDK_VERSION\` by the [sdk-watch workflow]($RUN_URL) — prompt v${prompt_version:-?}."
+            echo
+            echo "<!-- drift:$GROUP -->"
+          } > pr-body.md
+
+          # One drift:<group> label PER group — the claim/park queries key on
+          # individual group names, and a multi-group PR claims each of them.
+          GH_TOKEN="${{ github.token }}" gh label create drift --color b60205 \
+            --description "Agent PR reconciling SDK field drift on a covered group" 2>/dev/null || true
+          group_label_args=""
+          for g in ${GROUP//,/ }; do
+            GH_TOKEN="${{ github.token }}" gh label create "drift:${g}" --color b60205 \
+              --description "Drift PR for SDK group ${g}" 2>/dev/null || true
+            group_label_args="$group_label_args --add-label drift:${g}"
+          done
+          GH_TOKEN="${{ github.token }}" gh label create "$type_label" --color 0e8a16 \
+            --description "Release-drafter version resolver label" 2>/dev/null || true
+          GH_TOKEN="${{ github.token }}" gh label create skip-e2e --color ededed \
+            --description "Skip the acceptance suite on this PR" 2>/dev/null || true
+
+          # Draft first, label, then ready — same test.yml race avoidance as
+          # scaffold.
+          url="$reuse_pr"
+          if [ -z "$url" ]; then
+            url=$(GH_TOKEN="$APP_TOKEN" gh pr create --draft \
+              --head "$branch" \
+              --title "${prefix}(coverage): 🤖 reconcile field drift on SDK group(s) ${GROUP}" \
+              --body-file pr-body.md)
+          fi
+          # shellcheck disable=SC2086 — group_label_args is a flag list on purpose
+          GH_TOKEN="$APP_TOKEN" gh pr edit "$url" \
+            --add-label drift $group_label_args \
+            --add-label "$type_label" --add-label skip-e2e
+          if [ "$(GH_TOKEN="$APP_TOKEN" gh pr view "$url" --json isDraft --jq '.isDraft')" = "true" ]; then
+            GH_TOKEN="$APP_TOKEN" gh pr ready "$url"
+          fi
+          echo "PR (ready for review): $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the transcript
+        if: steps.select.outputs.has_work == 'true' && steps.agent.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: drift-transcript
+          path: ${{ steps.agent.outputs.execution_file }}
+          retention-days: 14
+          overwrite: true
+          if-no-files-found: ignore
+
+      - name: Capture the failed tree
+        if: failure() && steps.select.outputs.has_work == 'true'
+        run: |
+          set -uo pipefail
+          git add -A
+          git diff --cached HEAD > drift-failure.patch || true
+          git status --porcelain > drift-failure-status.txt || true
+          if grep -Eq 'sk-ant-|ANTHROPIC_API_KEY|BEGIN[ A-Z]*PRIVATE KEY' drift-failure.patch; then
+            echo "patch withheld: it matches a key-material pattern; inspect the run log instead" > drift-failure.patch
+            echo "::warning::failure patch withheld — key-material pattern detected in the agent's tree"
+          fi
+
+      - name: Upload failure artifacts
+        if: failure() && steps.select.outputs.has_work == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: drift-failure
+          path: |
+            /tmp/drift-prompt.md
+            ${{ steps.agent.outputs.execution_file }}
+            drift-failure.patch
+            drift-failure-status.txt
+          retention-days: 14
+          overwrite: true
+          if-no-files-found: ignore
+
+      - name: Note the failure on the tracking issue
+        if: failure() && steps.select.outputs.has_work == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GROUP: ${{ steps.select.outputs.group }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          existing=$(gh issue list --label sdk-coverage --state open --limit 100 \
+            --json number,body --jq \
+            'map(select(.body | contains("<!-- sdk-coverage-tracking -->"))) | sort_by(.number) | .[0].number // empty')
+          [ -n "$existing" ] || exit 0
+          gh issue comment "$existing" --body "Drift-fix run for \`$GROUP\` failed — no PR was opened. Transcript and diff: $RUN_URL"
+
   # Turn ONE pending group into a draft PR. One group per run keeps prompts
   # small, failures attributable, and manifest/provider.go conflicts between
   # sibling scaffold PRs structurally rare; the open-PR cap keeps the reviewer's
-  # plate full without flooding. This is the only job that can see the Anthropic
-  # key, and it never runs on an empty queue — the $0-on-no-delta guarantee is
-  # structural, not behavioral.
+  # plate full without flooding. This job and driftfix are the only ones that can
+  # see the Anthropic key, and neither runs on an empty queue — the $0-on-no-delta
+  # guarantee is structural, not behavioral.
   scaffold:
-    needs: detect
+    needs: [detect, driftfix]
     # Real work only, on a sane pinned manifest, never on a dry run. A
     # contradicted manifest means the coverage ledger is lying, and scaffolding
-    # on top of it risks double-implementing a group.
+    # on top of it risks double-implementing a group. driftfix goes first purely
+    # for ORDERING (never two agent jobs racing on PRs); its failure does not
+    # block scaffolding — a bump-free scaffold is safe whatever the drift
+    # picture, and a bumping one has its own drift guard that parks it.
     if: >-
+      !cancelled() &&
+      needs.driftfix.result != 'cancelled' &&
       github.event.inputs.dry_run != 'true' &&
       needs.detect.outputs.pending != '0' &&
       needs.detect.outputs.pinned_check_ok == 'true'
@@ -409,7 +1059,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          adoptions=$(gh pr list --state open --json number,isDraft,body \
+          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body \
             --jq '[.[] | select(.isDraft) | select((.body // "") | contains("<!-- scaffold:"))
                    | "\(.number)=\((.body | capture("<!-- scaffold:(?<g>[^ ]+) -->").g))"] | join(" ")')
           echo "adoptions=$adoptions" >> "$GITHUB_OUTPUT"
@@ -539,6 +1189,15 @@ jobs:
           # A bump that breaks the build is human work, not agent work: stop
           # before spending a single token.
           go build ./...
+          # The bump must not ride over breaking field drift on covered groups:
+          # the lock is only ever synced by a PR that addresses the drift (the
+          # drift-fix job, or a human), so syncing it here would launder a
+          # breaking change into a scaffold PR about something else. Additive
+          # drift does not block — the gate is breaking-only.
+          if ! go run ./cmd/sdkcoverage drift -strict -format text; then
+            echo "::error::bumping to $LATEST carries breaking field drift on covered groups — merge the drift-fix PR (or sync sdk-fields.lock.yaml in a reviewed PR) first; parking this scaffold run"
+            exit 1
+          fi
           git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
             commit -m "chore(deps): bump latitudesh-go-sdk to $LATEST" -- go.mod go.sum
 
@@ -723,11 +1382,17 @@ jobs:
             fi
           fi
           if [ -z "$reuse_pr" ]; then
+            # The group is covered as of this tree, so seed its lock entry
+            # surgically (one group, nothing else) — otherwise every scaffold
+            # merge immediately spawns a group_unlocked drift PR whose whole
+            # content would be this line. Deterministic, so it happens here and
+            # not in the agent.
+            go run ./cmd/sdkcoverage fields -write -group "$GROUP"
             # Commit by explicit pathspec — the gate already proved the diff is
             # in scope, and adding by name means a stray file could not ride
             # along even if it were not.
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
-              add -- latitudesh sdk-coverage.yaml templates examples docs
+              add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
             git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -797,7 +797,7 @@ jobs:
           if [ -z "$reuse_pr" ]; then
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
-            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            git -c core.hooksPath=/dev/null -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               commit -m "${prefix}(coverage): reconcile field drift on SDK group ${GROUP}"
             git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
           fi

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -760,6 +760,10 @@ jobs:
           APP_TOKEN: ${{ steps.app.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # This step holds the WRITE token, so it runs nothing the tree can
+          # extend: no go (a package initializer in agent-written code would
+          # execute with the token in reach), and git only with hooks disabled
+          # on the token-bearing pushes. jq/sed/gh/awk only read data.
           set -euo pipefail
           slug=$(printf '%s' "$GROUP" | tr '[:upper:]' '[:lower:]' | tr '.,' '--')
           branch="drift/${slug}-${{ github.run_id }}"
@@ -787,7 +791,7 @@ jobs:
               echo "branch ${branch} and its PR survive from a previous attempt — finishing their lifecycle"
             else
               echo "branch ${branch} is an orphan with no PR — replacing it with this attempt's tree"
-              git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
+              git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
             fi
           fi
           if [ -z "$reuse_pr" ]; then
@@ -795,7 +799,7 @@ jobs:
               add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               commit -m "${prefix}(coverage): reconcile field drift on SDK group ${GROUP}"
-            git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+            git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
           fi
 
           prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/fix-field-drift.md | head -1)
@@ -1328,6 +1332,31 @@ jobs:
           set -euo pipefail
           bash scripts/scaffold-validate.sh --group "$GROUP" --type-name "$TF_NAME" --kinds "$KINDS" --base HEAD
 
+      # Everything that COMPILES OR RUNS code from the tree happens here, before
+      # any write token exists in the job. `go run ./cmd/sdkcoverage` imports the
+      # agent-modifiable latitudesh package, so a package-level initializer the
+      # agent planted would execute inside this step — which is exactly why this
+      # step carries no token, and why the finalize step below must never invoke
+      # go (or anything else the tree can extend).
+      - name: Seed the lock and take the after-merge numbers
+        id: after
+        if: steps.select.outputs.has_work == 'true'
+        env:
+          GROUP: ${{ steps.select.outputs.group }}
+        run: |
+          set -euo pipefail
+          # The group is covered as of this tree, so seed its lock entry
+          # surgically (one group, nothing else) — otherwise every scaffold
+          # merge immediately spawns a group_unlocked drift PR whose whole
+          # content would be this line. Deterministic, so it happens here and
+          # not in the agent.
+          go run ./cmd/sdkcoverage fields -write -group "$GROUP"
+          # The tree now carries the scaffold, so a fresh report gives the
+          # after-merge coverage numbers for the PR body.
+          after=$(go run ./cmd/sdkcoverage report -format json)
+          echo "covered_after=$(echo "$after" | jq -r '.counts.covered')" >> "$GITHUB_OUTPUT"
+          echo "pending_after=$(echo "$after" | jq -r '.counts.pending')" >> "$GITHUB_OUTPUT"
+
       - name: Mint the installation token
         id: app
         if: steps.select.outputs.has_work == 'true'
@@ -1349,10 +1378,17 @@ jobs:
           PENDING_BEFORE: ${{ steps.render.outputs.pending_before }}
           TOTAL_GROUPS: ${{ steps.render.outputs.total_groups }}
           NOTES: ${{ steps.render.outputs.notes }}
+          COVERED_AFTER: ${{ steps.after.outputs.covered_after }}
+          PENDING_AFTER: ${{ steps.after.outputs.pending_after }}
           EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
           APP_TOKEN: ${{ steps.app.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # This step holds the WRITE token, so it runs nothing the tree can
+          # extend: no go (a package initializer in agent-written code would
+          # execute with the token in reach), and git only with hooks disabled
+          # (an agent-planted .git/hooks/pre-push would otherwise run here and
+          # see the token in the push URL). jq/sed/gh/awk only read data.
           set -euo pipefail
           short="${TF_NAME#latitudesh_}"
           branch="scaffold/${short}-${{ github.run_id }}"
@@ -1378,24 +1414,19 @@ jobs:
               echo "branch ${branch} and its PR survive from a previous attempt — finishing their lifecycle"
             else
               echo "branch ${branch} is an orphan with no PR — replacing it with this attempt's tree"
-              git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
+              git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" --delete "refs/heads/${branch}"
             fi
           fi
           if [ -z "$reuse_pr" ]; then
-            # The group is covered as of this tree, so seed its lock entry
-            # surgically (one group, nothing else) — otherwise every scaffold
-            # merge immediately spawns a group_unlocked drift PR whose whole
-            # content would be this line. Deterministic, so it happens here and
-            # not in the agent.
-            go run ./cmd/sdkcoverage fields -write -group "$GROUP"
             # Commit by explicit pathspec — the gate already proved the diff is
             # in scope, and adding by name means a stray file could not ride
-            # along even if it were not.
+            # along even if it were not. (The lock entry for the new group was
+            # seeded by the tokenless step above.)
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
-            git push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
+            git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
           fi
 
           prompt_version=$(sed -n 's/^prompt-version: *//p' .github/prompts/scaffold-resource.md | head -1)
@@ -1412,11 +1443,10 @@ jobs:
             handoff="_The agent did not emit a handoff block — read the transcript in the run artifacts before reviewing._"
           fi
 
-          # The tree now carries the scaffold, so a fresh report gives the
-          # after-merge coverage numbers for the summary.
-          after=$(go run ./cmd/sdkcoverage report -format json)
-          covered_after=$(echo "$after" | jq -r '.counts.covered')
-          pending_after=$(echo "$after" | jq -r '.counts.pending')
+          # After-merge coverage numbers come from the tokenless step above —
+          # never recomputed here, where computing them would execute tree code.
+          covered_after="$COVERED_AFTER"
+          pending_after="$PENDING_AFTER"
 
           # Speakeasy-style version suggestion. A new resource/data source is a
           # backwards-compatible addition, so the bump is always minor; the

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -489,8 +489,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body \
-            --jq '[.[] | select(.isDraft) | select((.body // "") | contains("<!-- drift:"))
+          # Ownership is verified structurally, never by the body marker alone:
+          # the draft must have been AUTHORED by this workflow's GitHub App, sit
+          # on a same-repo drift/* branch, and carry the marker. Anything else —
+          # a fork, an off-namespace branch, or a human-authored draft that
+          # imitates all of it — must never be granted skip-e2e and promoted to
+          # ready by the app token. If the app is ever renamed, adoption fails
+          # CLOSED: orphans stay visibly draft until this login is updated.
+          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body,author,headRefName,isCrossRepository \
+            --jq '[.[] | select(.isDraft)
+                   | select(.author.login == "app/latitudesh-sdk-watch")
+                   | select(.isCrossRepository | not)
+                   | select(.headRefName | startswith("drift/"))
+                   | select((.body // "") | contains("<!-- drift:"))
                    | "\(.number)=\((.body | capture("<!-- drift:(?<g>[^ ]+) -->").g))"] | join(" ")')
           echo "adoptions=$adoptions" >> "$GITHUB_OUTPUT"
           if [ -n "$adoptions" ]; then
@@ -672,14 +683,6 @@ jobs:
             echo "DRIFT_JSON_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # The agent's Write tool can reach .git and the runner home, and git
-      # config is a code-execution surface (hooks, core.fsmonitor,
-      # credential.helper, insteadOf URL rewrites). Snapshot the repo-local
-      # config now, restore it wholesale before any write token exists.
-      - name: Snapshot clean git metadata
-        if: steps.select.outputs.has_work == 'true'
-        run: cp .git/config "$RUNNER_TEMP/clean-git-config"
-
       - name: Run the drift-fix agent
         id: agent
         if: steps.select.outputs.has_work == 'true'
@@ -747,17 +750,31 @@ jobs:
           bash scripts/scaffold-validate.sh --mode drift --group "$GROUP" --base HEAD
 
       # Undo any agent tampering with git's code-execution surfaces before the
-      # write token exists: hooks emptied, repo-local config restored from the
-      # pre-agent snapshot. The finalize step additionally ignores global and
-      # system git config, which the agent's unrestricted Write could also
-      # have planted.
-      - name: Restore clean git metadata
+      # write token exists: hooks emptied, and the repo-local config REGENERATED
+      # from scratch — never restored from a snapshot, because every snapshot
+      # location (including RUNNER_TEMP) is reachable by the agent's Write tool,
+      # and restoring an agent-writable file would just launder the tampering
+      # back in. Everything below is deterministic; filters, fsmonitor,
+      # credential helpers, and insteadOf rewrites cannot survive it. The
+      # finalize step additionally ignores global and system git config.
+      - name: Reset git metadata to known-good
         if: steps.select.outputs.has_work == 'true'
         run: |
           set -euo pipefail
           rm -rf .git/hooks
           mkdir .git/hooks
-          cp "$RUNNER_TEMP/clean-git-config" .git/config
+          cat > .git/config <<EOF
+          [core]
+          	repositoryformatversion = 0
+          	filemode = true
+          	bare = false
+          	logallrefupdates = true
+          [remote "origin"]
+          	url = https://github.com/${GH_REPO}.git
+          	fetch = +refs/heads/*:refs/remotes/origin/*
+          [gc]
+          	auto = 0
+          EOF
 
       - name: Mint the installation token
         id: app
@@ -782,7 +799,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # Global/system git config are agent-reachable files too — ignore
           # them entirely in this token-bearing step. Repo-local config was
-          # restored from the pre-agent snapshot a few steps up.
+          # regenerated from scratch a few steps up.
           GIT_CONFIG_GLOBAL: /dev/null
           GIT_CONFIG_SYSTEM: /dev/null
         run: |
@@ -1091,8 +1108,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body \
-            --jq '[.[] | select(.isDraft) | select((.body // "") | contains("<!-- scaffold:"))
+          # Ownership is verified structurally, never by the body marker alone:
+          # the draft must have been AUTHORED by this workflow's GitHub App, sit
+          # on a same-repo scaffold/* branch, and carry the marker. Anything
+          # else — a fork, an off-namespace branch, or a human-authored draft
+          # that imitates all of it — must never be granted skip-e2e and
+          # promoted to ready by the app token. If the app is ever renamed,
+          # adoption fails CLOSED: orphans stay visibly draft until this login
+          # is updated.
+          adoptions=$(gh pr list --state open --limit 100 --json number,isDraft,body,author,headRefName,isCrossRepository \
+            --jq '[.[] | select(.isDraft)
+                   | select(.author.login == "app/latitudesh-sdk-watch")
+                   | select(.isCrossRepository | not)
+                   | select(.headRefName | startswith("scaffold/"))
+                   | select((.body // "") | contains("<!-- scaffold:"))
                    | "\(.number)=\((.body | capture("<!-- scaffold:(?<g>[^ ]+) -->").g))"] | join(" ")')
           echo "adoptions=$adoptions" >> "$GITHUB_OUTPUT"
           if [ -n "$adoptions" ]; then
@@ -1277,14 +1306,6 @@ jobs:
             echo "SCAFFOLD_NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # The agent's Write tool can reach .git and the runner home, and git
-      # config is a code-execution surface (hooks, core.fsmonitor,
-      # credential.helper, insteadOf URL rewrites). Snapshot the repo-local
-      # config now, restore it wholesale before any write token exists.
-      - name: Snapshot clean git metadata
-        if: steps.select.outputs.has_work == 'true'
-        run: cp .git/config "$RUNNER_TEMP/clean-git-config"
-
       - name: Run the scaffolding agent
         id: agent
         if: steps.select.outputs.has_work == 'true'
@@ -1394,17 +1415,31 @@ jobs:
           echo "pending_after=$(echo "$after" | jq -r '.counts.pending')" >> "$GITHUB_OUTPUT"
 
       # Undo any agent tampering with git's code-execution surfaces before the
-      # write token exists: hooks emptied, repo-local config restored from the
-      # pre-agent snapshot. The finalize step additionally ignores global and
-      # system git config, which the agent's unrestricted Write could also
-      # have planted.
-      - name: Restore clean git metadata
+      # write token exists: hooks emptied, and the repo-local config REGENERATED
+      # from scratch — never restored from a snapshot, because every snapshot
+      # location (including RUNNER_TEMP) is reachable by the agent's Write tool,
+      # and restoring an agent-writable file would just launder the tampering
+      # back in. Everything below is deterministic; filters, fsmonitor,
+      # credential helpers, and insteadOf rewrites cannot survive it. The
+      # finalize step additionally ignores global and system git config.
+      - name: Reset git metadata to known-good
         if: steps.select.outputs.has_work == 'true'
         run: |
           set -euo pipefail
           rm -rf .git/hooks
           mkdir .git/hooks
-          cp "$RUNNER_TEMP/clean-git-config" .git/config
+          cat > .git/config <<EOF
+          [core]
+          	repositoryformatversion = 0
+          	filemode = true
+          	bare = false
+          	logallrefupdates = true
+          [remote "origin"]
+          	url = https://github.com/${GH_REPO}.git
+          	fetch = +refs/heads/*:refs/remotes/origin/*
+          [gc]
+          	auto = 0
+          EOF
 
       - name: Mint the installation token
         id: app
@@ -1434,7 +1469,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # Global/system git config are agent-reachable files too — ignore
           # them entirely in this token-bearing step. Repo-local config was
-          # restored from the pre-agent snapshot a few steps up.
+          # regenerated from scratch a few steps up.
           GIT_CONFIG_GLOBAL: /dev/null
           GIT_CONFIG_SYSTEM: /dev/null
         run: |

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -672,6 +672,14 @@ jobs:
             echo "DRIFT_JSON_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # The agent's Write tool can reach .git and the runner home, and git
+      # config is a code-execution surface (hooks, core.fsmonitor,
+      # credential.helper, insteadOf URL rewrites). Snapshot the repo-local
+      # config now, restore it wholesale before any write token exists.
+      - name: Snapshot clean git metadata
+        if: steps.select.outputs.has_work == 'true'
+        run: cp .git/config "$RUNNER_TEMP/clean-git-config"
+
       - name: Run the drift-fix agent
         id: agent
         if: steps.select.outputs.has_work == 'true'
@@ -738,6 +746,19 @@ jobs:
           set -euo pipefail
           bash scripts/scaffold-validate.sh --mode drift --group "$GROUP" --base HEAD
 
+      # Undo any agent tampering with git's code-execution surfaces before the
+      # write token exists: hooks emptied, repo-local config restored from the
+      # pre-agent snapshot. The finalize step additionally ignores global and
+      # system git config, which the agent's unrestricted Write could also
+      # have planted.
+      - name: Restore clean git metadata
+        if: steps.select.outputs.has_work == 'true'
+        run: |
+          set -euo pipefail
+          rm -rf .git/hooks
+          mkdir .git/hooks
+          cp "$RUNNER_TEMP/clean-git-config" .git/config
+
       - name: Mint the installation token
         id: app
         if: steps.select.outputs.has_work == 'true'
@@ -759,11 +780,18 @@ jobs:
           EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
           APP_TOKEN: ${{ steps.app.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Global/system git config are agent-reachable files too — ignore
+          # them entirely in this token-bearing step. Repo-local config was
+          # restored from the pre-agent snapshot a few steps up.
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_SYSTEM: /dev/null
         run: |
           # This step holds the WRITE token, so it runs nothing the tree can
           # extend: no go (a package initializer in agent-written code would
-          # execute with the token in reach), and git only with hooks disabled
-          # on the token-bearing pushes. jq/sed/gh/awk only read data.
+          # execute with the token in reach), and git only with its
+          # code-execution surfaces neutralized — hooks dir emptied and config
+          # restored above, hooksPath overridden again on commit and push as a
+          # second layer. jq/sed/gh/awk only read data.
           set -euo pipefail
           slug=$(printf '%s' "$GROUP" | tr '[:upper:]' '[:lower:]' | tr '.,' '--')
           branch="drift/${slug}-${{ github.run_id }}"
@@ -1249,6 +1277,14 @@ jobs:
             echo "SCAFFOLD_NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # The agent's Write tool can reach .git and the runner home, and git
+      # config is a code-execution surface (hooks, core.fsmonitor,
+      # credential.helper, insteadOf URL rewrites). Snapshot the repo-local
+      # config now, restore it wholesale before any write token exists.
+      - name: Snapshot clean git metadata
+        if: steps.select.outputs.has_work == 'true'
+        run: cp .git/config "$RUNNER_TEMP/clean-git-config"
+
       - name: Run the scaffolding agent
         id: agent
         if: steps.select.outputs.has_work == 'true'
@@ -1357,6 +1393,19 @@ jobs:
           echo "covered_after=$(echo "$after" | jq -r '.counts.covered')" >> "$GITHUB_OUTPUT"
           echo "pending_after=$(echo "$after" | jq -r '.counts.pending')" >> "$GITHUB_OUTPUT"
 
+      # Undo any agent tampering with git's code-execution surfaces before the
+      # write token exists: hooks emptied, repo-local config restored from the
+      # pre-agent snapshot. The finalize step additionally ignores global and
+      # system git config, which the agent's unrestricted Write could also
+      # have planted.
+      - name: Restore clean git metadata
+        if: steps.select.outputs.has_work == 'true'
+        run: |
+          set -euo pipefail
+          rm -rf .git/hooks
+          mkdir .git/hooks
+          cp "$RUNNER_TEMP/clean-git-config" .git/config
+
       - name: Mint the installation token
         id: app
         if: steps.select.outputs.has_work == 'true'
@@ -1383,12 +1432,18 @@ jobs:
           EXEC_FILE: ${{ steps.agent.outputs.execution_file }}
           APP_TOKEN: ${{ steps.app.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Global/system git config are agent-reachable files too — ignore
+          # them entirely in this token-bearing step. Repo-local config was
+          # restored from the pre-agent snapshot a few steps up.
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_SYSTEM: /dev/null
         run: |
           # This step holds the WRITE token, so it runs nothing the tree can
           # extend: no go (a package initializer in agent-written code would
-          # execute with the token in reach), and git only with hooks disabled
-          # (an agent-planted .git/hooks/pre-push would otherwise run here and
-          # see the token in the push URL). jq/sed/gh/awk only read data.
+          # execute with the token in reach), and git only with its
+          # code-execution surfaces neutralized — hooks dir emptied and config
+          # restored above, hooksPath overridden again on commit and push as a
+          # second layer. jq/sed/gh/awk only read data.
           set -euo pipefail
           short="${TF_NAME#latitudesh_}"
           branch="scaffold/${short}-${{ github.run_id }}"
@@ -1424,7 +1479,7 @@ jobs:
             # seeded by the tokenless step above.)
             git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               add -- latitudesh sdk-coverage.yaml sdk-fields.lock.yaml templates examples docs
-            git -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
+            git -c core.hooksPath=/dev/null -c user.name="$GIT_BOT_NAME" -c user.email="$GIT_BOT_EMAIL" \
               commit -m "feat(${short}): scaffold ${TF_NAME} from SDK group ${GROUP}"
             git -c core.hooksPath=/dev/null push "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" "HEAD:refs/heads/${branch}"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,34 @@ make coverage-check    # what CI enforces
 
 Both run offline against the module cache and need no API token. The file's header
 comment explains every field.
+
+### Field drift
+
+Coverage says a Terraform type exists for a group; it says nothing about the fields
+*inside* it. [`sdk-fields.lock.yaml`](sdk-fields.lock.yaml) closes that gap: it is a
+go.sum-style snapshot of the covered groups' models — fields, types, wire names,
+enums, defaults, method signatures — as they were when a human last looked.
+`TestProviderSDKFieldDrift` diffs the pinned SDK against it on every PR.
+
+The severity split mirrors the group-level gate:
+
+- **Breaking drift fails CI** — a field removed or retyped, a required↔optional
+  flip, an enum value gone, a method removed or re-signed. The provider still
+  compiles in the old shape, so an SDK bump must not absorb these silently. Fix the
+  mapping in the named resource (or deliberately omit the change), then regenerate
+  the lock **in the same PR** — its diff is the review record of what you accepted.
+- **Additive drift never fails** — a new field, a new enum value, a deprecation, a
+  changed default or doc comment. It surfaces in the weekly tracking issue, and the
+  sdk-watch drift-fix job turns it into a draft PR.
+
+```sh
+make drift-report      # what moved, lock vs the pinned SDK
+make fields-sync       # accept it: regenerate the lock (full)
+go run ./cmd/sdkcoverage fields -write -group Servers   # accept one group only
+```
+
+Prefer the `-group` form in a PR that fixes one group's drift, so you do not
+silently accept every other group's. To leave an SDK field deliberately unmapped
+(the firewall's seeded port-22 rule is the canonical case), sync the lock and record
+why in that group's `notes:` in `sdk-coverage.yaml` — the lock line is the
+acceptance, the note is the audit trail.

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,15 @@ coverage-report:
 coverage-check:
 	go run ./cmd/sdkcoverage check
 
+# Field-level drift on covered groups, against the committed sdk-fields.lock.yaml.
+# drift-report shows it; fields-sync accepts it — run the sync in the PR that maps
+# (or deliberately omits) the change, and let the lock diff be reviewed there.
+drift-report:
+	go run ./cmd/sdkcoverage drift -format text
+
+fields-sync:
+	go run ./cmd/sdkcoverage fields -write
+
 # Validate generated scaffolding against the same offline gate the pipeline runs
 # before opening a draft PR. KINDS is what the coverage report requested for the
 # group — the gate fails any requested kind that was not delivered.

--- a/cmd/sdkcoverage/main.go
+++ b/cmd/sdkcoverage/main.go
@@ -8,6 +8,8 @@
 //	sdkcoverage check             # exit 1 on any violation
 //	sdkcoverage groups            # dump the raw SDK surface (no manifest needed)
 //	sdkcoverage shipped           # registered Terraform type names by kind, as JSON
+//	sdkcoverage fields            # field-level shape of the covered groups (-write updates the lock)
+//	sdkcoverage drift             # diff the lock against an SDK tree (-strict fails on breaking drift)
 //
 // Everything runs offline against the module cache; no API token is involved.
 package main
@@ -15,10 +17,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
 	"github.com/latitudesh/terraform-provider-latitudesh/v2/latitudesh"
@@ -46,9 +51,16 @@ func run(args []string) error {
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	manifestPath := flags.String("manifest", defaultManifestPath(), "path to the coverage manifest")
 	sdkDir := flags.String("sdk-dir", "", "SDK source directory (defaults to the pinned module in the module cache)")
-	format := flags.String("format", "", "report format: markdown, text, or json (report only)")
+	format := flags.String("format", "", "report format: markdown, text, or json (report and drift)")
+	lockPath := flags.String("lock", "", "path to the field lock (defaults to "+sdkcoverage.FieldLockFile+" next to the manifest)")
+	write := flags.Bool("write", false, "write the field lock instead of printing it (fields only)")
+	group := flags.String("group", "", "restrict the lock update to the named covered group(s), comma-separated (fields only)")
+	strict := flags.Bool("strict", false, "exit non-zero on breaking drift (drift only)")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
+	}
+	if *lockPath == "" {
+		*lockPath = filepath.Join(filepath.Dir(*manifestPath), sdkcoverage.FieldLockFile)
 	}
 
 	switch command {
@@ -57,9 +69,13 @@ func run(args []string) error {
 	case "report":
 		return runReport(*manifestPath, *sdkDir, *format)
 	case "check":
-		return runCheck(*manifestPath, *sdkDir)
+		return runCheck(*manifestPath, *sdkDir, *lockPath)
 	case "shipped":
 		return runShipped()
+	case "fields":
+		return runFields(*manifestPath, *sdkDir, *lockPath, *group, *write)
+	case "drift":
+		return runDrift(*manifestPath, *sdkDir, *lockPath, *format, *strict)
 	default:
 		usage()
 		return fmt.Errorf("unknown command %q", command)
@@ -67,17 +83,23 @@ func run(args []string) error {
 }
 
 func usage() {
-	fmt.Fprint(os.Stderr, `usage: sdkcoverage <report|check|groups|shipped> [flags]
+	fmt.Fprint(os.Stderr, `usage: sdkcoverage <report|check|groups|shipped|fields|drift> [flags]
 
   report   render the coverage table (markdown by default)
   check    exit non-zero when the SDK, the manifest, and the provider disagree
   groups   dump the raw SDK service-group surface, for seeding the manifest
   shipped  dump the registered Terraform type names by kind, as JSON
+  fields   render the covered groups' field-level shape as a lock document
+  drift    diff the committed field lock against an SDK tree
 
 flags:
   -manifest path   coverage manifest (default: sdk-coverage.yaml at the repo root)
   -sdk-dir path    SDK source directory (default: pinned module in the module cache)
-  -format fmt      markdown (default), text, or json, for report
+  -format fmt      markdown (default), text, or json, for report and drift
+  -lock path       field lock (default: sdk-fields.lock.yaml next to the manifest)
+  -write           write the field lock instead of printing it, for fields
+  -group names     restrict the lock update to these covered groups (comma-separated), for fields
+  -strict          exit non-zero on breaking drift, for drift
 `)
 }
 
@@ -134,30 +156,80 @@ func runReport(manifestPath, sdkDir, format string) error {
 	return nil
 }
 
-func runCheck(manifestPath, sdkDir string) error {
+func runCheck(manifestPath, sdkDir, lockPath string) error {
 	report, version, err := reconcile(manifestPath, sdkDir)
 	if err != nil {
 		return err
 	}
 
-	if report.OK() {
-		fmt.Printf("ok: %s — %d/%d covered, %d pending generation, %d excluded, %d need a human\n",
-			version, len(report.Covered), report.Total(),
-			len(report.Pending), len(report.Excluded), len(report.Unshaped))
-		if len(report.Revisit) > 0 {
-			// Informational by design: an API that grew is an opportunity, not a
-			// defect, so it must not fail the run.
-			fmt.Printf("note: %d group(s) excluded on API grounds now exceed their recorded ceiling — see `report`\n",
-				len(report.Revisit))
+	if !report.OK() {
+		fmt.Fprintf(os.Stderr, "%d violation(s):\n", len(report.Violations))
+		for _, v := range report.Violations {
+			fmt.Fprintf(os.Stderr, "  - %s\n", v)
 		}
-		return nil
+		return fmt.Errorf("coverage manifest is out of sync")
 	}
 
-	fmt.Fprintf(os.Stderr, "%d violation(s):\n", len(report.Violations))
-	for _, v := range report.Violations {
-		fmt.Fprintf(os.Stderr, "  - %s\n", v)
+	// Field drift is checked with the same severity split as the gate test:
+	// breaking drift between this SDK tree and the committed lock fails, so this
+	// command and TestProviderSDKFieldDrift cannot disagree; additive drift is a
+	// note. A missing lock is inert — pre-seed checkouts keep working.
+	if err := checkFieldDrift(manifestPath, sdkDir, lockPath); err != nil {
+		return err
 	}
-	return fmt.Errorf("coverage manifest is out of sync")
+
+	fmt.Printf("ok: %s — %d/%d covered, %d pending generation, %d excluded, %d need a human\n",
+		version, len(report.Covered), report.Total(),
+		len(report.Pending), len(report.Excluded), len(report.Unshaped))
+	if len(report.Revisit) > 0 {
+		// Informational by design: an API that grew is an opportunity, not a
+		// defect, so it must not fail the run.
+		fmt.Printf("note: %d group(s) excluded on API grounds now exceed their recorded ceiling — see `report`\n",
+			len(report.Revisit))
+	}
+	return nil
+}
+
+func checkFieldDrift(manifestPath, sdkDir, lockPath string) error {
+	lock, err := sdkcoverage.LoadFieldLock(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	fields, _, err := loadFieldSurface(manifestPath, sdkDir)
+	if err != nil {
+		return err
+	}
+	manifest, err := sdkcoverage.LoadManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	drift := sdkcoverage.DiffFieldSurfaces(lock.Surface(), fields, manifest)
+	var breaking []sdkcoverage.Drift
+	informational := 0
+	for _, d := range drift {
+		if d.Breaking() {
+			breaking = append(breaking, d)
+		} else {
+			informational++
+		}
+	}
+
+	if len(breaking) > 0 {
+		fmt.Fprintf(os.Stderr, "%d breaking field drift(s) against %s:\n", len(breaking), lockPath)
+		for _, d := range breaking {
+			fmt.Fprintf(os.Stderr, "  - %s\n", d)
+		}
+		return fmt.Errorf("field lock is out of sync — fix the mapping (or deliberately omit it), then `make fields-sync`")
+	}
+	if informational > 0 {
+		fmt.Printf("note: %d informational field drift(s) on covered groups — see `drift`\n", informational)
+	}
+	return nil
 }
 
 // runShipped prints the provider's registered type names split by kind. The
@@ -175,6 +247,151 @@ func runShipped() error {
 	}
 	fmt.Println(string(data))
 	return nil
+}
+
+// runFields renders the field-level shape of the covered groups as a lock
+// document. -write is the only path in this tool that touches the filesystem,
+// and it is how drift gets accepted: regenerate the lock in the PR that maps
+// (or deliberately omits) the change, and let the lock's diff be reviewed.
+//
+// -group narrows the update to the named covered groups, keeping the rest of
+// the lock byte-for-byte untouched. That is what lets a PR fixing some groups'
+// drift avoid silently accepting every other group's — the full regenerate is
+// for seeding and for PRs that really do triage everything.
+func runFields(manifestPath, sdkDir, lockPath, group string, write bool) error {
+	fields, _, err := loadFieldSurface(manifestPath, sdkDir)
+	if err != nil {
+		return err
+	}
+
+	var lock sdkcoverage.FieldLock
+	if group == "" {
+		lock = sdkcoverage.BuildFieldLock(fields)
+	} else {
+		lock, err = sdkcoverage.LoadFieldLock(lockPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("sdkcoverage: -group updates an existing lock, and %s does not exist — seed it first with a full `fields -write`", lockPath)
+		}
+		if err != nil {
+			return err
+		}
+		for _, g := range strings.Split(group, ",") {
+			g = strings.TrimSpace(g)
+			models, ok := fields.Groups[g]
+			if !ok {
+				return fmt.Errorf("sdkcoverage: %q is not a covered group in this SDK tree (see `report`)", g)
+			}
+			lock.Groups[g] = models
+		}
+		// The header labels the tree the lock was last written from; the
+		// untouched groups keep their acknowledged shapes regardless.
+		lock.SDKVersion = fields.SDKVersion
+	}
+
+	if !write {
+		fmt.Print(string(lock.Marshal()))
+		return nil
+	}
+	if err := sdkcoverage.WriteFieldLock(lockPath, lock); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s (%d covered group(s), SDK %s)\n", lockPath, len(lock.Groups), lock.SDKVersion)
+	return nil
+}
+
+// runDrift diffs the committed lock against an SDK tree. A missing lock is an
+// inert no-op, not an error: it keeps the command safe to wire into automation
+// before the lock has ever been seeded, and after, the gate makes sure the
+// lock cannot quietly disappear.
+func runDrift(manifestPath, sdkDir, lockPath, format string, strict bool) error {
+	lock, err := sdkcoverage.LoadFieldLock(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return renderDrift(nil, "", "", true, format, strict)
+	}
+	if err != nil {
+		return err
+	}
+
+	fields, _, err := loadFieldSurface(manifestPath, sdkDir)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := sdkcoverage.LoadManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	drift := sdkcoverage.DiffFieldSurfaces(lock.Surface(), fields, manifest)
+	return renderDrift(drift, lock.SDKVersion, fields.SDKVersion, false, format, strict)
+}
+
+func renderDrift(drift []sdkcoverage.Drift, lockVersion, sdkVersion string, lockMissing bool, format string, strict bool) error {
+	switch format {
+	case "text":
+		if lockMissing {
+			fmt.Println("no field lock found; nothing to diff (seed one with `sdkcoverage fields -write`)")
+			return nil
+		}
+		fmt.Print(sdkcoverage.DriftText(drift, lockVersion, sdkVersion))
+	case "", "markdown":
+		if lockMissing {
+			fmt.Println("no field lock found; nothing to diff (seed one with `sdkcoverage fields -write`)")
+			return nil
+		}
+		fmt.Print(sdkcoverage.DriftMarkdown(drift, lockVersion, sdkVersion))
+	case "json":
+		data, err := sdkcoverage.DriftJSON(drift, lockVersion, sdkVersion, lockMissing)
+		if err != nil {
+			return fmt.Errorf("sdkcoverage: rendering drift JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		return fmt.Errorf("unsupported drift format %q (want markdown, text, or json)", format)
+	}
+
+	if strict {
+		breaking := 0
+		for _, d := range drift {
+			if d.Breaking() {
+				breaking++
+			}
+		}
+		if breaking > 0 {
+			return fmt.Errorf("%d breaking field drift(s) — fix the mapping or regenerate the lock (`make fields-sync`) and get the diff reviewed", breaking)
+		}
+	}
+	return nil
+}
+
+// loadFieldSurface parses the field-level shape of the manifest's covered
+// groups from the given (or pinned) SDK tree.
+func loadFieldSurface(manifestPath, sdkDir string) (sdkcoverage.FieldSurface, string, error) {
+	surface, dir, err := loadSurface(sdkDir)
+	if err != nil {
+		return sdkcoverage.FieldSurface{}, "", err
+	}
+
+	manifest, err := sdkcoverage.LoadManifest(manifestPath)
+	if err != nil {
+		return sdkcoverage.FieldSurface{}, "", err
+	}
+
+	var covered []string
+	for name, entry := range manifest.Groups {
+		// Covered groups that the SDK no longer exposes are the group-level
+		// gate's finding, not a field-parse error.
+		if _, ok := surface.Groups[name]; ok && entry.Covered() {
+			covered = append(covered, name)
+		}
+	}
+	sort.Strings(covered)
+
+	fields, err := sdkcoverage.ParseFieldSurface(dir, surface, covered)
+	if err != nil {
+		return sdkcoverage.FieldSurface{}, "", err
+	}
+	return fields, dir, nil
 }
 
 func reconcile(manifestPath, sdkDir string) (sdkcoverage.Report, string, error) {

--- a/internal/sdkcoverage/drift.go
+++ b/internal/sdkcoverage/drift.go
@@ -1,0 +1,351 @@
+package sdkcoverage
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// DriftKind classifies one field-level difference between the lock and an SDK
+// tree.
+type DriftKind string
+
+const (
+	// Breaking kinds: the SDK no longer has a shape the provider's compiled-in
+	// mappings could still assume, so silently absorbing it risks a runtime
+	// break. These fail the gate when found between the lock and the PINNED SDK.
+
+	DriftFieldRemoved           DriftKind = "field_removed"
+	DriftFieldTypeChanged       DriftKind = "field_type_changed"
+	DriftFieldRequiredChanged   DriftKind = "field_required_changed"
+	DriftEnumValueRemoved       DriftKind = "enum_value_removed"
+	DriftMethodRemoved          DriftKind = "method_removed"
+	DriftMethodSignatureChanged DriftKind = "method_signature_changed"
+
+	// Informational kinds: new capability or behavior notes on a covered group.
+	// Reported and queued for a fix, never a failure — the same stance the
+	// group-level report takes on pending groups.
+
+	DriftFieldAdded     DriftKind = "field_added"
+	DriftFieldRenamed   DriftKind = "field_renamed"
+	DriftEnumValueAdded DriftKind = "enum_value_added"
+	DriftMethodAdded    DriftKind = "method_added"
+	DriftModelAdded     DriftKind = "model_added"
+	DriftModelRemoved   DriftKind = "model_removed"
+	DriftDeprecated     DriftKind = "deprecated"
+	DriftDefaultChanged DriftKind = "default_changed"
+	DriftDocChanged     DriftKind = "doc_changed"
+	DriftGroupUnlocked  DriftKind = "group_unlocked"
+	DriftGroupStale     DriftKind = "group_stale"
+)
+
+// Breaking reports whether this kind fails the gate. A removed model is not
+// here on purpose: removing a model only matters through the field or
+// signature that referenced it, and that reference drifts as its own breaking
+// row.
+func (k DriftKind) Breaking() bool {
+	switch k {
+	case DriftFieldRemoved, DriftFieldTypeChanged, DriftFieldRequiredChanged,
+		DriftEnumValueRemoved, DriftMethodRemoved, DriftMethodSignatureChanged:
+		return true
+	}
+	return false
+}
+
+// Drift is one difference between the acknowledged lock and an SDK tree,
+// attributed to the covered group it appeared under.
+type Drift struct {
+	// Group is the dotted group path the drift belongs to. A model shared by
+	// several covered groups drifts once per group: each mapping owner needs to
+	// see it.
+	Group string
+
+	Kind DriftKind
+
+	// Model is the qualified model name, e.g. "components.ServerData". Empty for
+	// method- and group-level drift.
+	Model string
+
+	// Field names what moved inside the model: a field's wire name, an enum
+	// value, or a method name. Empty for model- and group-level drift.
+	Field string
+
+	// Detail is the human-readable old→new explanation.
+	Detail string
+
+	// SuggestedAttribute is the Terraform attribute name a reviewer would expect
+	// for an added field. Advisory only, like SuggestTypeName: the real mapping
+	// is many-to-many and gets decided in review.
+	SuggestedAttribute string
+
+	// ImplementedBy names the Terraform types that own this group's mapping —
+	// who has to look.
+	ImplementedBy []string
+}
+
+// Breaking reports whether this drift fails the gate.
+func (d Drift) Breaking() bool { return d.Kind.Breaking() }
+
+func (d Drift) String() string {
+	var b strings.Builder
+	b.WriteString(d.Group)
+	if d.Model != "" {
+		b.WriteString(" " + d.Model)
+	}
+	if d.Field != "" {
+		b.WriteString(" " + d.Field)
+	}
+	fmt.Fprintf(&b, ": %s", d.Kind)
+	if d.Detail != "" {
+		b.WriteString(" — " + d.Detail)
+	}
+	return b.String()
+}
+
+// DiffFieldSurfaces compares the acknowledged baseline (the lock) against a
+// parsed surface. current is expected to hold exactly the covered groups;
+// manifest supplies each group's ImplementedBy for attribution.
+func DiffFieldSurfaces(baseline, current FieldSurface, manifest Manifest) []Drift {
+	var drift []Drift
+
+	for _, group := range sortedKeys(current.Groups) {
+		implementedBy := manifest.Groups[group].ImplementedBy
+
+		base, locked := baseline.Groups[group]
+		if !locked {
+			drift = append(drift, Drift{
+				Group:         group,
+				Kind:          DriftGroupUnlocked,
+				Detail:        "covered but absent from the lock — run `make fields-sync` to seed it",
+				ImplementedBy: implementedBy,
+			})
+			continue
+		}
+		drift = append(drift, diffGroup(group, base, current.Groups[group], implementedBy)...)
+	}
+
+	// Locked groups the parsed surface no longer carries: the group left
+	// coverage, or left the SDK entirely. The group-level gate owns the latter;
+	// either way the stale entry just wants a resync.
+	for _, group := range sortedKeys(baseline.Groups) {
+		if _, ok := current.Groups[group]; !ok {
+			drift = append(drift, Drift{
+				Group:  group,
+				Kind:   DriftGroupStale,
+				Detail: "locked but no longer a covered group — run `make fields-sync` to drop it",
+			})
+		}
+	}
+
+	sort.Slice(drift, func(i, j int) bool {
+		a, b := drift[i], drift[j]
+		if a.Group != b.Group {
+			return a.Group < b.Group
+		}
+		if a.Model != b.Model {
+			return a.Model < b.Model
+		}
+		if a.Field != b.Field {
+			return a.Field < b.Field
+		}
+		return a.Kind < b.Kind
+	})
+	return drift
+}
+
+func diffGroup(group string, base, cur GroupModels, implementedBy []string) []Drift {
+	var drift []Drift
+	row := func(kind DriftKind, model, field, detail string) {
+		drift = append(drift, Drift{
+			Group: group, Kind: kind, Model: model, Field: field,
+			Detail: detail, ImplementedBy: implementedBy,
+		})
+	}
+
+	for _, name := range sortedKeys(base.Methods) {
+		baseM := base.Methods[name]
+		curM, ok := cur.Methods[name]
+		if !ok {
+			row(DriftMethodRemoved, "", name, "method gone; signature was "+baseM.Signature)
+			continue
+		}
+		if baseM.Signature != curM.Signature {
+			row(DriftMethodSignatureChanged, "", name, baseM.Signature+" -> "+curM.Signature)
+		}
+		if baseM.Deprecated != curM.Deprecated {
+			row(DriftDeprecated, "", name, deprecationDetail(curM.Deprecated))
+		}
+	}
+	for _, name := range sortedKeys(cur.Methods) {
+		if _, ok := base.Methods[name]; !ok {
+			row(DriftMethodAdded, "", name, "new method "+cur.Methods[name].Signature)
+		}
+	}
+
+	var removed, added []string
+	for _, name := range sortedKeys(base.Models) {
+		if _, ok := cur.Models[name]; !ok {
+			removed = append(removed, name)
+		}
+	}
+	for _, name := range sortedKeys(cur.Models) {
+		if _, ok := base.Models[name]; !ok {
+			added = append(added, name)
+		}
+	}
+
+	// A removed and an added model with the identical shape is almost certainly
+	// a Speakeasy rename (operation renames cascade into their model names).
+	// Say so, and never expand either side into a per-field cascade: one line
+	// out, one line in.
+	for _, name := range removed {
+		detail := "model gone"
+		for _, other := range added {
+			if reflect.DeepEqual(base.Models[name], cur.Models[other]) {
+				detail = "model gone — possibly renamed to " + other
+				break
+			}
+		}
+		row(DriftModelRemoved, name, "", detail)
+	}
+	for _, name := range added {
+		row(DriftModelAdded, name, "", "new model: "+summarizeModel(cur.Models[name]))
+	}
+
+	for _, name := range sortedKeys(base.Models) {
+		if _, ok := cur.Models[name]; ok {
+			drift = append(drift, diffModel(group, name, base.Models[name], cur.Models[name], implementedBy)...)
+		}
+	}
+
+	return drift
+}
+
+func diffModel(group, model string, base, cur ModelShape, implementedBy []string) []Drift {
+	var drift []Drift
+	row := func(kind DriftKind, field, detail, suggested string) {
+		drift = append(drift, Drift{
+			Group: group, Kind: kind, Model: model, Field: field,
+			Detail: detail, SuggestedAttribute: suggested, ImplementedBy: implementedBy,
+		})
+	}
+
+	baseEnum := stringSet(base.Enum)
+	curEnum := stringSet(cur.Enum)
+	for _, v := range base.Enum {
+		if !curEnum[v] {
+			row(DriftEnumValueRemoved, v, "enum value gone — anything still sending or unmarshaling it breaks", "")
+		}
+	}
+	for _, v := range cur.Enum {
+		if !baseEnum[v] {
+			row(DriftEnumValueAdded, v, "new enum value", "")
+		}
+	}
+
+	if base.Doc != cur.Doc {
+		row(DriftDocChanged, "", "documentation changed — check for a behavior change the types cannot show", "")
+	}
+
+	baseFields := fieldsByIdentity(base.Fields)
+	curFields := fieldsByIdentity(cur.Fields)
+
+	for _, key := range sortedKeys(baseFields) {
+		bf := baseFields[key]
+		cf, ok := curFields[key]
+		if !ok {
+			row(DriftFieldRemoved, fieldLabel(bf), fmt.Sprintf("field gone; was %s", bf.Type), "")
+			continue
+		}
+		if bf.Name != cf.Name {
+			row(DriftFieldRenamed, fieldLabel(cf), fmt.Sprintf("Go name %s -> %s (wire name unchanged)", bf.Name, cf.Name), "")
+		}
+		// A field that only gained or lost its pointer alongside an optionality
+		// flip is one fact, not two: the required↔optional row carries it.
+		pointerFlipOnly := strings.TrimPrefix(bf.Type, "*") == strings.TrimPrefix(cf.Type, "*") &&
+			bf.Optional != cf.Optional
+		if bf.Type != cf.Type && !pointerFlipOnly {
+			row(DriftFieldTypeChanged, fieldLabel(cf), fmt.Sprintf("type %s -> %s", bf.Type, cf.Type), "")
+		}
+		if bf.Optional != cf.Optional {
+			row(DriftFieldRequiredChanged, fieldLabel(cf), requiredDetail(cf.Optional), "")
+		}
+		if bf.Default != cf.Default {
+			row(DriftDefaultChanged, fieldLabel(cf), fmt.Sprintf("default %s -> %s", orNone(bf.Default), orNone(cf.Default)), "")
+		}
+		if bf.Deprecated != cf.Deprecated {
+			row(DriftDeprecated, fieldLabel(cf), deprecationDetail(cf.Deprecated), "")
+		}
+		if bf.Doc != cf.Doc {
+			row(DriftDocChanged, fieldLabel(cf), "documentation changed — check for a behavior change the types cannot show", "")
+		}
+	}
+	for _, key := range sortedKeys(curFields) {
+		if _, ok := baseFields[key]; !ok {
+			cf := curFields[key]
+			row(DriftFieldAdded, fieldLabel(cf), fmt.Sprintf("new field %s", cf.Type), SuggestAttributeName(cf))
+		}
+	}
+
+	return drift
+}
+
+// fieldsByIdentity keys fields by what identifies them on the wire: the wire
+// name when there is one, the Go name otherwise. A wire rename therefore reads
+// as removed+added — which is what it is to the API — while a Go-only rename
+// stays matched and reads as the cosmetic drift it is.
+func fieldsByIdentity(fields []FieldShape) map[string]FieldShape {
+	out := make(map[string]FieldShape, len(fields))
+	for _, f := range fields {
+		out[fieldLabel(f)] = f
+	}
+	return out
+}
+
+func fieldLabel(f FieldShape) string {
+	if f.Wire != "" {
+		return f.Wire
+	}
+	return f.Name
+}
+
+func summarizeModel(m ModelShape) string {
+	switch {
+	case len(m.Enum) > 0:
+		return fmt.Sprintf("enum of %d value(s)", len(m.Enum))
+	case len(m.Fields) > 0:
+		return fmt.Sprintf("%d field(s)", len(m.Fields))
+	default:
+		return "empty struct"
+	}
+}
+
+func deprecationDetail(deprecated bool) string {
+	if deprecated {
+		return "now marked Deprecated"
+	}
+	return "no longer marked Deprecated"
+}
+
+func requiredDetail(optional bool) string {
+	if optional {
+		return "required -> optional"
+	}
+	return "optional -> required"
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return s
+}
+
+func stringSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, v := range values {
+		out[v] = true
+	}
+	return out
+}

--- a/internal/sdkcoverage/drift_test.go
+++ b/internal/sdkcoverage/drift_test.go
@@ -1,0 +1,124 @@
+package sdkcoverage
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var widgetsManifest = Manifest{Groups: map[string]Entry{
+	"Widgets": {ImplementedBy: []string{"latitudesh_widget"}},
+}}
+
+// TestDiffFieldSurfacesFixturePair drives the whole differ through the v1/v2
+// fixture pair, which mutates exactly one instance of each drift kind. The
+// want list below and the v2 package comment describe the same set — a change
+// to either fixture lands here.
+func TestDiffFieldSurfacesFixturePair(t *testing.T) {
+	v1 := parseFieldFixture(t, fieldSDKv1)
+	v2 := parseFieldFixture(t, fieldSDKv2)
+
+	drift := DiffFieldSurfaces(v1, v2, widgetsManifest)
+
+	got := make([]string, 0, len(drift))
+	for _, d := range drift {
+		got = append(got, fmt.Sprintf("%s|%s|%s|%s", d.Kind, d.Model, d.Field, marker(d.Breaking())))
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"default_changed|operations.ListWidgetsRequest|page[size]|info",
+		"deprecated||Legacy|info",
+		"doc_changed|components.WidgetData|label|info",
+		"enum_value_added|operations.WidgetColor|green|info",
+		"enum_value_removed|operations.WidgetColor|blue|BREAKING",
+		"field_added|components.WidgetData|badge|info",
+		"field_added|components.WidgetData|bgp_ready|info",
+		"field_removed|operations.CreateWidgetWidgetsRequestBody|size|BREAKING",
+		"field_required_changed|components.WidgetData|status|BREAKING",
+		"field_type_changed|components.WidgetData|weight|BREAKING",
+		"method_added||Update|info",
+		"method_removed||Delete|BREAKING",
+		"method_signature_changed||List|BREAKING",
+		"model_added|components.Badge||info",
+		"model_added|operations.UpdateWidgetResponse||info",
+		"model_removed|operations.DeleteWidgetResponse||info",
+	}
+	sort.Strings(want)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("drift rows:\n got %s\nwant %s", strings.Join(got, "\n     "), strings.Join(want, "\n     "))
+	}
+
+	for _, d := range drift {
+		if d.Group != "Widgets" {
+			t.Errorf("drift attributed to %q, want Widgets: %v", d.Group, d)
+		}
+		if !reflect.DeepEqual(d.ImplementedBy, []string{"latitudesh_widget"}) {
+			t.Errorf("ImplementedBy = %v: %v", d.ImplementedBy, d)
+		}
+		if d.Kind == DriftFieldAdded && d.Field == "bgp_ready" && d.SuggestedAttribute != "bgp_ready" {
+			t.Errorf("bgp_ready suggested attribute = %q", d.SuggestedAttribute)
+		}
+	}
+}
+
+func TestDiffFieldSurfacesIdentical(t *testing.T) {
+	v1 := parseFieldFixture(t, fieldSDKv1)
+	if drift := DiffFieldSurfaces(v1, v1, widgetsManifest); len(drift) != 0 {
+		t.Errorf("identical surfaces drifted: %v", drift)
+	}
+}
+
+func TestDiffFieldSurfacesGroupBookkeeping(t *testing.T) {
+	v1 := parseFieldFixture(t, fieldSDKv1)
+
+	// Covered but never locked: one informational nudge, no per-field noise.
+	drift := DiffFieldSurfaces(FieldSurface{}, v1, widgetsManifest)
+	if len(drift) != 1 || drift[0].Kind != DriftGroupUnlocked || drift[0].Breaking() {
+		t.Errorf("unlocked group: %v", drift)
+	}
+
+	// Locked but no longer covered (or gone from the SDK): the stale entry
+	// asks for a resync, nothing more.
+	drift = DiffFieldSurfaces(v1, FieldSurface{Groups: map[string]GroupModels{}}, widgetsManifest)
+	if len(drift) != 1 || drift[0].Kind != DriftGroupStale || drift[0].Breaking() {
+		t.Errorf("stale group: %v", drift)
+	}
+}
+
+// TestDiffFieldSurfacesRenameHint pins the heuristic: a removed model whose
+// shape matches an added one is flagged as a possible rename, and neither side
+// cascades into per-field rows.
+func TestDiffFieldSurfacesRenameHint(t *testing.T) {
+	shape := ModelShape{Fields: []FieldShape{{Name: "ID", Wire: "id", Type: "*string", Optional: true}}}
+	base := FieldSurface{Groups: map[string]GroupModels{
+		"Widgets": {Models: map[string]ModelShape{"operations.PutWidget": shape}},
+	}}
+	cur := FieldSurface{Groups: map[string]GroupModels{
+		"Widgets": {Models: map[string]ModelShape{"operations.PatchWidget": shape}},
+	}}
+
+	drift := DiffFieldSurfaces(base, cur, widgetsManifest)
+	if len(drift) != 2 {
+		t.Fatalf("want exactly removed+added, got %v", drift)
+	}
+	var sawHint bool
+	for _, d := range drift {
+		if d.Kind == DriftModelRemoved && strings.Contains(d.Detail, "possibly renamed to operations.PatchWidget") {
+			sawHint = true
+		}
+	}
+	if !sawHint {
+		t.Errorf("no rename hint in %v", drift)
+	}
+}
+
+func marker(breaking bool) string {
+	if breaking {
+		return "BREAKING"
+	}
+	return "info"
+}

--- a/internal/sdkcoverage/driftreport.go
+++ b/internal/sdkcoverage/driftreport.go
@@ -1,0 +1,175 @@
+package sdkcoverage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// jsonDriftReport is the machine-readable drift document. It is a separate
+// document from jsonReport on purpose: the coverage report's field names are a
+// stable contract with the sdk-watch workflow, and drift gets its own contract
+// rather than a risky extension of that one. Keep these field names stable too —
+// the workflow reads counts.breaking and counts.informational.
+type jsonDriftReport struct {
+	SDKModule string `json:"sdk_module"`
+
+	// LockSDKVersion labels the tree the lock was generated from, SDKVersion the
+	// tree being compared. Both informational; the diff runs on shapes.
+	LockSDKVersion string `json:"lock_sdk_version,omitempty"`
+	SDKVersion     string `json:"sdk_version,omitempty"`
+
+	// LockMissing means there was no lock to compare against, so the document is
+	// an inert no-op rather than a claim that nothing drifted.
+	LockMissing bool `json:"lock_missing"`
+
+	// OK means no breaking drift.
+	OK bool `json:"ok"`
+
+	Counts jsonDriftCounts `json:"counts"`
+	Drift  []jsonDrift     `json:"drift"`
+}
+
+type jsonDriftCounts struct {
+	Total         int `json:"total"`
+	Breaking      int `json:"breaking"`
+	Informational int `json:"informational"`
+}
+
+type jsonDrift struct {
+	Group              string   `json:"group"`
+	Kind               string   `json:"kind"`
+	Breaking           bool     `json:"breaking"`
+	Model              string   `json:"model,omitempty"`
+	Field              string   `json:"field,omitempty"`
+	Detail             string   `json:"detail"`
+	SuggestedAttribute string   `json:"suggested_attribute,omitempty"`
+	ImplementedBy      []string `json:"implemented_by"`
+}
+
+// DriftJSON renders a drift set as an indented JSON document. lockVersion and
+// sdkVersion label the two sides; lockMissing renders the inert no-op form.
+func DriftJSON(drift []Drift, lockVersion, sdkVersion string, lockMissing bool) ([]byte, error) {
+	doc := jsonDriftReport{
+		SDKModule:      SDKModulePath,
+		LockSDKVersion: lockVersion,
+		SDKVersion:     sdkVersion,
+		LockMissing:    lockMissing,
+		OK:             countBreaking(drift) == 0,
+		Counts: jsonDriftCounts{
+			Total:         len(drift),
+			Breaking:      countBreaking(drift),
+			Informational: len(drift) - countBreaking(drift),
+		},
+		Drift: make([]jsonDrift, 0, len(drift)),
+	}
+	for _, d := range drift {
+		implementedBy := d.ImplementedBy
+		if implementedBy == nil {
+			// Arrays are never null, same convention as the coverage document.
+			implementedBy = []string{}
+		}
+		doc.Drift = append(doc.Drift, jsonDrift{
+			Group:              d.Group,
+			Kind:               string(d.Kind),
+			Breaking:           d.Breaking(),
+			Model:              d.Model,
+			Field:              d.Field,
+			Detail:             d.Detail,
+			SuggestedAttribute: d.SuggestedAttribute,
+			ImplementedBy:      implementedBy,
+		})
+	}
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// DriftMarkdown renders a drift set for a tracking issue or PR body: breaking
+// drift first under a warning, additions and notes after.
+func DriftMarkdown(drift []Drift, lockVersion, sdkVersion string) string {
+	var b strings.Builder
+
+	b.WriteString("# Field drift on covered groups\n\n")
+	if lockVersion != "" || sdkVersion != "" {
+		fmt.Fprintf(&b, "Lock: `%s` — SDK: `%s`\n\n", orDash(lockVersion), orDash(sdkVersion))
+	}
+
+	if len(drift) == 0 {
+		b.WriteString("No drift: the SDK still has the shape the lock acknowledges.\n")
+		return b.String()
+	}
+
+	var breaking, informational []Drift
+	for _, d := range drift {
+		if d.Breaking() {
+			breaking = append(breaking, d)
+		} else {
+			informational = append(informational, d)
+		}
+	}
+
+	if len(breaking) > 0 {
+		b.WriteString("> [!WARNING]\n")
+		fmt.Fprintf(&b, "> %d breaking change(s) on covered groups. The provider still compiles in the old shape; "+
+			"triage these before (or in) the PR that bumps the SDK.\n", len(breaking))
+		b.WriteString("\n## Breaking\n\n")
+		writeDriftTable(&b, breaking)
+	}
+
+	if len(informational) > 0 {
+		b.WriteString("\n## New capability and notes\n\n")
+		writeDriftTable(&b, informational)
+	}
+
+	return b.String()
+}
+
+func writeDriftTable(b *strings.Builder, drift []Drift) {
+	b.WriteString("| Group | Kind | Where | Detail | Suggested attribute | Implemented by |\n|---|---|---|---|---|---|\n")
+	for _, d := range drift {
+		where := d.Model
+		if d.Field != "" {
+			if where != "" {
+				where += "."
+			}
+			where += d.Field
+		}
+		fmt.Fprintf(b, "| `%s` | `%s` | %s | %s | %s | %s |\n",
+			d.Group, d.Kind, orDash(codeOrEmpty(where)), orDash(d.Detail),
+			orDash(codeOrEmpty(d.SuggestedAttribute)), codeList(d.ImplementedBy))
+	}
+}
+
+// DriftText renders a short human-readable drift summary for terminal use.
+func DriftText(drift []Drift, lockVersion, sdkVersion string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "lock %s vs SDK %s\n", orDash(lockVersion), orDash(sdkVersion))
+	breaking := countBreaking(drift)
+	fmt.Fprintf(&b, "%d drift row(s): %d breaking, %d informational\n", len(drift), breaking, len(drift)-breaking)
+
+	for _, d := range drift {
+		marker := " "
+		if d.Breaking() {
+			marker = "!"
+		}
+		fmt.Fprintf(&b, "  %s %s\n", marker, d)
+	}
+	return b.String()
+}
+
+func countBreaking(drift []Drift) int {
+	n := 0
+	for _, d := range drift {
+		if d.Breaking() {
+			n++
+		}
+	}
+	return n
+}
+
+func codeOrEmpty(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "`" + s + "`"
+}

--- a/internal/sdkcoverage/fieldlock.go
+++ b/internal/sdkcoverage/fieldlock.go
@@ -1,0 +1,207 @@
+package sdkcoverage
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FieldLockFile is the lock's conventional name at the repository root, next to
+// the coverage manifest.
+const FieldLockFile = "sdk-fields.lock.yaml"
+
+// SupportedFieldLockVersion is the only lock schema version this code
+// understands. Bump it together with any breaking change to the layout.
+const SupportedFieldLockVersion = 1
+
+// FieldLock is the committed record of the field-level SDK shape a human last
+// acknowledged, go.sum-style: the covered groups' models as they were when
+// someone ran `sdkcoverage fields -write` and got the diff reviewed.
+//
+// The lock — not the pinned SDK version — is the drift baseline. A pinned-vs-
+// latest diff evaporates the moment anything bumps go.mod (the scaffold job
+// does, routinely) whether or not the drift was ever mapped; the lock stays
+// stale until a PR that actually addresses the drift regenerates it, so
+// regenerating it is the act of acceptance and the lock's git diff is the
+// record of what was accepted.
+type FieldLock struct {
+	Version    int                    `yaml:"version"`
+	SDKModule  string                 `yaml:"sdk_module"`
+	SDKVersion string                 `yaml:"sdk_version,omitempty"`
+	Groups     map[string]GroupModels `yaml:"groups"`
+}
+
+// Surface returns the lock's shape as a FieldSurface, the form the differ
+// takes.
+func (l FieldLock) Surface() FieldSurface {
+	return FieldSurface{SDKVersion: l.SDKVersion, Groups: l.Groups}
+}
+
+// BuildFieldLock wraps a parsed surface in the lock's identity envelope.
+func BuildFieldLock(fields FieldSurface) FieldLock {
+	return FieldLock{
+		Version:    SupportedFieldLockVersion,
+		SDKModule:  SDKModulePath,
+		SDKVersion: fields.SDKVersion,
+		Groups:     fields.Groups,
+	}
+}
+
+// LoadFieldLock reads and parses the lock at path.
+func LoadFieldLock(path string) (FieldLock, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return FieldLock{}, fmt.Errorf("sdkcoverage: reading field lock: %w", err)
+	}
+
+	var lock FieldLock
+	// KnownFields for the same reason as the manifest: a typo in a lock key must
+	// be an error, not a line that silently stops meaning anything.
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&lock); err != nil {
+		return FieldLock{}, fmt.Errorf("sdkcoverage: parsing %s: %w", path, err)
+	}
+
+	if lock.Version != SupportedFieldLockVersion {
+		return FieldLock{}, fmt.Errorf(
+			"sdkcoverage: %s declares version %d, but this build understands version %d",
+			path, lock.Version, SupportedFieldLockVersion)
+	}
+	if lock.SDKModule != SDKModulePath {
+		return FieldLock{}, fmt.Errorf(
+			"sdkcoverage: %s declares sdk_module %q, but drift is computed against %q",
+			path, lock.SDKModule, SDKModulePath)
+	}
+
+	if lock.Groups == nil {
+		lock.Groups = map[string]GroupModels{}
+	}
+	return lock, nil
+}
+
+// Marshal renders the lock deterministically: sorted keys everywhere and one
+// flow-style line per field, so two runs over the same SDK are byte-identical,
+// lock diffs read like drift reports, and a merge conflict is resolved by
+// regenerating rather than by hand-picking hunks.
+//
+// Rendering is by hand rather than through the yaml encoder because the
+// encoder guarantees neither the flow layout nor the key order this file's
+// diffability depends on. Loading still goes through the yaml decoder, which
+// keeps the two sides honest: anything Marshal writes that the schema does not
+// know fails the very next load.
+func (l FieldLock) Marshal() []byte {
+	var b strings.Builder
+
+	b.WriteString("# Field-level shape of the covered latitudesh-go-sdk service groups, as last\n")
+	b.WriteString("# acknowledged. Regenerate with `make fields-sync` (or `go run ./cmd/sdkcoverage\n")
+	b.WriteString("# fields -write`) in the PR that maps — or deliberately omits — the change;\n")
+	b.WriteString("# this file's git diff is the record of what that PR accepted.\n")
+	b.WriteString("# See CONTRIBUTING.md, \"Field drift\".\n")
+	fmt.Fprintf(&b, "version: %d\n", l.Version)
+	fmt.Fprintf(&b, "sdk_module: %s\n", l.SDKModule)
+	if l.SDKVersion != "" {
+		fmt.Fprintf(&b, "sdk_version: %s\n", l.SDKVersion)
+	}
+
+	b.WriteString("groups:\n")
+	for _, group := range sortedKeys(l.Groups) {
+		fmt.Fprintf(&b, "  %s:\n", group)
+		gm := l.Groups[group]
+
+		if len(gm.Methods) > 0 {
+			b.WriteString("    methods:\n")
+			for _, name := range sortedKeys(gm.Methods) {
+				m := gm.Methods[name]
+				fmt.Fprintf(&b, "      %s: {signature: %s", name, strconv.Quote(m.Signature))
+				if m.Deprecated {
+					b.WriteString(", deprecated: true")
+				}
+				b.WriteString("}\n")
+			}
+		}
+
+		if len(gm.Models) > 0 {
+			b.WriteString("    models:\n")
+			for _, name := range sortedKeys(gm.Models) {
+				model := gm.Models[name]
+				fmt.Fprintf(&b, "      %s:\n", name)
+				if model.Doc != "" {
+					fmt.Fprintf(&b, "        doc: %s\n", strconv.Quote(model.Doc))
+				}
+				if len(model.Enum) > 0 {
+					fmt.Fprintf(&b, "        enum: [%s]\n", quotedList(model.Enum))
+				}
+				if len(model.Fields) > 0 {
+					b.WriteString("        fields:\n")
+					fields := append([]FieldShape(nil), model.Fields...)
+					sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+					for _, f := range fields {
+						b.WriteString("          - " + f.flowLine() + "\n")
+					}
+				}
+			}
+		}
+	}
+
+	return []byte(b.String())
+}
+
+// WriteFieldLock writes the lock to path — the one write this package ever
+// performs, and only ever on request.
+func WriteFieldLock(path string, lock FieldLock) error {
+	if err := os.WriteFile(path, lock.Marshal(), 0o644); err != nil {
+		return fmt.Errorf("sdkcoverage: writing field lock: %w", err)
+	}
+	return nil
+}
+
+// flowLine renders one field as a single flow-style YAML map, false and empty
+// attributes omitted. strconv.Quote emits double-quoted strings, which YAML
+// parses identically for the ASCII content these values carry.
+func (f FieldShape) flowLine() string {
+	parts := []string{
+		"name: " + strconv.Quote(f.Name),
+	}
+	if f.Wire != "" {
+		parts = append(parts, "wire: "+strconv.Quote(f.Wire))
+	}
+	parts = append(parts, "type: "+strconv.Quote(f.Type))
+	if f.Optional {
+		parts = append(parts, "optional: true")
+	}
+	if f.Default != "" {
+		parts = append(parts, "default: "+strconv.Quote(f.Default))
+	}
+	if f.Deprecated {
+		parts = append(parts, "deprecated: true")
+	}
+	if f.Doc != "" {
+		parts = append(parts, "doc: "+strconv.Quote(f.Doc))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func quotedList(values []string) string {
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	quoted := make([]string, len(sorted))
+	for i, v := range sorted {
+		quoted[i] = strconv.Quote(v)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/sdkcoverage/fieldlock_test.go
+++ b/internal/sdkcoverage/fieldlock_test.go
@@ -1,0 +1,80 @@
+package sdkcoverage
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFieldLockRoundTrip(t *testing.T) {
+	fields := parseFieldFixture(t, fieldSDKv1)
+	lock := BuildFieldLock(fields)
+
+	path := filepath.Join(t.TempDir(), FieldLockFile)
+	if err := WriteFieldLock(path, lock); err != nil {
+		t.Fatalf("WriteFieldLock: %v", err)
+	}
+
+	loaded, err := LoadFieldLock(path)
+	if err != nil {
+		t.Fatalf("LoadFieldLock: %v", err)
+	}
+
+	// Byte-stable: what the loaded lock marshals to is exactly what was
+	// written. This is the property that keeps lock diffs meaningful.
+	if !bytes.Equal(lock.Marshal(), loaded.Marshal()) {
+		t.Error("marshal after round trip differs from the original")
+	}
+
+	// And the round trip preserves shape, so the differ sees no drift.
+	if drift := DiffFieldSurfaces(loaded.Surface(), fields, Manifest{Groups: map[string]Entry{
+		"Widgets": {ImplementedBy: []string{"latitudesh_widget"}},
+	}}); len(drift) != 0 {
+		t.Errorf("round trip drifted: %v", drift)
+	}
+}
+
+func TestLoadFieldLockRejectsUnknownKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), FieldLockFile)
+	doc := `version: 1
+sdk_module: github.com/latitudesh/latitudesh-go-sdk
+groups:
+  Widgets:
+    methods:
+      List: {signature: "()", bogus: true}
+`
+	if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadFieldLock(path); err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("unknown key not rejected: %v", err)
+	}
+}
+
+func TestLoadFieldLockChecksIdentity(t *testing.T) {
+	write := func(t *testing.T, doc string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), FieldLockFile)
+		if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	if _, err := LoadFieldLock(write(t, "version: 2\nsdk_module: github.com/latitudesh/latitudesh-go-sdk\ngroups: {}\n")); err == nil {
+		t.Error("unsupported version not rejected")
+	}
+	if _, err := LoadFieldLock(write(t, "version: 1\nsdk_module: example.com/other\ngroups: {}\n")); err == nil {
+		t.Error("wrong sdk_module not rejected")
+	}
+}
+
+func TestLoadFieldLockMissingFile(t *testing.T) {
+	_, err := LoadFieldLock(filepath.Join(t.TempDir(), FieldLockFile))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("missing lock should surface os.ErrNotExist, got %v", err)
+	}
+}

--- a/internal/sdkcoverage/fields.go
+++ b/internal/sdkcoverage/fields.go
@@ -1,0 +1,537 @@
+package sdkcoverage
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"hash/fnv"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// This file parses the SDK one level below surface.go: not which groups and
+// methods exist, but the shape of the models those methods exchange. The group
+// walk answers "is there a Terraform type for this?"; the field walk answers
+// "has what that type maps changed since a human last looked?".
+//
+// Parsing stays purely syntactic, like ParseSurface: method signatures name
+// their models with operations.* / components.* selectors, and both models/
+// directories are flat single packages, so everything is reachable from the
+// syntax tree alone — no type-checking, no network, just the module cache.
+
+// FieldSurface is the field-level shape of a set of SDK service groups. The
+// same structs serialize into sdk-fields.lock.yaml, so what the parser sees and
+// what the lock records can never disagree about layout.
+type FieldSurface struct {
+	// SDKVersion labels which SDK tree the surface was parsed from. Informational:
+	// the diff runs on shapes, never on version strings.
+	SDKVersion string `yaml:"sdk_version,omitempty"`
+
+	// Groups is keyed by the dotted group path, covered groups only. Uncovered
+	// groups stay on the scaffold pipeline; recording their fields here would
+	// just be noise nobody is accountable for yet.
+	Groups map[string]GroupModels `yaml:"groups"`
+}
+
+// GroupModels is the field-level shape of one service group.
+type GroupModels struct {
+	// Methods maps each exported method to its rendered signature. A signature
+	// is compared as one opaque string: any parameter or result change is drift,
+	// and the old/new pair is its own explanation.
+	Methods map[string]MethodShape `yaml:"methods,omitempty"`
+
+	// Models are the operations.* and components.* types transitively reachable
+	// from the methods' parameters and results, keyed by qualified name. A model
+	// shared by several groups is recorded once per group, because each group's
+	// mapping owner needs to see it drift.
+	Models map[string]ModelShape `yaml:"models,omitempty"`
+}
+
+// MethodShape is one method's comparable identity.
+type MethodShape struct {
+	Signature  string `yaml:"signature"`
+	Deprecated bool   `yaml:"deprecated,omitempty"`
+}
+
+// ModelShape is one model type: a struct with fields, or a string enum with
+// values. Exactly one of Fields/Enum is populated; an empty struct has both nil.
+type ModelShape struct {
+	// Doc is a short hash of the type's doc comment. Speakeasy regenerates these
+	// from the OpenAPI spec, so a doc-only change is often a behavior change the
+	// types cannot show (a default rule documented away, a constraint reworded).
+	Doc string `yaml:"doc,omitempty"`
+
+	// Enum holds the wire values of a string enum, sorted.
+	Enum []string `yaml:"enum,omitempty"`
+
+	// Fields holds a struct's exported wire-relevant fields, sorted by name.
+	Fields []FieldShape `yaml:"fields,omitempty"`
+}
+
+// FieldShape is one struct field as the wire sees it.
+type FieldShape struct {
+	// Name is the Go field name.
+	Name string `yaml:"name"`
+
+	// Wire is the name on the wire: the json tag, or the name= part of a
+	// queryParam tag. Empty for untagged fields (response payload envelopes).
+	Wire string `yaml:"wire,omitempty"`
+
+	// Type is the field's type exactly as written, e.g. "*string" or
+	// "[]CreateFirewallRules". Same-package references stay unqualified, which is
+	// stable because models are keyed per package.
+	Type string `yaml:"type"`
+
+	// Optional means a pointer type or an omitempty json tag — either way the
+	// wire can omit it. A required↔optional flip is a contract change.
+	Optional bool `yaml:"optional,omitempty"`
+
+	// Default is the `default:` tag value the SDK injects client-side. A changed
+	// default alters behavior without touching any type.
+	Default string `yaml:"default,omitempty"`
+
+	Deprecated bool `yaml:"deprecated,omitempty"`
+
+	// Doc is a short hash of the field's doc comment, for the same reason as
+	// ModelShape.Doc.
+	Doc string `yaml:"doc,omitempty"`
+}
+
+// ParseFieldSurface parses the field-level shape of the named groups from the
+// SDK tree at dir. surface supplies each group's backing type name, which is
+// how methods are resolved (never by field name — see Group.TypeName).
+func ParseFieldSurface(dir string, surface Surface, groups []string) (FieldSurface, error) {
+	root, err := indexModels(dir, ".")
+	if err != nil {
+		return FieldSurface{}, err
+	}
+	pkgs := map[string]*modelIndex{
+		"operations": nil,
+		"components": nil,
+	}
+	for name := range pkgs {
+		idx, err := indexModels(dir, filepath.Join("models", name))
+		if err != nil {
+			return FieldSurface{}, err
+		}
+		pkgs[name] = idx
+	}
+
+	out := FieldSurface{
+		SDKVersion: VersionFromDir(dir),
+		Groups:     make(map[string]GroupModels, len(groups)),
+	}
+	for _, name := range groups {
+		group, ok := surface.Groups[name]
+		if !ok {
+			return FieldSurface{}, fmt.Errorf("sdkcoverage: group %q not in the parsed surface", name)
+		}
+		out.Groups[name] = parseGroupModels(group, root, pkgs)
+	}
+	return out, nil
+}
+
+// parseGroupModels renders every method on the group's type and walks the
+// models reachable from their signatures.
+func parseGroupModels(group Group, root *modelIndex, pkgs map[string]*modelIndex) GroupModels {
+	gm := GroupModels{
+		Methods: make(map[string]MethodShape),
+		Models:  make(map[string]ModelShape),
+	}
+
+	seen := map[string]bool{}
+	for _, decl := range root.funcs[group.TypeName] {
+		gm.Methods[decl.Name.Name] = MethodShape{
+			Signature:  renderSignature(decl.Type),
+			Deprecated: isDeprecated(decl.Doc),
+		}
+		for _, ref := range signatureModelRefs(decl.Type) {
+			walkModel(ref, pkgs, gm.Models, seen)
+		}
+	}
+
+	if len(gm.Methods) == 0 {
+		gm.Methods = nil
+	}
+	if len(gm.Models) == 0 {
+		gm.Models = nil
+	}
+	return gm
+}
+
+// modelRef is a qualified type reference, e.g. {pkg: "operations", name:
+// "GetServersRequest"}.
+type modelRef struct {
+	pkg  string
+	name string
+}
+
+func (r modelRef) String() string { return r.pkg + "." + r.name }
+
+// walkModel records the model behind ref and recurses into every model its
+// fields reference. seen guards cycles (WidgetData.Parent *WidgetData is legal
+// and the components package has real self-references).
+func walkModel(ref modelRef, pkgs map[string]*modelIndex, out map[string]ModelShape, seen map[string]bool) {
+	if seen[ref.String()] {
+		return
+	}
+	seen[ref.String()] = true
+
+	idx, ok := pkgs[ref.pkg]
+	if !ok || idx == nil {
+		return
+	}
+
+	if values, ok := idx.enums[ref.name]; ok {
+		out[ref.String()] = ModelShape{Doc: idx.docs[ref.name], Enum: values}
+		return
+	}
+
+	raw, ok := idx.structs[ref.name]
+	if !ok {
+		// Not declared in the models packages: a leaf like types.Date or a
+		// helper from internal/. The referencing field's Type string still
+		// carries its name, so a change there is not invisible — just opaque.
+		return
+	}
+
+	shape := ModelShape{Doc: idx.docs[ref.name]}
+	for _, field := range raw {
+		fs, refs, keep := field.shape(ref.pkg)
+		if !keep {
+			continue
+		}
+		shape.Fields = append(shape.Fields, fs)
+		for _, next := range refs {
+			walkModel(next, pkgs, out, seen)
+		}
+	}
+	sort.Slice(shape.Fields, func(i, j int) bool { return shape.Fields[i].Name < shape.Fields[j].Name })
+	out[ref.String()] = shape
+}
+
+// modelIndex is the raw syntactic index of one flat package: struct fields,
+// string-enum values, docs, and method declarations by receiver.
+type modelIndex struct {
+	structs map[string][]rawField
+	enums   map[string][]string
+	docs    map[string]string
+	funcs   map[string][]*ast.FuncDecl
+}
+
+// rawField is one struct field before shaping: everything still attached to
+// the syntax it came from.
+type rawField struct {
+	name    string
+	typ     ast.Expr
+	tag     string
+	doc     string
+	depr    bool
+	funcTyp bool
+}
+
+// shape turns a raw field into its recorded form plus the model references its
+// type carries. keep is false for fields the wire never sees: json:"-" infra
+// (HTTPMeta) and func-typed pagination helpers (Next).
+func (f rawField) shape(pkg string) (FieldShape, []modelRef, bool) {
+	tag := reflect.StructTag(f.tag)
+	jsonName, jsonOpts := splitTag(tag.Get("json"))
+	if jsonName == "-" || f.funcTyp {
+		return FieldShape{}, nil, false
+	}
+
+	wire := jsonName
+	if wire == "" {
+		wire = queryParamName(tag.Get("queryParam"))
+	}
+
+	typeStr := types.ExprString(f.typ)
+	return FieldShape{
+		Name:       f.name,
+		Wire:       wire,
+		Type:       typeStr,
+		Optional:   strings.HasPrefix(typeStr, "*") || hasOption(jsonOpts, "omitempty"),
+		Default:    tag.Get("default"),
+		Deprecated: f.depr,
+		Doc:        f.doc,
+	}, exprModelRefs(f.typ, pkg), true
+}
+
+// indexModels parses every non-test .go file in dir/sub and indexes what the
+// field walk needs. A missing sub directory is not an error: a fixture SDK (or
+// a future SDK layout change) without one simply has no models there.
+func indexModels(dir, sub string) (*modelIndex, error) {
+	idx := &modelIndex{
+		structs: map[string][]rawField{},
+		enums:   map[string][]string{},
+		docs:    map[string]string{},
+		funcs:   map[string][]*ast.FuncDecl{},
+	}
+
+	pattern := filepath.Join(dir, sub, "*.go")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("sdkcoverage: globbing %s: %w", pattern, err)
+	}
+	sort.Strings(files)
+
+	fset := token.NewFileSet()
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("sdkcoverage: parsing %s: %w", path, err)
+		}
+		idx.addModelFile(file)
+	}
+
+	for name, values := range idx.enums {
+		sort.Strings(values)
+		idx.enums[name] = values
+	}
+	return idx, nil
+}
+
+func (idx *modelIndex) addModelFile(file *ast.File) {
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv == nil || d.Name == nil || !d.Name.IsExported() {
+				continue
+			}
+			if recv := receiverTypeName(d.Recv); recv != "" {
+				idx.funcs[recv] = append(idx.funcs[recv], d)
+			}
+
+		case *ast.GenDecl:
+			switch d.Tok {
+			case token.TYPE:
+				for _, spec := range d.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					doc := ts.Doc
+					if doc == nil {
+						doc = d.Doc
+					}
+					idx.docs[ts.Name.Name] = docHash(doc)
+					if st, ok := ts.Type.(*ast.StructType); ok {
+						idx.structs[ts.Name.Name] = rawFields(st)
+					}
+				}
+
+			case token.CONST:
+				// Speakeasy enums are const blocks of typed string literals:
+				//   const ( CreateFirewallProtocolTCP CreateFirewallProtocol = "TCP" ... )
+				// The wire value is the literal, so that is what gets recorded.
+				for _, spec := range d.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok || vs.Type == nil {
+						continue
+					}
+					ident, ok := vs.Type.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					for _, value := range vs.Values {
+						if lit, ok := value.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+							// Unquote, never Trim: the wire value is what the
+							// literal MEANS, and Trim would keep escapes verbatim
+							// (or over-trim a value ending in an escaped quote).
+							if v, err := strconv.Unquote(lit.Value); err == nil {
+								idx.enums[ident.Name] = append(idx.enums[ident.Name], v)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func rawFields(st *ast.StructType) []rawField {
+	if st.Fields == nil {
+		return nil
+	}
+
+	var fields []rawField
+	for _, field := range st.Fields.List {
+		var tag string
+		if field.Tag != nil {
+			tag = strings.Trim(field.Tag.Value, "`")
+		}
+		doc := docHash(field.Doc)
+		depr := isDeprecated(field.Doc)
+		_, isFunc := field.Type.(*ast.FuncType)
+
+		names := field.Names
+		if len(names) == 0 {
+			// An embedded field has no name of its own; record it under its
+			// terminal type identifier, like Go promotes it. Skipping it instead
+			// would drop the embedded model and every promoted field from the
+			// surface — a change there would then be invisible, the exact
+			// silent-absorption this parser exists to prevent.
+			if ident := terminalIdent(field.Type); ident != nil {
+				names = []*ast.Ident{ident}
+			}
+		}
+		for _, name := range names {
+			if !name.IsExported() {
+				continue
+			}
+			fields = append(fields, rawField{
+				name:    name.Name,
+				typ:     field.Type,
+				tag:     tag,
+				doc:     doc,
+				depr:    depr,
+				funcTyp: isFunc,
+			})
+		}
+	}
+	return fields
+}
+
+// terminalIdent unwraps a type expression to the identifier an embedded field
+// is promoted under: *Base -> Base, components.Base -> Base.
+func terminalIdent(expr ast.Expr) *ast.Ident {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t
+	case *ast.StarExpr:
+		return terminalIdent(t.X)
+	case *ast.SelectorExpr:
+		return t.Sel
+	case *ast.IndexExpr:
+		return terminalIdent(t.X)
+	}
+	return nil
+}
+
+// renderSignature renders a method's parameter and result types, e.g.
+// "(context.Context, string, ...operations.Option) (*operations.GetServerResponse, error)".
+// Only types, never parameter names: a rename that changes no type changes
+// nothing on the wire.
+func renderSignature(ft *ast.FuncType) string {
+	render := func(list *ast.FieldList) string {
+		if list == nil {
+			return "()"
+		}
+		var parts []string
+		for _, field := range list.List {
+			typ := types.ExprString(field.Type)
+			// An anonymous parameter is one entry; named ones repeat the type
+			// once per name, matching how the signature reads in the source.
+			n := len(field.Names)
+			if n == 0 {
+				n = 1
+			}
+			for i := 0; i < n; i++ {
+				parts = append(parts, typ)
+			}
+		}
+		return "(" + strings.Join(parts, ", ") + ")"
+	}
+	return render(ft.Params) + " " + render(ft.Results)
+}
+
+// signatureModelRefs extracts the operations.*/components.* references from a
+// method's parameters and results — the entry points of the model walk.
+func signatureModelRefs(ft *ast.FuncType) []modelRef {
+	var refs []modelRef
+	collect := func(list *ast.FieldList) {
+		if list == nil {
+			return
+		}
+		for _, field := range list.List {
+			// The root package has no bare model idents, so pkg "" makes
+			// exprModelRefs keep only qualified references.
+			refs = append(refs, exprModelRefs(field.Type, "")...)
+		}
+	}
+	collect(ft.Params)
+	collect(ft.Results)
+	return refs
+}
+
+// exprModelRefs finds the model references inside a type expression. pkg is the
+// package the expression appears in: a bare Ident there is a same-package
+// reference, while a SelectorExpr names its package explicitly.
+func exprModelRefs(expr ast.Expr, pkg string) []modelRef {
+	var refs []modelRef
+	ast.Inspect(expr, func(n ast.Node) bool {
+		switch t := n.(type) {
+		case *ast.SelectorExpr:
+			if x, ok := t.X.(*ast.Ident); ok {
+				if x.Name == "operations" || x.Name == "components" {
+					refs = append(refs, modelRef{pkg: x.Name, name: t.Sel.Name})
+				}
+				// Any selector's parts are fully handled here; descending would
+				// misread the Sel as a bare Ident.
+				return false
+			}
+		case *ast.Ident:
+			if pkg != "" && t.IsExported() {
+				refs = append(refs, modelRef{pkg: pkg, name: t.Name})
+			}
+		}
+		return true
+	})
+	return refs
+}
+
+// docHash reduces a doc comment to a short stable fingerprint. Whitespace is
+// normalized first so a re-wrap is not drift; the fingerprint is compared for
+// equality only, so eight hex digits are plenty.
+func docHash(doc *ast.CommentGroup) string {
+	if doc == nil {
+		return ""
+	}
+	text := strings.Join(strings.Fields(doc.Text()), " ")
+	if text == "" {
+		return ""
+	}
+	h := fnv.New32a()
+	h.Write([]byte(text))
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+func isDeprecated(doc *ast.CommentGroup) bool {
+	if doc == nil {
+		return false
+	}
+	return strings.Contains(doc.Text(), "Deprecated:")
+}
+
+func splitTag(tag string) (name string, opts []string) {
+	parts := strings.Split(tag, ",")
+	return parts[0], parts[1:]
+}
+
+func hasOption(opts []string, want string) bool {
+	for _, o := range opts {
+		if o == want {
+			return true
+		}
+	}
+	return false
+}
+
+// queryParamName extracts the name= part of a Speakeasy queryParam tag, e.g.
+// `queryParam:"style=form,explode=true,name=filter[project]"` -> "filter[project]".
+func queryParamName(tag string) string {
+	for _, part := range strings.Split(tag, ",") {
+		if v, ok := strings.CutPrefix(part, "name="); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/sdkcoverage/fields_test.go
+++ b/internal/sdkcoverage/fields_test.go
@@ -1,0 +1,183 @@
+package sdkcoverage
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	fieldSDKv1 = "testdata/fieldsdk/v1"
+	fieldSDKv2 = "testdata/fieldsdk/v2"
+)
+
+// parseFieldFixture parses one of the fieldsdk fixtures with Widgets as the
+// only covered group — the drift tests' shared setup.
+func parseFieldFixture(t *testing.T, dir string) FieldSurface {
+	t.Helper()
+
+	surface, err := ParseSurface(dir)
+	if err != nil {
+		t.Fatalf("ParseSurface(%s): %v", dir, err)
+	}
+	fields, err := ParseFieldSurface(dir, surface, []string{"Widgets"})
+	if err != nil {
+		t.Fatalf("ParseFieldSurface(%s): %v", dir, err)
+	}
+	return fields
+}
+
+func TestParseFieldSurfaceModels(t *testing.T) {
+	fields := parseFieldFixture(t, fieldSDKv1)
+
+	widgets, ok := fields.Groups["Widgets"]
+	if !ok {
+		t.Fatal("Widgets not parsed")
+	}
+
+	// Everything reachable from the five methods' signatures — and nothing
+	// else. Notably absent: components.HTTPMetadata (its field is json:"-"),
+	// and every Gadget model (Gadgets is not covered).
+	wantModels := []string{
+		"components.Pagination",
+		"components.Widget",
+		"components.WidgetData",
+		"components.WidgetList",
+		"operations.CreateWidgetResponse",
+		"operations.CreateWidgetWidgetsRequestBody",
+		"operations.DeleteWidgetResponse",
+		"operations.GetWidgetResponse",
+		"operations.LegacyWidgetResponse",
+		"operations.ListWidgetsRequest",
+		"operations.ListWidgetsResponse",
+		"operations.WidgetColor",
+	}
+	if got := sortedKeys(widgets.Models); !reflect.DeepEqual(got, wantModels) {
+		t.Errorf("models:\n got %v\nwant %v", got, wantModels)
+	}
+
+	wantMethods := []string{"Create", "Delete", "Get", "Legacy", "List"}
+	if got := sortedKeys(widgets.Methods); !reflect.DeepEqual(got, wantMethods) {
+		t.Errorf("methods:\n got %v\nwant %v", got, wantMethods)
+	}
+}
+
+func TestParseFieldSurfaceSignatures(t *testing.T) {
+	widgets := parseFieldFixture(t, fieldSDKv1).Groups["Widgets"]
+
+	want := map[string]MethodShape{
+		"List": {Signature: "(context.Context, operations.ListWidgetsRequest, ...operations.Option) (*operations.ListWidgetsResponse, error)"},
+		"Get":  {Signature: "(context.Context, string, ...operations.Option) (*operations.GetWidgetResponse, error)"},
+	}
+	for name, shape := range want {
+		if got := widgets.Methods[name]; got != shape {
+			t.Errorf("%s = %+v, want %+v", name, got, shape)
+		}
+	}
+	if widgets.Methods["Legacy"].Deprecated {
+		t.Error("Legacy is not deprecated in v1")
+	}
+}
+
+func TestParseFieldSurfaceFieldShapes(t *testing.T) {
+	widgets := parseFieldFixture(t, fieldSDKv1).Groups["Widgets"]
+
+	request := widgets.Models["operations.ListWidgetsRequest"]
+	byName := map[string]FieldShape{}
+	for _, f := range request.Fields {
+		byName[f.Name] = f
+	}
+
+	// queryParam name= extraction, the default: tag, and pointer optionality.
+	pageSize := byName["PageSize"]
+	if pageSize.Wire != "page[size]" || pageSize.Default != "20" || !pageSize.Optional || pageSize.Type != "*int64" {
+		t.Errorf("PageSize = %+v", pageSize)
+	}
+	if f := byName["FilterName"]; f.Wire != "filter[name]" {
+		t.Errorf("FilterName wire = %q", f.Wire)
+	}
+
+	// json tags: a value field without omitempty is required.
+	body := widgets.Models["operations.CreateWidgetWidgetsRequestBody"]
+	for _, f := range body.Fields {
+		if f.Name == "Name" && (f.Optional || f.Wire != "name" || f.Type != "string") {
+			t.Errorf("Name = %+v", f)
+		}
+	}
+
+	// Enums record sorted wire values.
+	if enum := widgets.Models["operations.WidgetColor"].Enum; !reflect.DeepEqual(enum, []string{"blue", "red"}) {
+		t.Errorf("WidgetColor enum = %v", enum)
+	}
+
+	// The self-referencing Parent field proves the cycle guard; its presence
+	// proves untagged recursion into same-package types.
+	data := widgets.Models["components.WidgetData"]
+	var sawParent bool
+	for _, f := range data.Fields {
+		if f.Name == "Parent" {
+			sawParent = true
+		}
+		if f.Name == "Status" && f.Optional {
+			t.Errorf("Status should be required in v1: %+v", f)
+		}
+	}
+	if !sawParent {
+		t.Error("WidgetData.Parent not recorded")
+	}
+
+	// The pagination helper is not a wire field.
+	response := widgets.Models["operations.ListWidgetsResponse"]
+	for _, f := range response.Fields {
+		if f.Name == "Next" {
+			t.Error("func-typed Next must be filtered")
+		}
+		if f.Name == "HTTPMeta" {
+			t.Error("json:\"-\" HTTPMeta must be filtered")
+		}
+	}
+
+	// Embedded fields are recorded under their promoted name and their model is
+	// walked — an embedding the parser skipped would be a permanent blind spot.
+	list := widgets.Models["components.WidgetList"]
+	var sawEmbedded bool
+	for _, f := range list.Fields {
+		if f.Name == "Pagination" && f.Type == "Pagination" {
+			sawEmbedded = true
+		}
+	}
+	if !sawEmbedded {
+		t.Error("embedded Pagination not recorded on WidgetList")
+	}
+}
+
+func TestParseFieldSurfaceDeterministic(t *testing.T) {
+	a := parseFieldFixture(t, fieldSDKv1)
+	b := parseFieldFixture(t, fieldSDKv1)
+	if !reflect.DeepEqual(a, b) {
+		t.Error("two parses of the same tree differ")
+	}
+}
+
+// TestParseFieldSurfacePinnedSDK is the smoke test against the real SDK: the
+// walk must terminate and produce models for a real covered group, whatever
+// shape the pinned release has.
+func TestParseFieldSurfacePinnedSDK(t *testing.T) {
+	dir, err := PinnedModuleDir(SDKModulePath)
+	if err != nil {
+		t.Skipf("pinned SDK unavailable: %v", err)
+	}
+
+	surface, err := ParseSurface(dir)
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+	fields, err := ParseFieldSurface(dir, surface, []string{"Servers"})
+	if err != nil {
+		t.Fatalf("ParseFieldSurface: %v", err)
+	}
+
+	servers := fields.Groups["Servers"]
+	if len(servers.Methods) == 0 || len(servers.Models) == 0 {
+		t.Fatalf("Servers parsed empty: %d methods, %d models", len(servers.Methods), len(servers.Models))
+	}
+}

--- a/internal/sdkcoverage/naming.go
+++ b/internal/sdkcoverage/naming.go
@@ -35,6 +35,35 @@ func SuggestTypeName(groupName, providerTypeName string) string {
 	return providerTypeName + "_" + snake
 }
 
+// SuggestAttributeName proposes the Terraform attribute name a reviewer would
+// expect for an SDK model field. Advisory only, like SuggestTypeName: the real
+// mapping is many-to-many (Region.Site.Slug feeds both site and region), so
+// the suggestion seeds the drift report, never a check.
+//
+// The wire name is authoritative when there is one — Speakeasy already emits
+// snake_case json names, which is exactly Terraform's convention. Bracketed
+// query-parameter names flatten (filter[ram][eql] -> ram_eql), except the
+// pagination and metadata families, which are provider-internal and suggest
+// nothing. Untagged fields fall back to the Go name via splitWords.
+func SuggestAttributeName(f FieldShape) string {
+	wire := f.Wire
+	switch {
+	case wire == "":
+		words := splitWords(f.Name)
+		for i, w := range words {
+			words[i] = strings.ToLower(w)
+		}
+		return strings.Join(words, "_")
+	case strings.HasPrefix(wire, "page[") || strings.HasPrefix(wire, "stats[") || strings.HasPrefix(wire, "extra_fields["):
+		return ""
+	case strings.HasPrefix(wire, "filter[") && strings.HasSuffix(wire, "]"):
+		inner := wire[len("filter[") : len(wire)-1]
+		return strings.ReplaceAll(inner, "][", "_")
+	default:
+		return wire
+	}
+}
+
 // splitWords breaks a CamelCase/PascalCase identifier into words, keeping runs of
 // uppercase letters together as a single acronym: "APIKeys" -> ["API", "Keys"],
 // "IPAddresses" -> ["IP", "Addresses"], "VpnSessions" -> ["Vpn", "Sessions"].

--- a/internal/sdkcoverage/naming_test.go
+++ b/internal/sdkcoverage/naming_test.go
@@ -63,3 +63,28 @@ func TestSuggestTypeNameHonorsProviderPrefix(t *testing.T) {
 		t.Errorf("SuggestTypeName with custom prefix = %q, want example_server", got)
 	}
 }
+
+func TestSuggestAttributeName(t *testing.T) {
+	cases := []struct {
+		field FieldShape
+		want  string
+	}{
+		// json wire names are already Terraform-shaped.
+		{FieldShape{Name: "BgpReady", Wire: "bgp_ready"}, "bgp_ready"},
+		// filter[] query parameters flatten, including nested brackets.
+		{FieldShape{Name: "FilterProject", Wire: "filter[project]"}, "project"},
+		{FieldShape{Name: "FilterRAMEql", Wire: "filter[ram][eql]"}, "ram_eql"},
+		// Pagination and metadata families are provider-internal: no suggestion.
+		{FieldShape{Name: "PageSize", Wire: "page[size]"}, ""},
+		{FieldShape{Name: "StatsTotal", Wire: "stats[total]"}, ""},
+		{FieldShape{Name: "ExtraFieldsServers", Wire: "extra_fields[servers]"}, ""},
+		// Untagged fields fall back to the Go name.
+		{FieldShape{Name: "Widget"}, "widget"},
+		{FieldShape{Name: "BgpReady"}, "bgp_ready"},
+	}
+	for _, tc := range cases {
+		if got := SuggestAttributeName(tc.field); got != tc.want {
+			t.Errorf("SuggestAttributeName(%q/%q) = %q, want %q", tc.field.Name, tc.field.Wire, got, tc.want)
+		}
+	}
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v1/latitudesh.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v1/latitudesh.go
@@ -1,0 +1,48 @@
+// Package fieldsdk is a frozen mini-SDK for exercising the field-level parser.
+// It is parsed, never compiled, so unresolved identifiers are fine. Its sibling
+// v2 differs by exactly one instance of each drift kind — the pair is the
+// fixture for drift_test.go, so a change here ripples there.
+package fieldsdk
+
+type Latitudesh struct {
+	Widgets *Widgets
+	Gadgets *Gadgets
+
+	SDKVersion string
+}
+
+type Widgets struct{}
+
+// List returns every widget.
+func (s *Widgets) List(ctx context.Context, request operations.ListWidgetsRequest, opts ...operations.Option) (*operations.ListWidgetsResponse, error) {
+	return nil, nil
+}
+
+// Create makes a widget.
+func (s *Widgets) Create(ctx context.Context, request operations.CreateWidgetWidgetsRequestBody, opts ...operations.Option) (*operations.CreateWidgetResponse, error) {
+	return nil, nil
+}
+
+// Get fetches one widget.
+func (s *Widgets) Get(ctx context.Context, widgetID string, opts ...operations.Option) (*operations.GetWidgetResponse, error) {
+	return nil, nil
+}
+
+// Delete removes a widget.
+func (s *Widgets) Delete(ctx context.Context, widgetID string, opts ...operations.Option) (*operations.DeleteWidgetResponse, error) {
+	return nil, nil
+}
+
+// Legacy is an old endpoint.
+func (s *Widgets) Legacy(ctx context.Context, opts ...operations.Option) (*operations.LegacyWidgetResponse, error) {
+	return nil, nil
+}
+
+// Gadgets exists to prove the walk is covered-groups-only: v2 mutates its
+// models too, and none of that may drift.
+type Gadgets struct{}
+
+// Get fetches one gadget.
+func (s *Gadgets) Get(ctx context.Context, gadgetID string, opts ...operations.Option) (*operations.GetGadgetResponse, error) {
+	return nil, nil
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v1/models/components/widget.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v1/models/components/widget.go
@@ -1,0 +1,38 @@
+package components
+
+type Widget struct {
+	Data *WidgetData `json:"data,omitempty"`
+}
+
+type WidgetData struct {
+	ID *string `json:"id,omitempty"`
+	// Weight in grams.
+	Weight *int64 `json:"weight,omitempty"`
+	// The label shown in the dashboard.
+	Label  *string `json:"label,omitempty"`
+	Status string  `json:"status"`
+	// Parent is a self-reference: the walk's cycle guard is what keeps this from
+	// recursing forever.
+	Parent *WidgetData `json:"parent,omitempty"`
+}
+
+// Pagination is embedded into WidgetList: the walk must record embedded fields
+// under their promoted name and follow their type, or a change here would be
+// invisible.
+type Pagination struct {
+	Page *int64 `json:"page,omitempty"`
+}
+
+type WidgetList struct {
+	Pagination
+	Data []WidgetData `json:"data,omitempty"`
+}
+
+type Gadget struct {
+	ID   *string `json:"id,omitempty"`
+	Knob *string `json:"knob,omitempty"`
+}
+
+type HTTPMetadata struct {
+	Response *http.Response `json:"-"`
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v1/models/operations/gadgets.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v1/models/operations/gadgets.go
@@ -1,0 +1,7 @@
+package operations
+
+type GetGadgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Gadget *components.Gadget
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v1/models/operations/widgets.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v1/models/operations/widgets.go
@@ -1,0 +1,50 @@
+package operations
+
+type WidgetColor string
+
+const (
+	WidgetColorRed  WidgetColor = "red"
+	WidgetColorBlue WidgetColor = "blue"
+)
+
+type ListWidgetsRequest struct {
+	// The widget name to filter by
+	FilterName *string `queryParam:"style=form,explode=true,name=filter[name]"`
+	// Number of items to return per page
+	PageSize *int64 `default:"20" queryParam:"style=form,explode=true,name=page[size]"`
+}
+
+type ListWidgetsResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	WidgetList *components.WidgetList
+	Next       func() (*ListWidgetsResponse, error)
+}
+
+type CreateWidgetWidgetsRequestBody struct {
+	Name  string       `json:"name"`
+	Color *WidgetColor `json:"color,omitempty"`
+	Size  *string      `json:"size,omitempty"`
+}
+
+type CreateWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// Created
+	Widget *components.Widget
+}
+
+type GetWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Widget *components.Widget
+}
+
+type DeleteWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+}
+
+type LegacyWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Widget *components.Widget
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v2/latitudesh.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v2/latitudesh.go
@@ -1,0 +1,64 @@
+// Package fieldsdk (v2) is v1 after one instance of each drift kind:
+//
+//	method_removed            Widgets.Delete is gone
+//	method_signature_changed  Widgets.List gained a filterTag parameter
+//	method_added              Widgets.Update is new
+//	deprecated                Widgets.Legacy gained a Deprecated: marker
+//	enum_value_removed/added  WidgetColor renamed "blue" to "green"
+//	default_changed           ListWidgetsRequest.PageSize default 20 -> 50
+//	field_removed             CreateWidgetWidgetsRequestBody.Size is gone
+//	field_added               WidgetData gained bgp_ready and badge
+//	model_added               components.Badge and operations.UpdateWidgetResponse are new
+//	model_removed             operations.DeleteWidgetResponse is gone
+//	field_type_changed        WidgetData.Weight *int64 -> *string
+//	field_required_changed    WidgetData.Status string -> *string omitempty
+//	doc_changed               WidgetData.Label's doc comment changed
+//
+// Gadgets mutates too (Gadget.Knob is gone), and being uncovered must produce
+// no drift at all.
+package fieldsdk
+
+type Latitudesh struct {
+	Widgets *Widgets
+	Gadgets *Gadgets
+
+	SDKVersion string
+}
+
+type Widgets struct{}
+
+// List returns every widget.
+func (s *Widgets) List(ctx context.Context, request operations.ListWidgetsRequest, filterTag *string, opts ...operations.Option) (*operations.ListWidgetsResponse, error) {
+	return nil, nil
+}
+
+// Create makes a widget.
+func (s *Widgets) Create(ctx context.Context, request operations.CreateWidgetWidgetsRequestBody, opts ...operations.Option) (*operations.CreateWidgetResponse, error) {
+	return nil, nil
+}
+
+// Get fetches one widget.
+func (s *Widgets) Get(ctx context.Context, widgetID string, opts ...operations.Option) (*operations.GetWidgetResponse, error) {
+	return nil, nil
+}
+
+// Update changes a widget.
+func (s *Widgets) Update(ctx context.Context, widgetID string, requestBody operations.CreateWidgetWidgetsRequestBody, opts ...operations.Option) (*operations.UpdateWidgetResponse, error) {
+	return nil, nil
+}
+
+// Legacy is an old endpoint.
+//
+// Deprecated: use List instead.
+func (s *Widgets) Legacy(ctx context.Context, opts ...operations.Option) (*operations.LegacyWidgetResponse, error) {
+	return nil, nil
+}
+
+// Gadgets exists to prove the walk is covered-groups-only: its models mutated
+// here in v2, and none of that may drift.
+type Gadgets struct{}
+
+// Get fetches one gadget.
+func (s *Gadgets) Get(ctx context.Context, gadgetID string, opts ...operations.Option) (*operations.GetGadgetResponse, error) {
+	return nil, nil
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v2/models/components/widget.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v2/models/components/widget.go
@@ -1,0 +1,46 @@
+package components
+
+type Widget struct {
+	Data *WidgetData `json:"data,omitempty"`
+}
+
+type WidgetData struct {
+	ID *string `json:"id,omitempty"`
+	// Weight in grams.
+	Weight *string `json:"weight,omitempty"`
+	// The label shown on the invoice.
+	Label  *string `json:"label,omitempty"`
+	Status *string `json:"status,omitempty"`
+	// Parent is a self-reference: the walk's cycle guard is what keeps this from
+	// recursing forever.
+	Parent   *WidgetData `json:"parent,omitempty"`
+	BgpReady *bool       `json:"bgp_ready,omitempty"`
+	Badge    *Badge      `json:"badge,omitempty"`
+}
+
+// Badge is a whole new model: it must surface as one model_added row, never as
+// a per-field cascade of its own fields.
+type Badge struct {
+	Kind  *string `json:"kind,omitempty"`
+	Score *int64  `json:"score,omitempty"`
+}
+
+// Pagination is embedded into WidgetList: the walk must record embedded fields
+// under their promoted name and follow their type, or a change here would be
+// invisible.
+type Pagination struct {
+	Page *int64 `json:"page,omitempty"`
+}
+
+type WidgetList struct {
+	Pagination
+	Data []WidgetData `json:"data,omitempty"`
+}
+
+type Gadget struct {
+	ID *string `json:"id,omitempty"`
+}
+
+type HTTPMetadata struct {
+	Response *http.Response `json:"-"`
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v2/models/operations/gadgets.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v2/models/operations/gadgets.go
@@ -1,0 +1,7 @@
+package operations
+
+type GetGadgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Gadget *components.Gadget
+}

--- a/internal/sdkcoverage/testdata/fieldsdk/v2/models/operations/widgets.go
+++ b/internal/sdkcoverage/testdata/fieldsdk/v2/models/operations/widgets.go
@@ -1,0 +1,51 @@
+package operations
+
+type WidgetColor string
+
+const (
+	WidgetColorRed   WidgetColor = "red"
+	WidgetColorGreen WidgetColor = "green"
+)
+
+type ListWidgetsRequest struct {
+	// The widget name to filter by
+	FilterName *string `queryParam:"style=form,explode=true,name=filter[name]"`
+	// Number of items to return per page
+	PageSize *int64 `default:"50" queryParam:"style=form,explode=true,name=page[size]"`
+}
+
+type ListWidgetsResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	WidgetList *components.WidgetList
+	Next       func() (*ListWidgetsResponse, error)
+}
+
+type CreateWidgetWidgetsRequestBody struct {
+	Name  string       `json:"name"`
+	Color *WidgetColor `json:"color,omitempty"`
+}
+
+type CreateWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// Created
+	Widget *components.Widget
+}
+
+type GetWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Widget *components.Widget
+}
+
+type UpdateWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Widget *components.Widget
+}
+
+type LegacyWidgetResponse struct {
+	HTTPMeta components.HTTPMetadata `json:"-"`
+	// OK
+	Widget *components.Widget
+}

--- a/latitudesh/sdk_coverage_test.go
+++ b/latitudesh/sdk_coverage_test.go
@@ -23,9 +23,10 @@ import (
 // would block every bump on a product decision its author was never asked to make.
 // Those groups surface in the report instead (`make coverage-report`).
 //
-// It is also blind to changes *within* an already-covered group: only group and
-// method names are parsed, never model fields or signatures. A new field on an
-// existing resource is invisible here.
+// Changes *within* an already-covered group — model fields, types, enums,
+// method signatures — are deliberately not this test's job: only group and
+// method names are parsed here. That is TestProviderSDKFieldDrift's beat,
+// against sdk-fields.lock.yaml.
 func TestProviderSDKCoverage(t *testing.T) {
 	sdkDir, err := sdkcoverage.PinnedModuleDir(sdkcoverage.SDKModulePath)
 	if err != nil {

--- a/latitudesh/sdk_field_drift_test.go
+++ b/latitudesh/sdk_field_drift_test.go
@@ -1,0 +1,79 @@
+package latitudesh
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/latitudesh/terraform-provider-latitudesh/v2/internal/sdkcoverage"
+)
+
+// TestProviderSDKFieldDrift keeps sdk-fields.lock.yaml honest about the shape
+// of the covered groups' models: the fields, types, tags, enums, and method
+// signatures the provider's mappings were written against.
+//
+// Like TestProviderSDKCoverage it is a static check — no network, no API
+// token, no TF_ACC — and like it, it fails only on contradictions: BREAKING
+// drift between the pinned SDK and the committed lock (a field removed or
+// retyped, a required flip, an enum value gone, a method removed or its
+// signature changed). Those are shapes the provider still compiles in, so
+// absorbing them silently in an SDK bump risks a runtime break.
+//
+// Additive drift — a new field, a new enum value, a deprecation, a changed
+// default or doc — is logged, never a failure: new capability on a covered
+// group is the drift-fix pipeline's queue (see .github/workflows/sdk-watch.yml),
+// exactly as an uncovered group is the scaffold pipeline's.
+//
+// The fix for a breaking failure is to adjust the mapping in the named
+// Terraform types (or deliberately omit the change) and regenerate the lock in
+// the same PR: `make fields-sync`. The lock's git diff is the review record of
+// what was accepted.
+func TestProviderSDKFieldDrift(t *testing.T) {
+	lockPath := filepath.Join("..", sdkcoverage.FieldLockFile)
+	lock, err := sdkcoverage.LoadFieldLock(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("%s not present — field drift is not tracked; seed it with `make fields-sync`", sdkcoverage.FieldLockFile)
+	}
+	if err != nil {
+		t.Fatalf("loading %s: %v", lockPath, err)
+	}
+
+	sdkDir, err := sdkcoverage.PinnedModuleDir(sdkcoverage.SDKModulePath)
+	if err != nil {
+		t.Fatalf("resolving the pinned SDK module: %v", err)
+	}
+	surface, err := sdkcoverage.ParseSurface(sdkDir)
+	if err != nil {
+		t.Fatalf("parsing the SDK surface at %s: %v", sdkDir, err)
+	}
+	manifest, err := sdkcoverage.LoadManifest(filepath.Join("..", sdkcoverage.ManifestFile))
+	if err != nil {
+		t.Fatalf("loading the coverage manifest: %v", err)
+	}
+
+	// Covered groups the SDK still exposes; a covered group the SDK lost is
+	// TestProviderSDKCoverage's finding, not a field-parse error here.
+	var covered []string
+	for name, entry := range manifest.Groups {
+		if _, ok := surface.Groups[name]; ok && entry.Covered() {
+			covered = append(covered, name)
+		}
+	}
+	sort.Strings(covered)
+
+	fields, err := sdkcoverage.ParseFieldSurface(sdkDir, surface, covered)
+	if err != nil {
+		t.Fatalf("parsing the SDK field surface: %v", err)
+	}
+
+	for _, d := range sdkcoverage.DiffFieldSurfaces(lock.Surface(), fields, manifest) {
+		if d.Breaking() {
+			t.Errorf("breaking field drift: %s — fix the mapping in %v (or deliberately omit it), then run `make fields-sync` and let the lock diff be reviewed",
+				d, d.ImplementedBy)
+		} else {
+			t.Logf("field drift (informational): %s", d)
+		}
+	}
+}

--- a/scripts/render-scaffold-prompt.sh
+++ b/scripts/render-scaffold-prompt.sh
@@ -7,10 +7,11 @@
 # what production runs.
 #
 # Inputs come through the environment (GROUP, KINDS, TF_NAME, METHODS, NOTES,
-# SDK_VERSION), never argv: values are free text from the coverage report and
-# argv would invite quoting bugs. The splice uses index/substr rather than gsub:
-# a gsub replacement string treats '&' and '\' specially, so a note containing
-# either would silently corrupt the rendered prompt.
+# SDK_VERSION, and for the drift template DRIFT_JSON, IMPLEMENTED_BY), never
+# argv: values are free text from the coverage report and argv would invite
+# quoting bugs. The splice uses index/substr rather than gsub: a gsub
+# replacement string treats '&' and '\' specially, so a note containing either
+# would silently corrupt the rendered prompt.
 #
 # Usage:
 #   GROUP=... KINDS=... TF_NAME=... METHODS=... NOTES=... SDK_VERSION=... \
@@ -20,9 +21,12 @@ set -euo pipefail
 TEMPLATE="${1:-.github/prompts/scaffold-resource.md}"
 [ -f "$TEMPLATE" ] || { echo "render-scaffold-prompt.sh: no such template: $TEMPLATE" >&2; exit 2; }
 
-for v in GROUP KINDS TF_NAME METHODS NOTES SDK_VERSION MAX_TURNS; do
-	if [ -z "${!v:-}" ]; then
-		echo "render-scaffold-prompt.sh: $v must be set (and non-empty) in the environment" >&2
+# Require exactly the variables the template references, so the one renderer
+# serves both prompt templates without dummy values for the other's tokens —
+# and a template gaining a token cannot silently render it empty.
+for v in GROUP KINDS TF_NAME METHODS NOTES SDK_VERSION MAX_TURNS DRIFT_JSON IMPLEMENTED_BY; do
+	if grep -q "{{$v}}" "$TEMPLATE" && [ -z "${!v:-}" ]; then
+		echo "render-scaffold-prompt.sh: $v must be set (and non-empty) in the environment — $TEMPLATE references {{$v}}" >&2
 		exit 2
 	fi
 done
@@ -45,5 +49,7 @@ awk '
 		line = subst(line, "{{NOTES}}", ENVIRON["NOTES"])
 		line = subst(line, "{{SDK_VERSION}}", ENVIRON["SDK_VERSION"])
 		line = subst(line, "{{MAX_TURNS}}", ENVIRON["MAX_TURNS"])
+		line = subst(line, "{{DRIFT_JSON}}", ENVIRON["DRIFT_JSON"])
+		line = subst(line, "{{IMPLEMENTED_BY}}", ENVIRON["IMPLEMENTED_BY"])
 		print line
 	}' "$TEMPLATE"

--- a/scripts/scaffold-validate.sh
+++ b/scripts/scaffold-validate.sh
@@ -15,14 +15,24 @@
 #
 # Usage:
 #   scripts/scaffold-validate.sh --group <SDKGroup> --type-name <latitudesh_x> --kinds <resource,datasource> [--base <ref>]
+#   scripts/scaffold-validate.sh --mode drift --group <SDKGroup>[,<SDKGroup>...] [--base <ref>]
 #
-#   --group       the SDK service group that was scaffolded (e.g. PublicNetworks)
+#   --group       the SDK service group that was scaffolded (e.g. PublicNetworks).
+#                 In drift mode this may be a comma-separated list: a drift PR
+#                 that bumps the SDK must resolve EVERY breaking-drifted group in
+#                 one change, or the gate (which checks the whole surface) could
+#                 never go green for any of them.
 #   --type-name   the Terraform type name that was added (e.g. latitudesh_public_network)
 #   --kinds       comma-separated kinds that were REQUESTED (resource, datasource,
 #                 action). Required: coverage alone cannot express this — one
 #                 implemented kind marks the whole group covered, so a datasource
 #                 the shape asked for would otherwise go silently undelivered,
 #                 and the group never returns to the pending queue to flag it.
+#   --mode        scaffold (default) gates a NEW type; drift gates a change that
+#                 reconciles an EXISTING covered group with SDK field drift. In
+#                 drift mode --type-name/--kinds do not apply: success is "zero
+#                 remaining drift for the group, lock synced, own tests present",
+#                 not "a new type was delivered".
 #   --base        git ref the change is measured against (default: HEAD)
 #
 set -euo pipefail
@@ -30,11 +40,12 @@ set -euo pipefail
 GROUP=""
 TYPE_NAME=""
 KINDS=""
+MODE="scaffold"
 BASE="HEAD"
 
 while [ $# -gt 0 ]; do
 	case "$1" in
-	--group | --type-name | --kinds | --base)
+	--group | --type-name | --kinds | --mode | --base)
 		# Explicit check: under set -e a bare `shift 2` with no value would kill
 		# the script silently, with no message and a misleading exit code.
 		if [ $# -lt 2 ]; then
@@ -45,6 +56,7 @@ while [ $# -gt 0 ]; do
 		--group) GROUP="$2" ;;
 		--type-name) TYPE_NAME="$2" ;;
 		--kinds) KINDS="$2" ;;
+		--mode) MODE="$2" ;;
 		--base) BASE="$2" ;;
 		esac
 		shift 2
@@ -56,26 +68,46 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
-if [ -z "$GROUP" ] || [ -z "$TYPE_NAME" ] || [ -z "$KINDS" ]; then
-	echo "usage: $0 --group <SDKGroup> --type-name <latitudesh_x> --kinds <resource,datasource> [--base <ref>]" >&2
+case "$MODE" in
+scaffold)
+	if [ -z "$GROUP" ] || [ -z "$TYPE_NAME" ] || [ -z "$KINDS" ]; then
+		echo "usage: $0 --group <SDKGroup> --type-name <latitudesh_x> --kinds <resource,datasource> [--base <ref>]" >&2
+		exit 2
+	fi
+	;;
+drift)
+	if [ -z "$GROUP" ]; then
+		echo "usage: $0 --mode drift --group <SDKGroup> [--base <ref>]" >&2
+		exit 2
+	fi
+	if [ -n "$TYPE_NAME" ] || [ -n "$KINDS" ]; then
+		echo "--type-name/--kinds do not apply in drift mode" >&2
+		exit 2
+	fi
+	;;
+*)
+	echo "unknown mode $MODE (want scaffold or drift)" >&2
 	exit 2
-fi
+	;;
+esac
 
 # Normalize the kinds list ("resource, datasource" and "resource,datasource"
 # both arrive here — the report joins with a comma and a space).
 kinds=()
-for kind in $(printf '%s' "$KINDS" | tr ',' ' '); do
-	case "$kind" in
-	resource | datasource | action) kinds+=("$kind") ;;
-	*)
-		echo "unknown kind $kind (want resource, datasource, or action)" >&2
+if [ "$MODE" = "scaffold" ]; then
+	for kind in $(printf '%s' "$KINDS" | tr ',' ' '); do
+		case "$kind" in
+		resource | datasource | action) kinds+=("$kind") ;;
+		*)
+			echo "unknown kind $kind (want resource, datasource, or action)" >&2
+			exit 2
+			;;
+		esac
+	done
+	if [ "${#kinds[@]}" -eq 0 ]; then
+		echo "--kinds lists no kinds" >&2
 		exit 2
-		;;
-	esac
-done
-if [ "${#kinds[@]}" -eq 0 ]; then
-	echo "--kinds lists no kinds" >&2
-	exit 2
+	fi
 fi
 
 ROOT=$(git rev-parse --show-toplevel)
@@ -132,7 +164,7 @@ for p in "${paths[@]}"; do
 		: ;;
 	latitudesh/provider.go)
 		: ;;
-	sdk-coverage.yaml)
+	sdk-coverage.yaml | sdk-fields.lock.yaml)
 		: ;;
 	# The first pattern of each pair already admits the subdirectories ('*'
 	# spans '/'), but the explicit variants spell the intent out — reviewers
@@ -203,12 +235,36 @@ echo "ok: unit tests pass"
 # covered). A group still pending means the resource was written but never
 # registered or never recorded in sdk-coverage.yaml.
 step "7/9 coverage reconciles"
+# check covers both ledgers: group-level contradictions AND breaking field
+# drift against sdk-fields.lock.yaml.
 go run ./cmd/sdkcoverage check || fail "sdkcoverage check found contradictions"
-report=$(go run ./cmd/sdkcoverage report -format json)
-if ! echo "$report" | jq -e --arg g "$GROUP" '.pending | map(.group) | index($g) | not' >/dev/null; then
-	fail "group $GROUP is still pending — the resource is not registered or not recorded in sdk-coverage.yaml"
+if [ "$MODE" = "scaffold" ]; then
+	report=$(go run ./cmd/sdkcoverage report -format json)
+	if ! echo "$report" | jq -e --arg g "$GROUP" '.pending | map(.group) | index($g) | not' >/dev/null; then
+		fail "group $GROUP is still pending — the resource is not registered or not recorded in sdk-coverage.yaml"
+	fi
+	echo "ok: coverage reconciles and $GROUP is covered"
+else
+	# The lock must still exist and actually load: deleting it would make every
+	# drift check downstream an inert no-op that reads as success.
+	[ -f sdk-fields.lock.yaml ] || fail "sdk-fields.lock.yaml is gone — a drift change regenerates the lock, never deletes it"
+
+	# Drift mode's success criterion: the target groups no longer drift AT ALL —
+	# every row was either mapped or accepted into the lock. A leftover
+	# informational row would pass `check` (breaking-only) while leaving the
+	# tracking issue reporting the very drift this PR claims to close.
+	drift=$(go run ./cmd/sdkcoverage drift -format json)
+	if [ "$(echo "$drift" | jq -r '.lock_missing')" = "true" ]; then
+		fail "the drift report cannot see the lock — sdk-fields.lock.yaml is missing or unreadable"
+	fi
+	groups_json=$(printf '%s' "$GROUP" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+	remaining=$(echo "$drift" | jq --argjson gs "$groups_json" '[.drift[] | select(.group as $g | $gs | index($g))] | length')
+	if [ "$remaining" -ne 0 ]; then
+		echo "$drift" | jq -r --argjson gs "$groups_json" '.drift[] | select(.group as $g | $gs | index($g)) | "  - [\(.kind)] \(.group) \(.model) \(.field): \(.detail)"' >&2
+		fail "target group(s) still have $remaining drift row(s) — map each one or accept it via 'go run ./cmd/sdkcoverage fields -write -group $GROUP'"
+	fi
+	echo "ok: coverage reconciles and $GROUP has zero remaining drift"
 fi
-echo "ok: coverage reconciles and $GROUP is covered"
 
 # ------------------------------------------------------------ 8. docs reproduce --
 # docs/ is generated from templates/ plus the schema. A hand-edit to docs/ is
@@ -229,6 +285,71 @@ fi
 echo "ok: docs regenerate with no drift"
 
 # -------------------------------------------------- 9. deliverables per kind --
+# Drift mode first: its deliverables are different in kind, not in degree. The
+# lock must be part of the change (regenerating it IS the act of acceptance the
+# whole pipeline hinges on), and a mapping change must bring its own offline
+# test — but there is no new type, so nothing below about registration,
+# templates, or examples applies.
+if [ "$MODE" = "drift" ]; then
+	step "9/9 drift deliverables"
+
+	lock_changed=false
+	code_changed=false
+	test_files=()
+	for p in "${paths[@]}"; do
+		case "$p" in
+		sdk-fields.lock.yaml) lock_changed=true ;;
+		latitudesh/*_test.go) [ -f "$p" ] && test_files+=("$p") ;;
+		latitudesh/*.go) code_changed=true ;;
+		esac
+	done
+
+	if [ "$lock_changed" != "true" ]; then
+		fail "sdk-fields.lock.yaml did not change — a drift PR must accept the drift it closes (go run ./cmd/sdkcoverage fields -write -group $GROUP)"
+	fi
+
+	# The lock diff must be scoped to the target groups: a full regenerate here
+	# would silently accept every OTHER group's drift inside a PR reviewed for
+	# these. Reconstruct the only acceptable lock — BASE's lock with exactly the
+	# target groups resynced — and require byte equality.
+	base_lock=$(mktemp)
+	expected_lock=$(mktemp)
+	if ! git show "$BASE:sdk-fields.lock.yaml" > "$base_lock" 2>/dev/null; then
+		rm -f "$base_lock" "$expected_lock"
+		fail "drift mode needs sdk-fields.lock.yaml to exist at $BASE — seeding the lock is a full 'fields -write', not a drift PR"
+	fi
+	if ! go run ./cmd/sdkcoverage fields -lock "$base_lock" -group "$GROUP" > "$expected_lock"; then
+		rm -f "$base_lock" "$expected_lock"
+		fail "could not compute the expected lock for $GROUP"
+	fi
+	if ! cmp -s "$expected_lock" sdk-fields.lock.yaml; then
+		diff "$expected_lock" sdk-fields.lock.yaml | head -20 >&2
+		rm -f "$base_lock" "$expected_lock"
+		fail "sdk-fields.lock.yaml changed outside the target group(s) $GROUP — regenerate it with 'go run ./cmd/sdkcoverage fields -write -group $GROUP' only"
+	fi
+	rm -f "$base_lock" "$expected_lock"
+
+	if [ "$code_changed" = "true" ]; then
+		if [ "${#test_files[@]}" -eq 0 ]; then
+			fail "the mapping changed but no latitudesh/*_test.go did — a schema or mapping change must bring its own test"
+		fi
+		has_offline=false
+		for f in "${test_files[@]}"; do
+			total=$(grep -cE '^func Test' "$f" || true)
+			acc=$(grep -cE '^func TestAcc' "$f" || true)
+			if [ "${total:-0}" -gt "${acc:-0}" ]; then
+				has_offline=true
+			fi
+		done
+		[ "$has_offline" = "true" ] || fail "no offline (non-TestAcc) test in the changed test files — nothing about the mapping change runs on ordinary PRs"
+	fi
+
+	echo "ok: lock accepted the drift$([ "$code_changed" = "true" ] && echo ", mapping change ships its own offline test")"
+	echo
+	echo "PASS: $GROUP — field drift reconciles"
+	exit 0
+fi
+
 # Coverage (step 7) only proves SOME implementation claimed the group. This step
 # holds the scaffold to what was actually requested: every asked-for kind is
 # actually registered and ships its Go file and doc template, an example exists,

--- a/sdk-fields.lock.yaml
+++ b/sdk-fields.lock.yaml
@@ -1,0 +1,2584 @@
+# Field-level shape of the covered latitudesh-go-sdk service groups, as last
+# acknowledged. Regenerate with `make fields-sync` (or `go run ./cmd/sdkcoverage
+# fields -write`) in the PR that maps — or deliberately omits — the change;
+# this file's git diff is the record of what that PR accepted.
+# See CONTRIBUTING.md, "Field drift".
+version: 1
+sdk_module: github.com/latitudesh/latitudesh-go-sdk
+sdk_version: v1.19.12
+groups:
+  ElasticIps:
+    methods:
+      CreateElasticIP: {signature: "(context.Context, components.CreateElasticIP, ...operations.Option) (*operations.CreateElasticIPResponse, error)"}
+      CreateElasticIPBgpSession: {signature: "(context.Context, string, components.CreateBgpSession, ...operations.Option) (*operations.CreateElasticIPBgpSessionResponse, error)"}
+      DeleteElasticIP: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteElasticIPResponse, error)"}
+      DeleteElasticIPBgpSession: {signature: "(context.Context, string, string, *bool, ...operations.Option) (*operations.DeleteElasticIPBgpSessionResponse, error)"}
+      GetElasticIP: {signature: "(context.Context, string, ...operations.Option) (*operations.GetElasticIPResponse, error)"}
+      GetElasticIPBgpSession: {signature: "(context.Context, string, string, ...operations.Option) (*operations.GetElasticIPBgpSessionResponse, error)"}
+      ListElasticIPBgpSessions: {signature: "(context.Context, string, ...operations.Option) (*operations.ListElasticIPBgpSessionsResponse, error)"}
+      ListElasticIps: {signature: "(context.Context, operations.ListElasticIpsRequest, ...operations.Option) (*operations.ListElasticIpsResponse, error)"}
+      UpdateElasticIP: {signature: "(context.Context, string, components.UpdateElasticIP, ...operations.Option) (*operations.UpdateElasticIPResponse, error)"}
+    models:
+      components.BgpSession:
+        fields:
+          - {name: "Data", wire: "data", type: "*BgpSessionData", optional: true}
+      components.BgpSessionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*BgpSessionDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*BgpSessionDataType", optional: true}
+      components.BgpSessionDataAttributes:
+        fields:
+          - {name: "Asn", wire: "asn", type: "*int64", optional: true}
+          - {name: "CreatedAt", wire: "created_at", type: "*time.Time", optional: true}
+          - {name: "Region", wire: "region", type: "*BgpSessionDataRegion", optional: true, doc: "21a2d42b"}
+          - {name: "Server", wire: "server", type: "*BgpSessionDataServer", optional: true, doc: "56545f09"}
+          - {name: "ServerIP", wire: "server_ip", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*BgpSessionDataStatus", optional: true}
+          - {name: "StatusMessage", wire: "status_message", type: "*string", optional: true, doc: "99520b2f"}
+      components.BgpSessionDataLocation:
+        doc: "d2730c26"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "2c1c4e48"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "558a9d7e"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "06ebf066"}
+      components.BgpSessionDataRegion:
+        doc: "9759e85d"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "7ed16c35"}
+          - {name: "Location", wire: "location", type: "*BgpSessionDataLocation", optional: true, doc: "35ff6857"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "d1a29dab"}
+      components.BgpSessionDataServer:
+        doc: "92ac1bb6"
+        fields:
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*string", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+      components.BgpSessionDataStatus:
+        enum: ["active", "configuring", "error", "pending", "removing"]
+      components.BgpSessionDataType:
+        enum: ["bgp_sessions"]
+      components.BgpSessions:
+        fields:
+          - {name: "Data", wire: "data", type: "[]BgpSessionData", optional: true}
+      components.CreateBgpSession:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateBgpSessionData"}
+      components.CreateBgpSessionAttributes:
+        fields:
+          - {name: "RequestorID", wire: "requestor_id", type: "*string", optional: true, doc: "c5801cde"}
+          - {name: "ServerID", wire: "server_id", type: "string", doc: "25dfc17b"}
+      components.CreateBgpSessionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateBgpSessionAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateBgpSessionType"}
+      components.CreateBgpSessionType:
+        enum: ["bgp_sessions"]
+      components.CreateElasticIP:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateElasticIPData"}
+      components.CreateElasticIPAttributes:
+        fields:
+          - {name: "Mode", wire: "mode", type: "*CreateElasticIPMode", optional: true, default: "routed", doc: "b024709a"}
+          - {name: "ProjectID", wire: "project_id", type: "string", doc: "aed8fe66"}
+          - {name: "ServerID", wire: "server_id", type: "*string", optional: true, doc: "3a677a1a"}
+          - {name: "ServerIds", wire: "server_ids", type: "[]string", optional: true, doc: "0f0f76f0"}
+          - {name: "Site", wire: "site", type: "*string", optional: true, doc: "21d77075"}
+      components.CreateElasticIPData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateElasticIPAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateElasticIPType"}
+      components.CreateElasticIPMode:
+        doc: "f6ad0574"
+        enum: ["bgp", "routed"]
+      components.CreateElasticIPType:
+        enum: ["elastic_ips"]
+      components.ElasticIP:
+        fields:
+          - {name: "Data", wire: "data", type: "*ElasticIPData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*ElasticIPMeta", optional: true}
+      components.ElasticIPData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ElasticIPDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "20134be6"}
+          - {name: "Type", wire: "type", type: "*ElasticIPDataType", optional: true}
+      components.ElasticIPDataAttributes:
+        fields:
+          - {name: "Address", wire: "address", type: "*string", optional: true, doc: "594c336d"}
+          - {name: "CreatedAt", wire: "created_at", type: "*time.Time", optional: true, doc: "38c629e4"}
+          - {name: "Family", wire: "family", type: "*Family", optional: true, doc: "e7e3e78f"}
+          - {name: "Mode", wire: "mode", type: "*Mode", optional: true, doc: "e8bb01b2"}
+          - {name: "PrefixLength", wire: "prefix_length", type: "*int64", optional: true, doc: "483fc205"}
+          - {name: "Project", wire: "project", type: "*ElasticIPDataProject", optional: true, doc: "da562966"}
+          - {name: "Region", wire: "region", type: "*ElasticIPDataRegion", optional: true, doc: "21a2d42b"}
+          - {name: "Server", wire: "server", type: "*ElasticIPDataServer", optional: true, doc: "cd2483fc"}
+          - {name: "Status", wire: "status", type: "*Status", optional: true, doc: "04b0410b"}
+      components.ElasticIPDataProject:
+        doc: "ffc9bcd8"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.ElasticIPDataRegion:
+        doc: "aa874796"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "7ed16c35"}
+          - {name: "Location", wire: "location", type: "*Location", optional: true, doc: "35ff6857"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "d1a29dab"}
+      components.ElasticIPDataServer:
+        doc: "147484a2"
+        fields:
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*string", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+      components.ElasticIPDataType:
+        enum: ["elastic_ips"]
+      components.ElasticIPMeta:
+      components.ElasticIps:
+        fields:
+          - {name: "Data", wire: "data", type: "[]ElasticIPData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*ElasticIpsMeta", optional: true}
+      components.ElasticIpsMeta:
+      components.Family:
+        doc: "a05bc2d2"
+        enum: ["IPv4"]
+      components.Location:
+        doc: "17a561dd"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "2c1c4e48"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "558a9d7e"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "06ebf066"}
+      components.Mode:
+        doc: "a18e28cc"
+        enum: ["bgp", "routed"]
+      components.Status:
+        doc: "f3077d7e"
+        enum: ["active", "configuring", "error", "moving", "pending", "releasing"]
+      components.UpdateElasticIP:
+        fields:
+          - {name: "Data", wire: "data", type: "UpdateElasticIPData"}
+      components.UpdateElasticIPAttributes:
+        fields:
+          - {name: "ServerID", wire: "server_id", type: "string", doc: "74c796e0"}
+      components.UpdateElasticIPData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "UpdateElasticIPAttributes"}
+          - {name: "Type", wire: "type", type: "UpdateElasticIPType"}
+      components.UpdateElasticIPType:
+        enum: ["elastic_ips"]
+      operations.CreateElasticIPBgpSessionResponse:
+        fields:
+          - {name: "BgpSession", type: "*components.BgpSession", optional: true, doc: "41d09a60"}
+      operations.CreateElasticIPResponse:
+        fields:
+          - {name: "ElasticIP", type: "*components.ElasticIP", optional: true, doc: "41d09a60"}
+      operations.DeleteElasticIPBgpSessionResponse:
+      operations.DeleteElasticIPResponse:
+      operations.FilterStatus:
+        doc: "f758ffc1"
+        enum: ["active", "configuring", "error", "moving", "releasing"]
+      operations.GetElasticIPBgpSessionResponse:
+        fields:
+          - {name: "BgpSession", type: "*components.BgpSession", optional: true, doc: "6d8303b0"}
+      operations.GetElasticIPResponse:
+        fields:
+          - {name: "ElasticIP", type: "*components.ElasticIP", optional: true, doc: "6d8303b0"}
+      operations.ListElasticIPBgpSessionsResponse:
+        fields:
+          - {name: "BgpSessions", type: "*components.BgpSessions", optional: true, doc: "6d8303b0"}
+      operations.ListElasticIpsRequest:
+        fields:
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "71642854"}
+          - {name: "FilterServer", wire: "filter[server]", type: "*string", optional: true, doc: "5db5257a"}
+          - {name: "FilterStatus", wire: "filter[status]", type: "*FilterStatus", optional: true, doc: "738f454c"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+      operations.ListElasticIpsResponse:
+        fields:
+          - {name: "ElasticIps", type: "*components.ElasticIps", optional: true, doc: "6d8303b0"}
+      operations.UpdateElasticIPResponse:
+        fields:
+          - {name: "ElasticIP", type: "*components.ElasticIP", optional: true, doc: "41d09a60"}
+  Firewalls:
+    methods:
+      Create: {signature: "(context.Context, operations.CreateFirewallFirewallsRequestBody, ...operations.Option) (*operations.CreateFirewallResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteFirewallResponse, error)"}
+      DeleteAssignment: {signature: "(context.Context, string, string, ...operations.Option) (*operations.DeleteFirewallAssignmentResponse, error)"}
+      Get: {signature: "(context.Context, string, ...operations.Option) (*operations.GetFirewallResponse, error)"}
+      GetAllFirewallAssignments: {signature: "(context.Context, *string, *string, *int64, *int64, ...operations.Option) (*operations.GetAllFirewallAssignmentsResponse, error)"}
+      List: {signature: "(context.Context, *string, *string, *int64, *int64, ...operations.Option) (*operations.ListFirewallsResponse, error)"}
+      ListAssignments: {signature: "(context.Context, string, *int64, *int64, ...operations.Option) (*operations.GetFirewallAssignmentsResponse, error)"}
+      Update: {signature: "(context.Context, string, operations.UpdateFirewallFirewallsRequestBody, ...operations.Option) (*operations.UpdateFirewallResponse, error)"}
+    models:
+      components.Firewall:
+        fields:
+          - {name: "Data", wire: "data", type: "*FirewallData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*FirewallMeta", optional: true}
+      components.FirewallAssignmentData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*FirewallAssignmentDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*FirewallAssignmentDataType", optional: true}
+      components.FirewallAssignmentDataAttributes:
+        fields:
+          - {name: "Firewall", wire: "firewall", type: "*FirewallAssignmentDataFirewall", optional: true}
+          - {name: "FirewallID", wire: "firewall_id", type: "*string", optional: true}
+          - {name: "Server", wire: "server", type: "*FirewallAssignmentDataServer", optional: true, doc: "b1e30418"}
+          - {name: "VirtualMachine", wire: "virtual_machine", type: "*FirewallAssignmentDataVirtualMachine", optional: true, doc: "6c1c1971"}
+      components.FirewallAssignmentDataFirewall:
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.FirewallAssignmentDataServer:
+        doc: "4e4c7655"
+        fields:
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+      components.FirewallAssignmentDataType:
+        enum: ["firewall_assignments"]
+      components.FirewallAssignmentDataVirtualMachine:
+        doc: "538a393d"
+        fields:
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+      components.FirewallAssignments:
+        fields:
+          - {name: "Data", wire: "data", type: "[]FirewallAssignmentData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*FirewallAssignmentsMeta", optional: true}
+      components.FirewallAssignmentsMeta:
+      components.FirewallData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*FirewallDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*FirewallDataType", optional: true}
+      components.FirewallDataAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Project", wire: "project", type: "*FirewallDataProject", optional: true}
+          - {name: "Rules", wire: "rules", type: "[]Rules", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]Tags", optional: true}
+      components.FirewallDataProject:
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.FirewallDataType:
+        enum: ["firewalls"]
+      components.FirewallMeta:
+      components.Firewalls:
+        fields:
+          - {name: "Data", wire: "data", type: "[]FirewallData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*FirewallsMeta", optional: true}
+      components.FirewallsMeta:
+      components.Rules:
+        fields:
+          - {name: "Default", wire: "default", type: "*bool", optional: true, doc: "97a9c6ee"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "77a04ac8"}
+          - {name: "From", wire: "from", type: "*string", optional: true, doc: "b85679de"}
+          - {name: "Port", wire: "port", type: "*string", optional: true}
+          - {name: "Protocol", wire: "protocol", type: "*string", optional: true}
+          - {name: "To", wire: "to", type: "*string", optional: true, doc: "53d408d3"}
+      components.Tags:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      operations.CreateFirewallFirewallsAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "string"}
+          - {name: "Project", wire: "project", type: "string"}
+          - {name: "Rules", wire: "rules", type: "[]CreateFirewallRules", optional: true, doc: "69d44e3e"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true, doc: "4c13ef02"}
+      operations.CreateFirewallFirewallsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateFirewallFirewallsAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateFirewallFirewallsType"}
+      operations.CreateFirewallFirewallsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateFirewallFirewallsData"}
+      operations.CreateFirewallFirewallsType:
+        enum: ["firewalls"]
+      operations.CreateFirewallProtocol:
+        enum: ["TCP", "UDP"]
+      operations.CreateFirewallResponse:
+        fields:
+          - {name: "Firewall", type: "*components.Firewall", optional: true, doc: "09de135b"}
+      operations.CreateFirewallRules:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "77a04ac8"}
+          - {name: "From", wire: "from", type: "*string", optional: true, doc: "b85679de"}
+          - {name: "Port", wire: "port", type: "*string", optional: true, doc: "782de412"}
+          - {name: "Protocol", wire: "protocol", type: "*CreateFirewallProtocol", optional: true}
+          - {name: "To", wire: "to", type: "*string", optional: true, doc: "53d408d3"}
+      operations.DeleteFirewallAssignmentResponse:
+      operations.DeleteFirewallResponse:
+      operations.GetAllFirewallAssignmentsResponse:
+        fields:
+          - {name: "FirewallAssignments", type: "*components.FirewallAssignments", optional: true, doc: "6d8303b0"}
+      operations.GetFirewallAssignmentsResponse:
+        fields:
+          - {name: "FirewallAssignments", type: "*components.FirewallAssignments", optional: true, doc: "6d8303b0"}
+      operations.GetFirewallResponse:
+        fields:
+          - {name: "Firewall", type: "*components.Firewall", optional: true, doc: "6d8303b0"}
+      operations.ListFirewallsResponse:
+        fields:
+          - {name: "Firewalls", type: "*components.Firewalls", optional: true, doc: "6d8303b0"}
+      operations.UpdateFirewallFirewallsAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Rules", wire: "rules", type: "[]UpdateFirewallFirewallsRules", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true, doc: "a34d61dd"}
+      operations.UpdateFirewallFirewallsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateFirewallFirewallsAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "UpdateFirewallFirewallsType"}
+      operations.UpdateFirewallFirewallsProtocol:
+        enum: ["TCP", "UDP"]
+      operations.UpdateFirewallFirewallsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "UpdateFirewallFirewallsData"}
+      operations.UpdateFirewallFirewallsRules:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "77a04ac8"}
+          - {name: "From", wire: "from", type: "*string", optional: true}
+          - {name: "Port", wire: "port", type: "*string", optional: true, doc: "782de412"}
+          - {name: "Protocol", wire: "protocol", type: "*UpdateFirewallFirewallsProtocol", optional: true}
+          - {name: "To", wire: "to", type: "*string", optional: true}
+      operations.UpdateFirewallFirewallsType:
+        enum: ["firewalls"]
+      operations.UpdateFirewallResponse:
+        fields:
+          - {name: "Firewall", type: "*components.Firewall", optional: true, doc: "6d8303b0"}
+  Firewalls.Assignments:
+    methods:
+      Create: {signature: "(context.Context, string, operations.CreateFirewallAssignmentFirewallsAssignmentsRequestBody, ...operations.Option) (*operations.CreateFirewallAssignmentResponse, error)"}
+    models:
+      components.FirewallServer:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*FirewallServerAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*FirewallServerType", optional: true}
+      components.FirewallServerAttributes:
+        fields:
+          - {name: "FirewallID", wire: "firewall_id", type: "*string", optional: true}
+          - {name: "ServerID", wire: "server_id", type: "*string", optional: true}
+      components.FirewallServerType:
+        enum: ["firewall_servers"]
+      operations.CreateFirewallAssignmentFirewallsAssignmentsAttributes:
+        fields:
+          - {name: "ServerID", wire: "server_id", type: "*string", optional: true, doc: "ba9fef2b"}
+          - {name: "VirtualMachineID", wire: "virtual_machine_id", type: "*string", optional: true, doc: "4751a8f1"}
+      operations.CreateFirewallAssignmentFirewallsAssignmentsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateFirewallAssignmentFirewallsAssignmentsAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateFirewallAssignmentFirewallsAssignmentsType"}
+      operations.CreateFirewallAssignmentFirewallsAssignmentsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateFirewallAssignmentFirewallsAssignmentsData"}
+      operations.CreateFirewallAssignmentFirewallsAssignmentsType:
+        enum: ["firewall_assignments"]
+      operations.CreateFirewallAssignmentResponse:
+        fields:
+          - {name: "FirewallServer", type: "*components.FirewallServer", optional: true, doc: "09de135b"}
+  Plans:
+    methods:
+      Get: {signature: "(context.Context, string, ...operations.Option) (*operations.GetPlanResponse, error)"}
+      GetBandwidth: {signature: "(context.Context, operations.GetBandwidthPlansRequest, ...operations.Option) (*operations.GetBandwidthPlansResponse, error)"}
+      GetManagedDatabasePlans: {signature: "(context.Context, ...operations.Option) (*operations.GetManagedDatabasePlansResponse, error)"}
+      List: {signature: "(context.Context, operations.GetPlansRequest, ...operations.Option) (*operations.GetPlansResponse, error)"}
+      ListStorage: {signature: "(context.Context, *string, *string, ...operations.Option) (*operations.GetStoragePlansResponse, error)"}
+      UpdateBandwidth: {signature: "(context.Context, operations.UpdatePlansBandwidthPlansRequestBody, ...operations.Option) (*operations.UpdatePlansBandwidthResponse, error)"}
+    models:
+      components.BandwidthPackages:
+        fields:
+          - {name: "Data", wire: "data", type: "*BandwidthPackagesData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*BandwidthPackagesMeta", optional: true}
+      components.BandwidthPackagesAttributes:
+        fields:
+          - {name: "Packages", wire: "packages", type: "[]Packages", optional: true}
+          - {name: "Project", wire: "project", type: "*BandwidthPackagesProject", optional: true}
+      components.BandwidthPackagesData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*BandwidthPackagesAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*BandwidthPackagesType", optional: true}
+      components.BandwidthPackagesMeta:
+      components.BandwidthPackagesProject:
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.BandwidthPackagesType:
+        enum: ["bandwidth_packages"]
+      components.BandwidthPlanData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*BandwidthPlanDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*BandwidthPlanDataType", optional: true}
+      components.BandwidthPlanDataAttributes:
+        fields:
+          - {name: "Locations", wire: "locations", type: "[]string", optional: true}
+          - {name: "Pricing", wire: "pricing", type: "*Pricing", optional: true}
+          - {name: "Region", wire: "region", type: "*string", optional: true}
+      components.BandwidthPlanDataType:
+        enum: ["bandwidth_plan"]
+      components.BandwidthPlans:
+        fields:
+          - {name: "Data", wire: "data", type: "[]BandwidthPlanData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.Brl:
+        fields:
+          - {name: "Hourly", wire: "hourly", type: "*int64", optional: true}
+          - {name: "Monthly", wire: "monthly", type: "*int64", optional: true}
+          - {name: "Yearly", wire: "yearly", type: "*int64", optional: true}
+      components.CPU:
+        fields:
+          - {name: "Clock", wire: "clock", type: "*float64", optional: true}
+          - {name: "Cores", wire: "cores", type: "*float64", optional: true}
+          - {name: "Count", wire: "count", type: "*float64", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.Drives:
+        fields:
+          - {name: "Count", wire: "count", type: "*float64", optional: true}
+          - {name: "Size", wire: "size", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*PlanDataAttributesType", optional: true}
+      components.Gpu:
+        fields:
+          - {name: "Count", wire: "count", type: "*float64", optional: true}
+          - {name: "Interconnect", wire: "interconnect", type: "*string", optional: true, doc: "fade139f"}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+          - {name: "VramPerGpu", wire: "vram_per_gpu", type: "*float64", optional: true, doc: "850c64d2"}
+      components.Locations:
+        fields:
+          - {name: "Available", wire: "available", type: "[]string", optional: true}
+          - {name: "InStock", wire: "in_stock", type: "[]string", optional: true}
+      components.ManagedDatabasePlanAttributes:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ManagedDatabasePlanAttributesAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*ManagedDatabasePlanAttributesType", optional: true}
+      components.ManagedDatabasePlanAttributesAttributes:
+        fields:
+          - {name: "Engine", wire: "engine", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Regions", wire: "regions", type: "[]ManagedDatabasePlanAttributesRegions", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Specs", wire: "specs", type: "*ManagedDatabasePlanAttributesSpecs", optional: true}
+      components.ManagedDatabasePlanAttributesPricing:
+        fields:
+          - {name: "Month", wire: "month", type: "*float64", optional: true}
+          - {name: "Year", wire: "year", type: "*float64", optional: true}
+      components.ManagedDatabasePlanAttributesRegions:
+        fields:
+          - {name: "City", wire: "city", type: "*string", optional: true}
+          - {name: "Country", wire: "country", type: "*string", optional: true}
+          - {name: "Pricing", wire: "pricing", type: "map[string]ManagedDatabasePlanAttributesPricing", optional: true}
+          - {name: "Region", wire: "region", type: "*string", optional: true}
+          - {name: "Site", wire: "site", type: "*ManagedDatabasePlanAttributesSite", optional: true}
+      components.ManagedDatabasePlanAttributesSite:
+        fields:
+          - {name: "Facility", wire: "facility", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.ManagedDatabasePlanAttributesSpecs:
+        fields:
+          - {name: "CPU", wire: "cpu", type: "*string", optional: true}
+          - {name: "Iops", wire: "iops", type: "*string", optional: true}
+          - {name: "Memory", wire: "memory", type: "*string", optional: true}
+          - {name: "Replicas", wire: "replicas", type: "*int64", optional: true}
+          - {name: "Shards", wire: "shards", type: "*int64", optional: true}
+          - {name: "Storage", wire: "storage", type: "*string", optional: true}
+      components.ManagedDatabasePlanAttributesType:
+        enum: ["managed_database_plans"]
+      components.ManagedDatabasePlans:
+        fields:
+          - {name: "Data", wire: "data", type: "[]ManagedDatabasePlanAttributes", optional: true}
+      components.Memory:
+        fields:
+          - {name: "Total", wire: "total", type: "*float64", optional: true}
+      components.Nics:
+        fields:
+          - {name: "Count", wire: "count", type: "*float64", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.Packages:
+        fields:
+          - {name: "Contracted", wire: "contracted", type: "*int64", optional: true}
+          - {name: "Currency", wire: "currency", type: "*string", optional: true}
+          - {name: "RegionSlug", wire: "region_slug", type: "*string", optional: true}
+          - {name: "TotalPrice", wire: "total_price", type: "*float64", optional: true}
+          - {name: "UnitPrice", wire: "unit_price", type: "*float64", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Plan:
+        fields:
+          - {name: "Data", wire: "data", type: "*PlanData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PlanMeta", optional: true}
+      components.PlanData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PlanDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*PlanDataType", optional: true}
+      components.PlanDataAttributes:
+        fields:
+          - {name: "AvailableOperatingSystems", wire: "available_operating_systems", type: "[]string", optional: true}
+          - {name: "Features", wire: "features", type: "[]PlanDataFeatures", optional: true, doc: "275f88e3"}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Regions", wire: "regions", type: "[]PlanDataRegions", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Specs", wire: "specs", type: "*Specs", optional: true}
+      components.PlanDataAttributesType:
+        enum: ["HDD", "NVME", "SSD"]
+      components.PlanDataBRL:
+        fields:
+          - {name: "Hour", wire: "hour", type: "*float64", optional: true}
+          - {name: "Month", wire: "month", type: "*float64", optional: true}
+          - {name: "Year", wire: "year", type: "*float64", optional: true}
+      components.PlanDataFeatures:
+        enum: ["raid", "sev", "ssh", "user_data"]
+      components.PlanDataPricing:
+        fields:
+          - {name: "Brl", wire: "BRL", type: "*PlanDataBRL", optional: true}
+          - {name: "Usd", wire: "USD", type: "*PlanDataUSD", optional: true}
+      components.PlanDataRegions:
+        fields:
+          - {name: "DeploysInstantly", wire: "deploys_instantly", type: "[]string", optional: true}
+          - {name: "Locations", wire: "locations", type: "*Locations", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Pricing", wire: "pricing", type: "*PlanDataPricing", optional: true}
+          - {name: "StockLevel", wire: "stock_level", type: "*StockLevel", optional: true}
+      components.PlanDataType:
+        enum: ["plans"]
+      components.PlanDataUSD:
+        fields:
+          - {name: "Hour", wire: "hour", type: "*float64", optional: true}
+          - {name: "Month", wire: "month", type: "*float64", optional: true}
+          - {name: "Year", wire: "year", type: "*float64", optional: true}
+      components.PlanMeta:
+      components.Pricing:
+        fields:
+          - {name: "Brl", wire: "brl", type: "*Brl", optional: true}
+          - {name: "Usd", wire: "usd", type: "*Usd", optional: true}
+      components.Specs:
+        fields:
+          - {name: "CPU", wire: "cpu", type: "*CPU", optional: true}
+          - {name: "Drives", wire: "drives", type: "[]Drives", optional: true}
+          - {name: "Gpu", wire: "gpu", type: "*Gpu", optional: true}
+          - {name: "Memory", wire: "memory", type: "*Memory", optional: true}
+          - {name: "Nics", wire: "nics", type: "[]Nics", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.StockLevel:
+        enum: ["high", "low", "medium", "unavailable"]
+      components.StoragePlanData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*StoragePlanDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*StoragePlanDataType", optional: true}
+      components.StoragePlanDataAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Regions", wire: "regions", type: "[]StoragePlanDataRegions", optional: true}
+          - {name: "StoragePlanStorageClass", wire: "storage_class", type: "*StoragePlanStorageClass", optional: true}
+          - {name: "StoragePlanStorageType", wire: "storage_type", type: "*StoragePlanStorageType", optional: true}
+      components.StoragePlanDataBRL:
+        fields:
+          - {name: "Month", wire: "month", type: "*float64", optional: true}
+      components.StoragePlanDataPricing:
+        fields:
+          - {name: "Brl", wire: "BRL", type: "*StoragePlanDataBRL", optional: true}
+          - {name: "Usd", wire: "USD", type: "*StoragePlanDataUSD", optional: true}
+      components.StoragePlanDataRegions:
+        fields:
+          - {name: "Locations", wire: "locations", type: "[]string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Pricing", wire: "pricing", type: "*StoragePlanDataPricing", optional: true}
+      components.StoragePlanDataType:
+        enum: ["storage_plans"]
+      components.StoragePlanDataUSD:
+        fields:
+          - {name: "Month", wire: "month", type: "*float64", optional: true}
+      components.StoragePlanStorageClass:
+        enum: ["high_performance", "standard"]
+      components.StoragePlanStorageType:
+        enum: ["filesystem", "object"]
+      components.StoragePlans:
+        fields:
+          - {name: "Data", wire: "data", type: "[]StoragePlanData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*StoragePlansMeta", optional: true}
+      components.StoragePlansMeta:
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      components.Usd:
+        fields:
+          - {name: "Hourly", wire: "hourly", type: "*int64", optional: true}
+          - {name: "Monthly", wire: "monthly", type: "*int64", optional: true}
+          - {name: "Yearly", wire: "yearly", type: "*int64", optional: true}
+      operations.FilterStockLevel:
+        doc: "431d4ce8"
+        enum: ["high", "low", "medium", "unavailable", "unique"]
+      operations.GetBandwidthPlansRequest:
+        fields:
+          - {name: "APIVersion", type: "*string", optional: true, default: "2023-06-01"}
+          - {name: "FilterID", wire: "filter[id]", type: "*string", optional: true, doc: "42c84e6a"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetBandwidthPlansResponse:
+        fields:
+          - {name: "BandwidthPlans", type: "*components.BandwidthPlans", optional: true, doc: "6d8303b0"}
+      operations.GetManagedDatabasePlansResponse:
+        fields:
+          - {name: "ManagedDatabasePlans", type: "*components.ManagedDatabasePlans", optional: true, doc: "6d8303b0"}
+      operations.GetPlanResponse:
+        fields:
+          - {name: "Plan", type: "*components.Plan", optional: true, doc: "6d8303b0"}
+      operations.GetPlansRequest:
+        fields:
+          - {name: "FilterDisk", wire: "filter[disk]", type: "*int64", optional: true, doc: "8b9e5ead"}
+          - {name: "FilterGpu", wire: "filter[gpu]", type: "*bool", optional: true, doc: "d15cf75d"}
+          - {name: "FilterInStock", wire: "filter[in_stock]", type: "*bool", optional: true, doc: "34c93e66"}
+          - {name: "FilterLocation", wire: "filter[location]", type: "*string", optional: true, doc: "7768c6cc"}
+          - {name: "FilterName", wire: "filter[name]", type: "*string", optional: true, doc: "5ea359a4"}
+          - {name: "FilterRAM", wire: "filter[ram]", type: "*int64", optional: true, doc: "2f2f6210"}
+          - {name: "FilterSlug", wire: "filter[slug]", type: "*string", optional: true, doc: "fa16d1ec"}
+          - {name: "FilterStockLevel", wire: "filter[stock_level]", type: "*FilterStockLevel", optional: true, doc: "196e87f9"}
+      operations.GetPlansResponse:
+        fields:
+          - {name: "Object", type: "*GetPlansResponseBody", optional: true, doc: "6d8303b0"}
+      operations.GetPlansResponseBody:
+        doc: "4ae7c7ca"
+        fields:
+          - {name: "Data", wire: "data", type: "[]components.PlanData", optional: true}
+      operations.GetStoragePlansResponse:
+        fields:
+          - {name: "StoragePlans", type: "*components.StoragePlans", optional: true, doc: "6d8303b0"}
+      operations.UpdatePlansBandwidthPlansAttributes:
+        fields:
+          - {name: "Project", wire: "project", type: "*string", optional: true, doc: "a16e8892"}
+          - {name: "Quantity", wire: "quantity", type: "*int64", optional: true, doc: "31d166b4"}
+          - {name: "RegionSlug", wire: "region_slug", type: "*string", optional: true, doc: "cbece953"}
+      operations.UpdatePlansBandwidthPlansData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdatePlansBandwidthPlansAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "*UpdatePlansBandwidthPlansType", optional: true}
+      operations.UpdatePlansBandwidthPlansRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*UpdatePlansBandwidthPlansData", optional: true}
+      operations.UpdatePlansBandwidthPlansType:
+        enum: ["bandwidth_packages"]
+      operations.UpdatePlansBandwidthResponse:
+        fields:
+          - {name: "BandwidthPackages", type: "*components.BandwidthPackages", optional: true, doc: "6d8303b0"}
+  PrivateNetworks:
+    methods:
+      Assign: {signature: "(context.Context, operations.AssignServerVirtualNetworkPrivateNetworksRequestBody, ...operations.Option) (*operations.AssignServerVirtualNetworkResponse, error)"}
+      Create: {signature: "(context.Context, operations.CreateVirtualNetworkPrivateNetworksRequestBody, ...operations.Option) (*operations.CreateVirtualNetworkResponse, error)"}
+      DeleteAssignment: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteVirtualNetworksAssignmentsResponse, error)"}
+      Get: {signature: "(context.Context, string, ...operations.Option) (*operations.GetVirtualNetworkResponse, error)"}
+      List: {signature: "(context.Context, operations.GetVirtualNetworksRequest, ...operations.Option) (*operations.GetVirtualNetworksResponse, error)"}
+      ListAssignments: {signature: "(context.Context, operations.GetVirtualNetworksAssignmentsRequest, ...operations.Option) (*operations.GetVirtualNetworksAssignmentsResponse, error)"}
+      Update: {signature: "(context.Context, string, operations.UpdateVirtualNetworkPrivateNetworksRequestBody, ...operations.Option) (*operations.UpdateVirtualNetworkResponse, error)"}
+    models:
+      components.Billing:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.ProjectInclude:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Billing", wire: "billing", type: "*Billing", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*string", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Stats", wire: "stats", type: "*ProjectIncludeStats", optional: true}
+      components.ProjectIncludeStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*int64", optional: true}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*int64", optional: true}
+          - {name: "Prefixes", wire: "prefixes", type: "*int64", optional: true}
+          - {name: "Servers", wire: "servers", type: "*int64", optional: true}
+          - {name: "Storages", wire: "storages", type: "*int64", optional: true}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*int64", optional: true}
+          - {name: "Vlans", wire: "vlans", type: "*int64", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      components.VirtualNetwork:
+        fields:
+          - {name: "Data", wire: "data", type: "*VirtualNetworkData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*VirtualNetworkMeta", optional: true}
+      components.VirtualNetworkAssignment:
+        fields:
+          - {name: "Data", wire: "data", type: "*VirtualNetworkAssignmentData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*VirtualNetworkAssignmentMeta", optional: true}
+      components.VirtualNetworkAssignmentData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*VirtualNetworkAssignmentDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*VirtualNetworkAssignmentDataType", optional: true}
+      components.VirtualNetworkAssignmentDataAttributes:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Server", wire: "server", type: "*VirtualNetworkAssignmentDataServer", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+          - {name: "Vid", wire: "vid", type: "*int64", optional: true}
+          - {name: "VirtualNetworkID", wire: "virtual_network_id", type: "*string", optional: true}
+      components.VirtualNetworkAssignmentDataServer:
+        fields:
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Label", wire: "label", type: "*string", optional: true}
+          - {name: "Locked", wire: "locked", type: "*bool", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      components.VirtualNetworkAssignmentDataType:
+        enum: ["virtual_network_assignment"]
+      components.VirtualNetworkAssignmentMeta:
+      components.VirtualNetworkAssignments:
+        fields:
+          - {name: "Data", wire: "data", type: "[]VirtualNetworkAssignmentData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.VirtualNetworkData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*VirtualNetworkDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*VirtualNetworkDataType", optional: true}
+      components.VirtualNetworkDataAttributes:
+        fields:
+          - {name: "AssignmentsCount", wire: "assignments_count", type: "*int64", optional: true, doc: "c6df2bba"}
+          - {name: "CreatedAt", wire: "created_at", type: "*time.Time", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "d26f3cd8"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "81b25629"}
+          - {name: "Project", wire: "project", type: "*ProjectInclude", optional: true}
+          - {name: "Region", wire: "region", type: "*VirtualNetworkDataRegion", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]VirtualNetworkDataTags", optional: true, doc: "8c63a69c"}
+          - {name: "Vid", wire: "vid", type: "*int64", optional: true, doc: "24a9e0c8"}
+      components.VirtualNetworkDataRegion:
+        fields:
+          - {name: "City", wire: "city", type: "*string", optional: true}
+          - {name: "Country", wire: "country", type: "*string", optional: true}
+          - {name: "Site", wire: "site", type: "*VirtualNetworkDataSite", optional: true}
+      components.VirtualNetworkDataSite:
+        fields:
+          - {name: "Facility", wire: "facility", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.VirtualNetworkDataTags:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.VirtualNetworkDataType:
+        enum: ["virtual_networks"]
+      components.VirtualNetworkMeta:
+      components.VirtualNetworks:
+        fields:
+          - {name: "Data", wire: "data", type: "[]VirtualNetworkData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      operations.AssignServerVirtualNetworkPrivateNetworksAttributes:
+        fields:
+          - {name: "ServerID", wire: "server_id", type: "string"}
+          - {name: "VirtualNetworkID", wire: "virtual_network_id", type: "string"}
+      operations.AssignServerVirtualNetworkPrivateNetworksData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*AssignServerVirtualNetworkPrivateNetworksAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "AssignServerVirtualNetworkPrivateNetworksType"}
+      operations.AssignServerVirtualNetworkPrivateNetworksRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*AssignServerVirtualNetworkPrivateNetworksData", optional: true}
+      operations.AssignServerVirtualNetworkPrivateNetworksType:
+        enum: ["virtual_network_assignment"]
+      operations.AssignServerVirtualNetworkResponse:
+        fields:
+          - {name: "VirtualNetworkAssignment", type: "*components.VirtualNetworkAssignment", optional: true, doc: "09de135b"}
+      operations.CreateVirtualNetworkPrivateNetworksAttributes:
+        fields:
+          - {name: "Description", wire: "description", type: "string"}
+          - {name: "Project", wire: "project", type: "string", doc: "b2158adf"}
+          - {name: "Site", wire: "site", type: "*CreateVirtualNetworkPrivateNetworksSite", optional: true, doc: "007b22a5"}
+      operations.CreateVirtualNetworkPrivateNetworksData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "CreateVirtualNetworkPrivateNetworksAttributes"}
+          - {name: "Type", wire: "type", type: "CreateVirtualNetworkPrivateNetworksType"}
+      operations.CreateVirtualNetworkPrivateNetworksRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateVirtualNetworkPrivateNetworksData"}
+      operations.CreateVirtualNetworkPrivateNetworksSite:
+        doc: "6dce0dd4"
+        enum: ["ASH", "BUE", "CHI", "DAL", "FRA", "LAX", "LON", "MEX", "MEX2", "MIA", "MIA2", "NYC", "SAO", "SAO2", "SGP", "SYD", "TYO", "TYO2"]
+      operations.CreateVirtualNetworkPrivateNetworksType:
+        enum: ["virtual_network"]
+      operations.CreateVirtualNetworkResponse:
+        fields:
+          - {name: "VirtualNetwork", type: "*components.VirtualNetwork", optional: true, doc: "09de135b"}
+      operations.DeleteVirtualNetworksAssignmentsResponse:
+      operations.GetVirtualNetworkResponse:
+        fields:
+          - {name: "VirtualNetwork", type: "*components.VirtualNetwork", optional: true, doc: "6d8303b0"}
+      operations.GetVirtualNetworksAssignmentsRequest:
+        fields:
+          - {name: "FilterServer", wire: "filter[server]", type: "*string", optional: true, doc: "5db5257a"}
+          - {name: "FilterVid", wire: "filter[vid]", type: "*string", optional: true, doc: "ee41f374"}
+          - {name: "FilterVirtualNetworkID", wire: "filter[virtual_network_id]", type: "*string", optional: true, doc: "f5d6e7f8"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetVirtualNetworksAssignmentsResponse:
+        fields:
+          - {name: "VirtualNetworkAssignments", type: "*components.VirtualNetworkAssignments", optional: true, doc: "6d8303b0"}
+      operations.GetVirtualNetworksRequest:
+        fields:
+          - {name: "FilterLocation", wire: "filter[location]", type: "*string", optional: true, doc: "f71f9080"}
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "2bc99d14"}
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "62493801"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetVirtualNetworksResponse:
+        fields:
+          - {name: "VirtualNetworks", type: "*components.VirtualNetworks", optional: true, doc: "6d8303b0"}
+      operations.UpdateVirtualNetworkPrivateNetworksAttributes:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true}
+      operations.UpdateVirtualNetworkPrivateNetworksData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateVirtualNetworkPrivateNetworksAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "UpdateVirtualNetworkPrivateNetworksType"}
+      operations.UpdateVirtualNetworkPrivateNetworksRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "UpdateVirtualNetworkPrivateNetworksData"}
+      operations.UpdateVirtualNetworkPrivateNetworksType:
+        enum: ["virtual_networks"]
+      operations.UpdateVirtualNetworkResponse:
+        fields:
+          - {name: "VirtualNetwork", type: "*components.VirtualNetwork", optional: true, doc: "6d8303b0"}
+  Projects:
+    methods:
+      Create: {signature: "(context.Context, operations.CreateProjectProjectsRequestBody, ...operations.Option) (*operations.CreateProjectResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteProjectResponse, error)"}
+      GetProject: {signature: "(context.Context, string, ...operations.Option) (*operations.GetProjectResponse, error)"}
+      List: {signature: "(context.Context, operations.GetProjectsRequest, ...operations.Option) (*operations.GetProjectsResponse, error)"}
+      Update: {signature: "(context.Context, string, *operations.UpdateProjectProjectsRequestBody, ...operations.Option) (*operations.UpdateProjectResponse, error)"}
+    models:
+      components.BillingMethod:
+        enum: ["95th percentile", "Normal"]
+      components.BillingType:
+        enum: ["Custom", "Hourly", "Monthly", "Normal", "Yearly"]
+      components.Currency:
+        fields:
+          - {name: "Code", wire: "code", type: "*string", optional: true}
+          - {name: "CurrencyID", wire: "currency_id", type: "*int64", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.Environment:
+        enum: ["Development", "Production", "Staging"]
+      components.Limits:
+        fields:
+          - {name: "BareMetal", wire: "bare_metal", type: "*int64", optional: true}
+          - {name: "BareMetalGpu", wire: "bare_metal_gpu", type: "*int64", optional: true}
+          - {name: "BgpSessionPerIP", wire: "bgp_session_per_ip", type: "*int64", optional: true}
+          - {name: "BlockStorage", wire: "block_storage", type: "*int64", optional: true}
+          - {name: "Database", wire: "database", type: "*int64", optional: true}
+          - {name: "ElasticIP", wire: "elastic_ip", type: "*int64", optional: true}
+          - {name: "Filesystem", wire: "filesystem", type: "*int64", optional: true}
+          - {name: "PublicNetwork", wire: "public_network", type: "*int64", optional: true}
+          - {name: "VirtualMachine", wire: "virtual_machine", type: "*int64", optional: true}
+          - {name: "VirtualMachineGpu", wire: "virtual_machine_gpu", type: "*int64", optional: true}
+          - {name: "VirtualNetwork", wire: "virtual_network", type: "*int64", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Project:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ProjectAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "6a8c9d96"}
+          - {name: "Type", wire: "type", type: "*ProjectType", optional: true}
+      components.ProjectAttributes:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true, doc: "e25b4220"}
+          - {name: "Billing", wire: "billing", type: "*ProjectBilling", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*BillingMethod", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*BillingType", optional: true}
+          - {name: "Cost", wire: "cost", type: "*string", optional: true}
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "86d2ffdf"}
+          - {name: "Environment", wire: "environment", type: "*Environment", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "74851300"}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true, doc: "8135fd6a"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "12cff93d"}
+          - {name: "Stats", wire: "stats", type: "*ProjectStats", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]ProjectTags", optional: true, doc: "d425495e"}
+          - {name: "Team", wire: "team", type: "*TeamInclude", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+      components.ProjectBilling:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.ProjectStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*float64", optional: true, doc: "e1f45e2c"}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*float64", optional: true, doc: "6b81cdc8"}
+          - {name: "Prefixes", wire: "prefixes", type: "*float64", optional: true, doc: "17d7dac4"}
+          - {name: "Servers", wire: "servers", type: "*float64", optional: true, doc: "b028f1dd"}
+          - {name: "Storages", wire: "storages", type: "*float64", optional: true, doc: "442bcb73"}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*float64", optional: true, doc: "4bb32ef0"}
+          - {name: "Vlans", wire: "vlans", type: "*float64", optional: true, doc: "9ea72033"}
+      components.ProjectTags:
+      components.ProjectType:
+        enum: ["projects"]
+      components.Projects:
+        fields:
+          - {name: "Data", wire: "data", type: "[]Project", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.TeamInclude:
+        fields:
+          - {name: "Address", wire: "address", type: "*string", optional: true}
+          - {name: "Currency", wire: "currency", type: "*Currency", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "FeatureFlags", wire: "feature_flags", type: "[]string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Limits", wire: "limits", type: "*Limits", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      operations.CreateProjectEnvironment:
+        enum: ["Development", "Production", "Staging"]
+      operations.CreateProjectProjectsAttributes:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "2f28e863"}
+          - {name: "Environment", wire: "environment", type: "*CreateProjectEnvironment", optional: true}
+          - {name: "Name", wire: "name", type: "string", doc: "5b81c5ff"}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "CreateProjectProvisioningType", doc: "05010788"}
+      operations.CreateProjectProjectsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateProjectProjectsAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateProjectProjectsType"}
+      operations.CreateProjectProjectsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*CreateProjectProjectsData", optional: true}
+      operations.CreateProjectProjectsType:
+        enum: ["projects"]
+      operations.CreateProjectProvisioningType:
+        doc: "f2ebd5c1"
+        enum: ["on_demand", "reserved"]
+      operations.CreateProjectResponse:
+        fields:
+          - {name: "Object", type: "*CreateProjectResponseBody", optional: true, doc: "09de135b"}
+      operations.CreateProjectResponseBody:
+        doc: "0021df52"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.Project", optional: true}
+      operations.DeleteProjectResponse:
+      operations.GetProjectResponse:
+        fields:
+          - {name: "Object", type: "*GetProjectResponseBody", optional: true, doc: "6d8303b0"}
+      operations.GetProjectResponseBody:
+        doc: "1fbccb77"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.Project", optional: true}
+          - {name: "Meta", wire: "meta", type: "*Meta", optional: true}
+      operations.GetProjectsRequest:
+        fields:
+          - {name: "ExtraFieldsProjects", wire: "extra_fields[projects]", type: "*string", optional: true, doc: "23ef3c73"}
+          - {name: "FilterBillingType", wire: "filter[billing_type]", type: "*string", optional: true, doc: "63d8ad45"}
+          - {name: "FilterDescription", wire: "filter[description]", type: "*string", optional: true, doc: "ae085a3b"}
+          - {name: "FilterEnvironment", wire: "filter[environment]", type: "*string", optional: true, doc: "80a8ee15"}
+          - {name: "FilterName", wire: "filter[name]", type: "*string", optional: true, doc: "4714748a"}
+          - {name: "FilterSlug", wire: "filter[slug]", type: "*string", optional: true, doc: "54e71846"}
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "687603e1"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetProjectsResponse:
+        fields:
+          - {name: "Projects", type: "*components.Projects", optional: true, doc: "6d8303b0"}
+      operations.Meta:
+      operations.UpdateProjectProjectsAttributes:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*UpdateProjectProjectsEnvironment", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true}
+      operations.UpdateProjectProjectsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateProjectProjectsAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "UpdateProjectProjectsType"}
+      operations.UpdateProjectProjectsEnvironment:
+        enum: ["Development", "Production", "Staging"]
+      operations.UpdateProjectProjectsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "UpdateProjectProjectsData"}
+      operations.UpdateProjectProjectsType:
+        enum: ["projects"]
+      operations.UpdateProjectResponse:
+        fields:
+          - {name: "Object", type: "*UpdateProjectResponseBody", optional: true, doc: "6d8303b0"}
+      operations.UpdateProjectResponseBody:
+        doc: "cdaaa32a"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.Project", optional: true}
+  Regions:
+    methods:
+      Fetch: {signature: "(context.Context, string, ...operations.Option) (*operations.GetRegionResponse, error)"}
+      Get: {signature: "(context.Context, operations.GetRegionsRequest, ...operations.Option) (*operations.GetRegionsResponse, error)"}
+    models:
+      components.Country:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Region:
+        fields:
+          - {name: "Data", wire: "data", type: "*RegionData", optional: true}
+      components.RegionAttributes:
+        fields:
+          - {name: "Country", wire: "country", type: "*RegionCountry", optional: true}
+          - {name: "Facility", wire: "facility", type: "*string", optional: true}
+          - {name: "Features", wire: "features", type: "[]string", optional: true, doc: "6ac52a34"}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "NetworkGroup", wire: "network_group", type: "*string", optional: true, doc: "e4800b0d"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.RegionCountry:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.RegionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*RegionAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*RegionType", optional: true}
+      components.RegionType:
+        enum: ["regions"]
+      components.Regions:
+        fields:
+          - {name: "Data", wire: "data", type: "[]RegionsData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.RegionsAttributes:
+        fields:
+          - {name: "Country", wire: "country", type: "*Country", optional: true}
+          - {name: "Facility", wire: "facility", type: "*string", optional: true}
+          - {name: "Features", wire: "features", type: "[]string", optional: true, doc: "6ac52a34"}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "NetworkGroup", wire: "network_group", type: "*string", optional: true, doc: "e4800b0d"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.RegionsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*RegionsAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*RegionsType", optional: true}
+      components.RegionsType:
+        enum: ["regions"]
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      operations.GetRegionResponse:
+        fields:
+          - {name: "Region", type: "*components.Region", optional: true, doc: "6d8303b0"}
+      operations.GetRegionsRequest:
+        fields:
+          - {name: "FilterFeatures", wire: "filter[features]", type: "*string", optional: true, doc: "93d5e6b9"}
+          - {name: "IncludeCustom", wire: "include_custom", type: "*bool", optional: true, doc: "e37557f8"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetRegionsResponse:
+        fields:
+          - {name: "Regions", type: "*components.Regions", optional: true, doc: "6d8303b0"}
+  Roles:
+    methods:
+      Get: {signature: "(context.Context, string, ...operations.Option) (*operations.GetRoleIDResponse, error)"}
+      List: {signature: "(context.Context, *int64, *int64, *string, ...operations.Option) (*operations.GetRolesResponse, error)"}
+    models:
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Role:
+        fields:
+          - {name: "Data", wire: "data", type: "*RoleData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*RoleMeta", optional: true}
+      components.RoleData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*RoleDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*RoleDataType", optional: true}
+      components.RoleDataAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "3b8bfa48"}
+      components.RoleDataType:
+        enum: ["roles"]
+      components.RoleMeta:
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      operations.GetRoleIDResponse:
+        fields:
+          - {name: "Role", type: "*components.Role", optional: true, doc: "6d8303b0"}
+      operations.GetRolesResponse:
+        fields:
+          - {name: "Object", type: "*GetRolesResponseBody", optional: true, doc: "6d8303b0"}
+      operations.GetRolesResponseBody:
+        doc: "3b772cdb"
+        fields:
+          - {name: "Data", wire: "data", type: "[]components.RoleData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*components.PaginationMeta", optional: true}
+  SSHKeys:
+    methods:
+      Create: {signature: "(context.Context, operations.PostSSHKeySSHKeysRequestBody, ...operations.Option) (*operations.PostSSHKeyResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteSSHKeyResponse, error)"}
+      Get: {signature: "(context.Context, string, string, ...operations.Option) (*operations.GetProjectSSHKeyResponse, error)", deprecated: true}
+      List: {signature: "(context.Context, operations.GetProjectSSHKeysRequest, ...operations.Option) (*operations.GetProjectSSHKeysResponse, error)", deprecated: true}
+      ListAll: {signature: "(context.Context, operations.GetSSHKeysRequest, ...operations.Option) (*operations.GetSSHKeysResponse, error)"}
+      ModifyProjectKey: {signature: "(context.Context, string, string, operations.PutProjectSSHKeySSHKeysRequestBody, ...operations.Option) (*operations.PutProjectSSHKeyResponse, error)", deprecated: true}
+      RemoveFromProject: {signature: "(context.Context, string, string, ...operations.Option) (*operations.DeleteProjectSSHKeyResponse, error)", deprecated: true}
+      Retrieve: {signature: "(context.Context, string, ...operations.Option) (*operations.GetSSHKeyResponse, error)"}
+      Update: {signature: "(context.Context, string, operations.PutSSHKeySSHKeysRequestBody, ...operations.Option) (*operations.PutSSHKeyResponse, error)"}
+    models:
+      components.Billing:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.ProjectInclude:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Billing", wire: "billing", type: "*Billing", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*string", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Stats", wire: "stats", type: "*ProjectIncludeStats", optional: true}
+      components.ProjectIncludeStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*int64", optional: true}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*int64", optional: true}
+          - {name: "Prefixes", wire: "prefixes", type: "*int64", optional: true}
+          - {name: "Servers", wire: "servers", type: "*int64", optional: true}
+          - {name: "Storages", wire: "storages", type: "*int64", optional: true}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*int64", optional: true}
+          - {name: "Vlans", wire: "vlans", type: "*int64", optional: true}
+      components.SSHKeyData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*SSHKeyDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "SSHKeyDataType"}
+      components.SSHKeyDataAttributes:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Fingerprint", wire: "fingerprint", type: "*string", optional: true, doc: "005afc5e"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "56ba9e45"}
+          - {name: "Project", wire: "project", type: "*ProjectInclude", optional: true}
+          - {name: "PublicKey", wire: "public_key", type: "*string", optional: true, doc: "a4909821"}
+          - {name: "Tags", wire: "tags", type: "[]SSHKeyDataTags", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+          - {name: "User", wire: "user", type: "*UserInclude", optional: true}
+      components.SSHKeyDataTags:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.SSHKeyDataType:
+        enum: ["ssh_keys"]
+      components.SSHKeys:
+        fields:
+          - {name: "Data", wire: "data", type: "[]SSHKeyData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      components.UserInclude:
+        fields:
+          - {name: "AuthenticationFactorID", wire: "authentication_factor_id", type: "*string", optional: true}
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Email", wire: "email", type: "*string", optional: true}
+          - {name: "FirstName", wire: "first_name", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "LastName", wire: "last_name", type: "*string", optional: true}
+          - {name: "Role", wire: "role", type: "*UserIncludeRole", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+      components.UserIncludeRole:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+      operations.DeleteProjectSSHKeyResponse:
+      operations.DeleteSSHKeyResponse:
+      operations.GetProjectSSHKeyResponse:
+        fields:
+          - {name: "Object", type: "*GetProjectSSHKeyResponseBody", optional: true, doc: "6d8303b0"}
+      operations.GetProjectSSHKeyResponseBody:
+        doc: "a472511e"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.SSHKeyData", optional: true}
+      operations.GetProjectSSHKeysRequest:
+        fields:
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "62493801"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, doc: "192780e0"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, doc: "c6f100f1"}
+          - {name: "ProjectID", type: "string", doc: "31e93ebf"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetProjectSSHKeysResponse:
+        fields:
+          - {name: "SSHKeys", type: "*components.SSHKeys", optional: true, doc: "6d8303b0"}
+      operations.GetSSHKeyResponse:
+        fields:
+          - {name: "Object", type: "*GetSSHKeyResponseBody", optional: true, doc: "6d8303b0"}
+      operations.GetSSHKeyResponseBody:
+        doc: "7313f931"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.SSHKeyData", optional: true}
+      operations.GetSSHKeysRequest:
+        fields:
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "b2158adf"}
+          - {name: "FilterScope", wire: "filter[scope]", type: "*string", optional: true, doc: "7f1df16d"}
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "62493801"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, doc: "192780e0"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, doc: "c6f100f1"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetSSHKeysResponse:
+        fields:
+          - {name: "SSHKeys", type: "*components.SSHKeys", optional: true, doc: "6d8303b0"}
+      operations.PostSSHKeyResponse:
+        fields:
+          - {name: "Object", type: "*PostSSHKeyResponseBody", optional: true, doc: "09de135b"}
+      operations.PostSSHKeyResponseBody:
+        doc: "df148c42"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.SSHKeyData", optional: true}
+      operations.PostSSHKeySSHKeysAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "string", doc: "56ba9e45"}
+          - {name: "Project", wire: "project", type: "*string", optional: true, doc: "b2158adf"}
+          - {name: "PublicKey", wire: "public_key", type: "string", doc: "a4909821"}
+      operations.PostSSHKeySSHKeysData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PostSSHKeySSHKeysAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "PostSSHKeySSHKeysType"}
+      operations.PostSSHKeySSHKeysRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PostSSHKeySSHKeysData"}
+      operations.PostSSHKeySSHKeysType:
+        enum: ["ssh_keys"]
+      operations.PutProjectSSHKeyResponse:
+        fields:
+          - {name: "Object", type: "*PutProjectSSHKeyResponseBody", optional: true, doc: "6d8303b0"}
+      operations.PutProjectSSHKeyResponseBody:
+        doc: "567b3a09"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.SSHKeyData", optional: true}
+      operations.PutProjectSSHKeySSHKeysAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "56ba9e45"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true}
+      operations.PutProjectSSHKeySSHKeysData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PutProjectSSHKeySSHKeysAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "PutProjectSSHKeySSHKeysType"}
+      operations.PutProjectSSHKeySSHKeysRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PutProjectSSHKeySSHKeysData"}
+      operations.PutProjectSSHKeySSHKeysType:
+        enum: ["ssh_keys"]
+      operations.PutSSHKeyResponse:
+        fields:
+          - {name: "Object", type: "*PutSSHKeyResponseBody", optional: true, doc: "6d8303b0"}
+      operations.PutSSHKeyResponseBody:
+        doc: "a95ffe9c"
+        fields:
+          - {name: "Data", wire: "data", type: "*components.SSHKeyData", optional: true}
+      operations.PutSSHKeySSHKeysAttributes:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "56ba9e45"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true}
+      operations.PutSSHKeySSHKeysData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PutSSHKeySSHKeysAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "PutSSHKeySSHKeysType"}
+      operations.PutSSHKeySSHKeysRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PutSSHKeySSHKeysData"}
+      operations.PutSSHKeySSHKeysType:
+        enum: ["ssh_keys"]
+  Servers:
+    methods:
+      Create: {signature: "(context.Context, operations.CreateServerServersRequestBody, ...operations.Option) (*operations.CreateServerResponse, error)"}
+      CreateIpmiSession: {signature: "(context.Context, string, ...operations.Option) (*operations.CreateIpmiSessionResponse, error)"}
+      Delete: {signature: "(context.Context, string, *string, ...operations.Option) (*operations.DestroyServerResponse, error)"}
+      ExitRescueMode: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerExitRescueModeResponse, error)"}
+      Get: {signature: "(context.Context, string, *string, ...operations.Option) (*operations.GetServerResponse, error)"}
+      GetDeployConfig: {signature: "(context.Context, string, ...operations.Option) (*operations.GetServerDeployConfigResponse, error)"}
+      GetOutOfBand: {signature: "(context.Context, string, ...operations.Option) (*operations.GetServerOutOfBandResponse, error)"}
+      List: {signature: "(context.Context, operations.GetServersRequest, ...operations.Option) (*operations.GetServersResponse, error)"}
+      Lock: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerLockResponse, error)"}
+      Reinstall: {signature: "(context.Context, string, operations.CreateServerReinstallServersRequestBody, ...operations.Option) (*operations.CreateServerReinstallResponse, error)"}
+      RunAction: {signature: "(context.Context, string, operations.CreateServerActionServersRequestBody, ...operations.Option) (*operations.CreateServerActionResponse, error)"}
+      ScheduleDeletion: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerScheduleDeletionResponse, error)"}
+      StartOutOfBandConnection: {signature: "(context.Context, string, operations.CreateServerOutOfBandServersRequestBody, ...operations.Option) (*operations.CreateServerOutOfBandResponse, error)"}
+      StartRescueMode: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerStartRescueModeResponse, error)"}
+      Unlock: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerUnlockResponse, error)"}
+      UnscheduleDeletion: {signature: "(context.Context, string, ...operations.Option) (*operations.ServerUnscheduleDeletionResponse, error)"}
+      Update: {signature: "(context.Context, string, operations.UpdateServerServersRequestBody, ...operations.Option) (*operations.UpdateServerResponse, error)"}
+      UpdateDeployConfig: {signature: "(context.Context, string, operations.UpdateServerDeployConfigServersRequestBody, ...operations.Option) (*operations.UpdateServerDeployConfigResponse, error)"}
+    models:
+      components.Billing:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.Currency:
+        fields:
+          - {name: "Code", wire: "code", type: "*string", optional: true}
+          - {name: "CurrencyID", wire: "currency_id", type: "*int64", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.DeployConfig:
+        fields:
+          - {name: "Data", wire: "data", type: "*DeployConfigData", optional: true}
+      components.DeployConfigAttributes:
+        fields:
+          - {name: "DiskLayout", wire: "disk_layout", type: "[]DiskLayout", optional: true}
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*string", optional: true}
+          - {name: "PersistentNetboot", wire: "persistent_netboot", type: "*bool", optional: true, doc: "ffca1d5f"}
+          - {name: "PublicNetwork", wire: "public_network", type: "*bool", optional: true}
+          - {name: "PublicNetworkID", wire: "public_network_id", type: "*string", optional: true}
+          - {name: "Raid", wire: "raid", type: "*string", optional: true}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]string", optional: true}
+          - {name: "UserData", wire: "user_data", type: "*string", optional: true}
+      components.DeployConfigData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*DeployConfigAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+      components.DeployConfigFilesystem:
+        enum: ["ext4", "xfs"]
+      components.DeployConfigRaidLevel:
+        enum: ["raid-0", "raid-1"]
+      components.DeployConfigRole:
+        enum: ["os", "raw", "storage"]
+      components.DiskLayout:
+        fields:
+          - {name: "Count", wire: "count", type: "int64"}
+          - {name: "Filesystem", wire: "filesystem", type: "*DeployConfigFilesystem", optional: true}
+          - {name: "MountPoint", wire: "mount_point", type: "*string", optional: true}
+          - {name: "RaidLevel", wire: "raid_level", type: "*DeployConfigRaidLevel", optional: true}
+          - {name: "Role", wire: "role", type: "DeployConfigRole"}
+      components.Distro:
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "d0b9ff50"}
+          - {name: "Series", wire: "series", type: "*string", optional: true, doc: "118aca62"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "6cd6dff4"}
+      components.Interfaces:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "MacAddress", wire: "mac_address", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Role", wire: "role", type: "*ServerDataRole", optional: true}
+      components.IpmiSession:
+        fields:
+          - {name: "Data", wire: "data", type: "*IpmiSessionData", optional: true}
+      components.IpmiSessionAttributes:
+        fields:
+          - {name: "IpmiAddress", wire: "ipmi_address", type: "*string", optional: true, doc: "eb50f1b0"}
+          - {name: "IpmiPassword", wire: "ipmi_password", type: "*string", optional: true, doc: "c60b2314"}
+          - {name: "IpmiURL", wire: "ipmi_url", type: "*string", optional: true, doc: "0ee442a4"}
+          - {name: "IpmiUsername", wire: "ipmi_username", type: "*string", optional: true, doc: "ab81d4b5"}
+      components.IpmiSessionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*IpmiSessionAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*IpmiSessionType", optional: true}
+      components.IpmiSessionType:
+        enum: ["ipmi_sessions"]
+      components.IpmiStatus:
+        enum: ["Intermittent", "Normal", "Unavailable"]
+      components.Limits:
+        fields:
+          - {name: "BareMetal", wire: "bare_metal", type: "*int64", optional: true}
+          - {name: "BareMetalGpu", wire: "bare_metal_gpu", type: "*int64", optional: true}
+          - {name: "BgpSessionPerIP", wire: "bgp_session_per_ip", type: "*int64", optional: true}
+          - {name: "BlockStorage", wire: "block_storage", type: "*int64", optional: true}
+          - {name: "Database", wire: "database", type: "*int64", optional: true}
+          - {name: "ElasticIP", wire: "elastic_ip", type: "*int64", optional: true}
+          - {name: "Filesystem", wire: "filesystem", type: "*int64", optional: true}
+          - {name: "PublicNetwork", wire: "public_network", type: "*int64", optional: true}
+          - {name: "VirtualMachine", wire: "virtual_machine", type: "*int64", optional: true}
+          - {name: "VirtualMachineGpu", wire: "virtual_machine_gpu", type: "*int64", optional: true}
+          - {name: "VirtualNetwork", wire: "virtual_network", type: "*int64", optional: true}
+      components.OperatingSystem:
+        fields:
+          - {name: "Distro", wire: "distro", type: "*Distro", optional: true}
+          - {name: "Features", wire: "features", type: "*ServerDataFeatures", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "0e6f2309"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "a62f594d"}
+          - {name: "Version", wire: "version", type: "*string", optional: true, doc: "efa49a94"}
+      components.OutOfBandConnection:
+        fields:
+          - {name: "Data", wire: "data", type: "*OutOfBandConnectionData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*OutOfBandConnectionMeta", optional: true}
+      components.OutOfBandConnectionAttributes:
+        fields:
+          - {name: "AccessIP", wire: "access_ip", type: "*string", optional: true}
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Credentials", wire: "credentials", type: "*OutOfBandConnectionCredentials", optional: true, doc: "98375f0b"}
+          - {name: "Port", wire: "port", type: "*string", optional: true}
+          - {name: "SSHKey", wire: "ssh_key", type: "*SSHKey", optional: true}
+          - {name: "ServerID", wire: "server_id", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+          - {name: "Username", wire: "username", type: "*string", optional: true}
+      components.OutOfBandConnectionCredentials:
+        doc: "e98547b0"
+        fields:
+          - {name: "Password", wire: "password", type: "*string", optional: true}
+          - {name: "User", wire: "user", type: "*string", optional: true}
+      components.OutOfBandConnectionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*OutOfBandConnectionAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.OutOfBandConnectionMeta:
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.ProjectInclude:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Billing", wire: "billing", type: "*Billing", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*string", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Stats", wire: "stats", type: "*ProjectIncludeStats", optional: true}
+      components.ProjectIncludeStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*int64", optional: true}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*int64", optional: true}
+          - {name: "Prefixes", wire: "prefixes", type: "*int64", optional: true}
+          - {name: "Servers", wire: "servers", type: "*int64", optional: true}
+          - {name: "Storages", wire: "storages", type: "*int64", optional: true}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*int64", optional: true}
+          - {name: "Vlans", wire: "vlans", type: "*int64", optional: true}
+      components.SSHKey:
+        fields:
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Fingerprint", wire: "fingerprint", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+      components.Server:
+        fields:
+          - {name: "Data", wire: "data", type: "*ServerData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*ServerMeta", optional: true}
+      components.ServerAction:
+        fields:
+          - {name: "Data", wire: "data", type: "*ServerActionData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*ServerActionMeta", optional: true}
+      components.ServerActionAttributes:
+        fields:
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      components.ServerActionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ServerActionAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*ServerActionType", optional: true}
+      components.ServerActionMeta:
+      components.ServerActionType:
+        enum: ["actions"]
+      components.ServerData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ServerDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.ServerDataAttributes:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "Interfaces", wire: "interfaces", type: "[]Interfaces", optional: true}
+          - {name: "IpmiStatus", wire: "ipmi_status", type: "*IpmiStatus", optional: true}
+          - {name: "Label", wire: "label", type: "*string", optional: true, doc: "fa1bd70d"}
+          - {name: "Locked", wire: "locked", type: "*bool", optional: true}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*OperatingSystem", optional: true}
+          - {name: "Plan", wire: "plan", type: "*ServerDataPlan", optional: true}
+          - {name: "Price", wire: "price", type: "*float64", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+          - {name: "PrimaryIpv6", wire: "primary_ipv6", type: "*string", optional: true}
+          - {name: "Project", wire: "project", type: "*ProjectInclude", optional: true}
+          - {name: "PublicNetwork", wire: "public_network", type: "*ServerDataPublicNetwork", optional: true, doc: "7d7f0932"}
+          - {name: "PublicNetworkEligible", wire: "public_network_eligible", type: "*bool", optional: true, doc: "bdd4826f"}
+          - {name: "Region", wire: "region", type: "*ServerRegionResourceData", optional: true}
+          - {name: "RescueAllowed", wire: "rescue_allowed", type: "*bool", optional: true}
+          - {name: "Role", wire: "role", type: "*string", optional: true, doc: "ceda5ad9"}
+          - {name: "ScheduledDeletionAt", wire: "scheduled_deletion_at", type: "*string", optional: true}
+          - {name: "Site", wire: "site", type: "*string", optional: true}
+          - {name: "Specs", wire: "specs", type: "*ServerDataSpecs", optional: true}
+          - {name: "Status", wire: "status", type: "*ServerDataStatus", optional: true, doc: "ec3af91c"}
+          - {name: "Tags", wire: "tags", type: "[]ServerDataTags", optional: true}
+          - {name: "Team", wire: "team", type: "*TeamInclude", optional: true}
+      components.ServerDataFeatures:
+        fields:
+          - {name: "Raid", wire: "raid", type: "*bool", optional: true}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "*bool", optional: true}
+          - {name: "UserData", wire: "user_data", type: "*bool", optional: true}
+      components.ServerDataPlan:
+        fields:
+          - {name: "Billing", wire: "billing", type: "*string", optional: true, doc: "cf783e20"}
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "97d84660"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "f6c410e6"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "c76023de"}
+      components.ServerDataPublicNetwork:
+        doc: "572ce969"
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Ipv4", wire: "ipv4", type: "*string", optional: true}
+          - {name: "Ipv6", wire: "ipv6", type: "*string", optional: true}
+      components.ServerDataRole:
+        enum: ["external", "internal", "ipmi", "unknown"]
+      components.ServerDataSpecs:
+        fields:
+          - {name: "CPU", wire: "cpu", type: "*string", optional: true, doc: "0bc9f4a8"}
+          - {name: "Disk", wire: "disk", type: "*string", optional: true, doc: "68f22fae"}
+          - {name: "Gpu", wire: "gpu", type: "*string", optional: true, doc: "bc9939c6"}
+          - {name: "Nic", wire: "nic", type: "*string", optional: true, doc: "ca638448"}
+          - {name: "RAM", wire: "ram", type: "*string", optional: true, doc: "acafc17c"}
+      components.ServerDataStatus:
+        doc: "ae74e4c0"
+        enum: ["deploying", "disk_erasing", "failed_deployment", "off", "on", "rescue_mode", "unknown"]
+      components.ServerDataTags:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.ServerMeta:
+      components.ServerRegionResourceData:
+        fields:
+          - {name: "City", wire: "city", type: "*string", optional: true}
+          - {name: "Country", wire: "country", type: "*string", optional: true}
+          - {name: "Site", wire: "site", type: "*Site", optional: true}
+      components.ServerRescue:
+        fields:
+          - {name: "Meta", wire: "meta", type: "*ServerRescueMeta", optional: true}
+      components.ServerRescueMeta:
+      components.ServerScheduleDeletion:
+        fields:
+          - {name: "Data", wire: "data", type: "*ServerScheduleDeletionData", optional: true}
+      components.ServerScheduleDeletionAttributes:
+        fields:
+          - {name: "ScheduledDeletionAt", wire: "scheduled_deletion_at", type: "*string", optional: true}
+          - {name: "ServerID", wire: "server_id", type: "*string", optional: true}
+      components.ServerScheduleDeletionData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*ServerScheduleDeletionAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*ServerScheduleDeletionType", optional: true}
+      components.ServerScheduleDeletionType:
+        enum: ["schedule_deletion"]
+      components.Servers:
+        fields:
+          - {name: "Data", wire: "data", type: "[]ServerData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.Site:
+        fields:
+          - {name: "Facility", wire: "facility", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "RackID", wire: "rack_id", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.TeamInclude:
+        fields:
+          - {name: "Address", wire: "address", type: "*string", optional: true}
+          - {name: "Currency", wire: "currency", type: "*Currency", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "FeatureFlags", wire: "feature_flags", type: "[]string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Limits", wire: "limits", type: "*Limits", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      operations.CreateIpmiSessionResponse:
+        fields:
+          - {name: "IpmiSession", type: "*components.IpmiSession", optional: true, doc: "09de135b"}
+      operations.CreateServerActionAction:
+        doc: "1e6d7b61"
+        enum: ["power_off", "power_on", "reboot"]
+      operations.CreateServerActionResponse:
+        fields:
+          - {name: "ServerAction", type: "*components.ServerAction", optional: true, doc: "09de135b"}
+      operations.CreateServerActionServersAttributes:
+        fields:
+          - {name: "Action", wire: "action", type: "CreateServerActionAction", doc: "cd25a59f"}
+      operations.CreateServerActionServersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateServerActionServersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateServerActionServersType"}
+      operations.CreateServerActionServersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateServerActionServersData"}
+      operations.CreateServerActionServersType:
+        enum: ["actions"]
+      operations.CreateServerBilling:
+        doc: "207b2f2e"
+        enum: ["hourly", "monthly", "yearly"]
+      operations.CreateServerDiskLayout:
+        fields:
+          - {name: "Count", wire: "count", type: "int64"}
+          - {name: "Filesystem", wire: "filesystem", type: "*CreateServerFilesystem", optional: true}
+          - {name: "MountPoint", wire: "mount_point", type: "*string", optional: true}
+          - {name: "RaidLevel", wire: "raid_level", type: "*CreateServerRaidLevel", optional: true}
+          - {name: "Role", wire: "role", type: "CreateServerServersRole"}
+      operations.CreateServerFilesystem:
+        enum: ["ext4", "xfs"]
+      operations.CreateServerOperatingSystem:
+        doc: "fdcf25e4"
+        enum: ["centos_7_4_x64", "centos_8_x64", "debian_10", "debian_11", "debian_12", "ipxe", "rhel8", "rockylinux_8", "ubuntu22_ml_in_a_box", "ubuntu24_ml_in_a_box", "ubuntu_20_04_x64_lts", "ubuntu_22_04_x64_lts", "ubuntu_24_04_x64_lts", "windows_2022_std", "windows_server_2019_std_v1"]
+      operations.CreateServerOutOfBandResponse:
+        fields:
+          - {name: "OutOfBandConnection", type: "*components.OutOfBandConnection", optional: true, doc: "09de135b"}
+      operations.CreateServerOutOfBandServersAttributes:
+        fields:
+          - {name: "SSHKeyID", wire: "ssh_key_id", type: "string", doc: "98f0328f"}
+      operations.CreateServerOutOfBandServersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateServerOutOfBandServersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateServerOutOfBandServersType"}
+      operations.CreateServerOutOfBandServersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateServerOutOfBandServersData"}
+      operations.CreateServerOutOfBandServersType:
+        enum: ["out_of_band"]
+      operations.CreateServerPlan:
+        doc: "300886f5"
+        enum: ["c2-large-x86", "c2-medium-x86", "c2-small-x86", "c3-large-x86", "c3-medium-x86", "c3-small-x86", "c3-xlarge-x86", "g3-gh200", "g3-large-x86", "g3-medium-x86", "g3-small-x86", "g3-xlarge-x86", "g4-rtx6kpro-large", "m3-large-x86", "m4-metal-large", "m4-metal-small", "rs4-metal-xlarge", "s2-small-x86", "s3-large-x86"]
+      operations.CreateServerRaid:
+        doc: "3430342c"
+        enum: ["raid-0", "raid-1"]
+      operations.CreateServerRaidLevel:
+        enum: ["raid-0", "raid-1"]
+      operations.CreateServerReinstallResponse:
+      operations.CreateServerReinstallServersAttributes:
+        fields:
+          - {name: "DiskLayout", wire: "disk_layout", type: "[]CreateServerReinstallServersDiskLayout", optional: true}
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true, doc: "41be8acf"}
+          - {name: "Ipxe", wire: "ipxe", type: "*string", optional: true, doc: "fadd5457"}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*CreateServerReinstallServersOperatingSystem", optional: true, doc: "20138a4e"}
+          - {name: "PersistentNetboot", wire: "persistent_netboot", type: "*bool", optional: true, doc: "ffca1d5f"}
+          - {name: "PublicNetwork", wire: "public_network", type: "*bool", optional: true, doc: "a705fde7"}
+          - {name: "PublicNetworkID", wire: "public_network_id", type: "*string", optional: true, doc: "cd6c033b"}
+          - {name: "Raid", wire: "raid", type: "*CreateServerReinstallServersRaid", optional: true, doc: "f2c6f5c2"}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]string", optional: true, doc: "e7d4f653"}
+          - {name: "UserData", wire: "user_data", type: "*string", optional: true, doc: "9d2d7e48"}
+      operations.CreateServerReinstallServersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateServerReinstallServersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateServerReinstallServersType"}
+      operations.CreateServerReinstallServersDiskLayout:
+        fields:
+          - {name: "Count", wire: "count", type: "int64"}
+          - {name: "Filesystem", wire: "filesystem", type: "*CreateServerReinstallServersFilesystem", optional: true}
+          - {name: "MountPoint", wire: "mount_point", type: "*string", optional: true}
+          - {name: "RaidLevel", wire: "raid_level", type: "*CreateServerReinstallServersRaidLevel", optional: true}
+          - {name: "Role", wire: "role", type: "CreateServerReinstallServersRole"}
+      operations.CreateServerReinstallServersFilesystem:
+        enum: ["ext4", "xfs"]
+      operations.CreateServerReinstallServersOperatingSystem:
+        doc: "9b6a568e"
+        enum: ["centos_7_4_x64", "centos_8_x64", "debian_10", "debian_11", "debian_12", "ipxe", "rhel8", "rockylinux_8", "ubuntu22_ml_in_a_box", "ubuntu24_ml_in_a_box", "ubuntu_20_04_x64_lts", "ubuntu_22_04_x64_lts", "ubuntu_24_04_x64_lts", "windows_2022_std", "windows_server_2019_std_v1"]
+      operations.CreateServerReinstallServersRaid:
+        doc: "ae73c2c8"
+        enum: ["raid-0", "raid-1"]
+      operations.CreateServerReinstallServersRaidLevel:
+        enum: ["raid-0", "raid-1"]
+      operations.CreateServerReinstallServersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "CreateServerReinstallServersData"}
+      operations.CreateServerReinstallServersRole:
+        enum: ["os", "raw", "storage"]
+      operations.CreateServerReinstallServersType:
+        enum: ["reinstalls"]
+      operations.CreateServerResponse:
+        fields:
+          - {name: "Server", type: "*components.Server", optional: true, doc: "09de135b"}
+      operations.CreateServerServersAttributes:
+        fields:
+          - {name: "BgpReady", wire: "bgp_ready", type: "*bool", optional: true, doc: "13159bfc"}
+          - {name: "Billing", wire: "billing", type: "*CreateServerBilling", optional: true, doc: "64f8fe85"}
+          - {name: "DiskLayout", wire: "disk_layout", type: "[]CreateServerDiskLayout", optional: true}
+          - {name: "Hostname", wire: "hostname", type: "string", doc: "34d56b5c"}
+          - {name: "Ipxe", wire: "ipxe", type: "*string", optional: true, doc: "ba3179df"}
+          - {name: "OperatingSystem", wire: "operating_system", type: "CreateServerOperatingSystem", doc: "90601318"}
+          - {name: "PersistentNetboot", wire: "persistent_netboot", type: "*bool", optional: true, doc: "ffca1d5f"}
+          - {name: "Plan", wire: "plan", type: "CreateServerPlan", doc: "d5c61e12"}
+          - {name: "Project", wire: "project", type: "string", doc: "f855f31f"}
+          - {name: "Raid", wire: "raid", type: "*CreateServerRaid", optional: true, doc: "f2c6f5c2"}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]string", optional: true, doc: "cb759b5d"}
+          - {name: "Site", wire: "site", type: "CreateServerSite", doc: "1fc71af8"}
+          - {name: "UserData", wire: "user_data", type: "*string", optional: true, doc: "78299b0e"}
+      operations.CreateServerServersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateServerServersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "CreateServerServersType"}
+      operations.CreateServerServersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*CreateServerServersData", optional: true}
+      operations.CreateServerServersRole:
+        enum: ["os", "raw", "storage"]
+      operations.CreateServerServersType:
+        enum: ["servers"]
+      operations.CreateServerSite:
+        doc: "3e43a70f"
+        enum: ["ASH", "BUE", "CHI", "DAL", "FRA", "LAX", "LON", "MEX", "MEX2", "MIA", "MIA2", "NYC", "SAO", "SAO2", "SGP", "SYD", "TYO", "TYO2"]
+      operations.DestroyServerResponse:
+      operations.GetServerDeployConfigResponse:
+        fields:
+          - {name: "DeployConfig", type: "*components.DeployConfig", optional: true, doc: "6d8303b0"}
+      operations.GetServerOutOfBandResponse:
+        fields:
+          - {name: "OutOfBandConnection", type: "*components.OutOfBandConnection", optional: true, doc: "6d8303b0"}
+      operations.GetServerResponse:
+        fields:
+          - {name: "Server", type: "*components.Server", optional: true, doc: "6d8303b0"}
+      operations.GetServersRequest:
+        fields:
+          - {name: "ExtraFieldsServers", wire: "extra_fields[servers]", type: "*string", optional: true, doc: "359d7aad"}
+          - {name: "FilterCreatedAtGte", wire: "filter[created_at_gte]", type: "*string", optional: true, doc: "baf96d38"}
+          - {name: "FilterCreatedAtLte", wire: "filter[created_at_lte]", type: "*string", optional: true, doc: "91d19eb3"}
+          - {name: "FilterDiskEql", wire: "filter[disk][eql]", type: "*int64", optional: true, doc: "8f27e90e"}
+          - {name: "FilterDiskGte", wire: "filter[disk][gte]", type: "*int64", optional: true, doc: "ede7cf54"}
+          - {name: "FilterDiskLte", wire: "filter[disk][lte]", type: "*int64", optional: true, doc: "9bf87e01"}
+          - {name: "FilterGpu", wire: "filter[gpu]", type: "*bool", optional: true, doc: "d15cf75d"}
+          - {name: "FilterHostname", wire: "filter[hostname]", type: "*string", optional: true, doc: "5e802199"}
+          - {name: "FilterLabel", wire: "filter[label]", type: "*string", optional: true, doc: "59719708"}
+          - {name: "FilterPlan", wire: "filter[plan]", type: "*string", optional: true, doc: "5c73284b"}
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "42805174"}
+          - {name: "FilterRAMEql", wire: "filter[ram][eql]", type: "*int64", optional: true, doc: "6dd062cd"}
+          - {name: "FilterRAMGte", wire: "filter[ram][gte]", type: "*int64", optional: true, doc: "9f67fa90"}
+          - {name: "FilterRAMLte", wire: "filter[ram][lte]", type: "*int64", optional: true, doc: "b703c6b1"}
+          - {name: "FilterRegion", wire: "filter[region]", type: "*string", optional: true, doc: "ef1716a7"}
+          - {name: "FilterStatus", wire: "filter[status]", type: "*string", optional: true, doc: "7e957454"}
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "31c6f859"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetServersResponse:
+        fields:
+          - {name: "Servers", type: "*components.Servers", optional: true, doc: "6d8303b0"}
+      operations.ServerExitRescueModeResponse:
+        fields:
+          - {name: "ServerRescue", type: "*components.ServerRescue", optional: true, doc: "6d8303b0"}
+      operations.ServerLockResponse:
+        fields:
+          - {name: "Server", type: "*components.Server", optional: true, doc: "6d8303b0"}
+      operations.ServerScheduleDeletionResponse:
+        fields:
+          - {name: "ServerScheduleDeletion", type: "*components.ServerScheduleDeletion", optional: true, doc: "09de135b"}
+      operations.ServerStartRescueModeResponse:
+        fields:
+          - {name: "ServerRescue", type: "*components.ServerRescue", optional: true, doc: "09de135b"}
+      operations.ServerUnlockResponse:
+        fields:
+          - {name: "Server", type: "*components.Server", optional: true, doc: "6d8303b0"}
+      operations.ServerUnscheduleDeletionResponse:
+      operations.UpdateServerDeployConfigResponse:
+        fields:
+          - {name: "DeployConfig", type: "*components.DeployConfig", optional: true, doc: "6d8303b0"}
+      operations.UpdateServerDeployConfigServersAttributes:
+        fields:
+          - {name: "DiskLayout", wire: "disk_layout", type: "[]UpdateServerDeployConfigServersDiskLayout", optional: true}
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "IpxeURL", wire: "ipxe_url", type: "*string", optional: true, doc: "3842ea22"}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*UpdateServerDeployConfigServersOperatingSystem", optional: true}
+          - {name: "PersistentNetboot", wire: "persistent_netboot", type: "*bool", optional: true, doc: "ffca1d5f"}
+          - {name: "PublicNetwork", wire: "public_network", type: "*bool", optional: true, doc: "c7f66f2f"}
+          - {name: "PublicNetworkID", wire: "public_network_id", type: "*string", optional: true, doc: "c0148c92"}
+          - {name: "Raid", wire: "raid", type: "*UpdateServerDeployConfigServersRaid", optional: true, doc: "f2c6f5c2"}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]string", optional: true}
+          - {name: "UserData", wire: "user_data", type: "*string", optional: true, doc: "5d0721ab"}
+      operations.UpdateServerDeployConfigServersDiskLayout:
+        fields:
+          - {name: "Count", wire: "count", type: "int64"}
+          - {name: "Filesystem", wire: "filesystem", type: "*UpdateServerDeployConfigServersFilesystem", optional: true}
+          - {name: "MountPoint", wire: "mount_point", type: "*string", optional: true}
+          - {name: "RaidLevel", wire: "raid_level", type: "*UpdateServerDeployConfigServersRaidLevel", optional: true}
+          - {name: "Role", wire: "role", type: "UpdateServerDeployConfigServersRole"}
+      operations.UpdateServerDeployConfigServersFilesystem:
+        enum: ["ext4", "xfs"]
+      operations.UpdateServerDeployConfigServersOperatingSystem:
+        enum: ["centos_7_4_x64", "centos_8_x64", "debian_10", "debian_11", "debian_12", "ipxe", "rhel8", "rockylinux_8", "ubuntu22_ml_in_a_box", "ubuntu24_ml_in_a_box", "ubuntu_20_04_x64_lts", "ubuntu_22_04_x64_lts", "ubuntu_24_04_x64_lts", "windows_2022_std", "windows_server_2019_std_v1"]
+      operations.UpdateServerDeployConfigServersRaid:
+        doc: "d56e112c"
+        enum: ["raid-0", "raid-1"]
+      operations.UpdateServerDeployConfigServersRaidLevel:
+        enum: ["raid-0", "raid-1"]
+      operations.UpdateServerDeployConfigServersRequestBody:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateServerDeployConfigServersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "UpdateServerDeployConfigServersType"}
+      operations.UpdateServerDeployConfigServersRole:
+        enum: ["os", "raw", "storage"]
+      operations.UpdateServerDeployConfigServersType:
+        enum: ["deploy_config"]
+      operations.UpdateServerResponse:
+        fields:
+          - {name: "Server", type: "*components.Server", optional: true, doc: "6d8303b0"}
+      operations.UpdateServerServersAttributes:
+        fields:
+          - {name: "Billing", wire: "billing", type: "*UpdateServerServersBilling", optional: true, doc: "64f8fe85"}
+          - {name: "Hostname", wire: "hostname", type: "*string", optional: true}
+          - {name: "Project", wire: "project", type: "*string", optional: true, doc: "f6a8788a"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true, doc: "b88bd5c0"}
+      operations.UpdateServerServersBilling:
+        doc: "c8c45f41"
+        enum: ["hourly", "monthly", "yearly"]
+      operations.UpdateServerServersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateServerServersAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*UpdateServerServersType", optional: true}
+      operations.UpdateServerServersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*UpdateServerServersData", optional: true}
+      operations.UpdateServerServersType:
+        enum: ["servers"]
+  Tags:
+    methods:
+      Create: {signature: "(context.Context, operations.CreateTagTagsRequestBody, ...operations.Option) (*operations.CreateTagResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DestroyTagResponse, error)"}
+      List: {signature: "(context.Context, ...operations.Option) (*operations.GetTagsResponse, error)"}
+      Update: {signature: "(context.Context, string, operations.UpdateTagTagsRequestBody, ...operations.Option) (*operations.UpdateTagResponse, error)"}
+    models:
+      components.Currency:
+        fields:
+          - {name: "Code", wire: "code", type: "*string", optional: true}
+          - {name: "CurrencyID", wire: "currency_id", type: "*int64", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.CustomTag:
+        fields:
+          - {name: "Data", wire: "data", type: "*CustomTagData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*CustomTagMeta", optional: true}
+      components.CustomTagData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CustomTagDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*CustomTagDataType", optional: true}
+      components.CustomTagDataAttributes:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true, doc: "0ae280e2"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "fc142109"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "a849a268"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "3b29f510"}
+          - {name: "Team", wire: "team", type: "*TeamInclude", optional: true}
+      components.CustomTagDataType:
+        enum: ["tags"]
+      components.CustomTagMeta:
+      components.CustomTags:
+        fields:
+          - {name: "Data", wire: "data", type: "[]CustomTagData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*CustomTagsMeta", optional: true}
+      components.CustomTagsMeta:
+      components.Limits:
+        fields:
+          - {name: "BareMetal", wire: "bare_metal", type: "*int64", optional: true}
+          - {name: "BareMetalGpu", wire: "bare_metal_gpu", type: "*int64", optional: true}
+          - {name: "BgpSessionPerIP", wire: "bgp_session_per_ip", type: "*int64", optional: true}
+          - {name: "BlockStorage", wire: "block_storage", type: "*int64", optional: true}
+          - {name: "Database", wire: "database", type: "*int64", optional: true}
+          - {name: "ElasticIP", wire: "elastic_ip", type: "*int64", optional: true}
+          - {name: "Filesystem", wire: "filesystem", type: "*int64", optional: true}
+          - {name: "PublicNetwork", wire: "public_network", type: "*int64", optional: true}
+          - {name: "VirtualMachine", wire: "virtual_machine", type: "*int64", optional: true}
+          - {name: "VirtualMachineGpu", wire: "virtual_machine_gpu", type: "*int64", optional: true}
+          - {name: "VirtualNetwork", wire: "virtual_network", type: "*int64", optional: true}
+      components.TeamInclude:
+        fields:
+          - {name: "Address", wire: "address", type: "*string", optional: true}
+          - {name: "Currency", wire: "currency", type: "*Currency", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "FeatureFlags", wire: "feature_flags", type: "[]string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Limits", wire: "limits", type: "*Limits", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      operations.CreateTagResponse:
+        fields:
+          - {name: "CustomTag", type: "*components.CustomTag", optional: true, doc: "09de135b"}
+      operations.CreateTagTagsAttributes:
+        fields:
+          - {name: "Color", wire: "color", type: "string", doc: "0ae280e2"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "fc142109"}
+          - {name: "Name", wire: "name", type: "string", doc: "a849a268"}
+      operations.CreateTagTagsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*CreateTagTagsAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "*CreateTagTagsType", optional: true}
+      operations.CreateTagTagsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*CreateTagTagsData", optional: true}
+      operations.CreateTagTagsType:
+        enum: ["tags"]
+      operations.DestroyTagResponse:
+      operations.GetTagsResponse:
+        fields:
+          - {name: "CustomTags", type: "*components.CustomTags", optional: true, doc: "6d8303b0"}
+      operations.UpdateTagResponse:
+        fields:
+          - {name: "CustomTag", type: "*components.CustomTag", optional: true, doc: "6d8303b0"}
+      operations.UpdateTagTagsAttributes:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true, doc: "0ae280e2"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "fc142109"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "a849a268"}
+      operations.UpdateTagTagsData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UpdateTagTagsAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*UpdateTagTagsType", optional: true}
+      operations.UpdateTagTagsRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "*UpdateTagTagsData", optional: true}
+      operations.UpdateTagTagsType:
+        enum: ["tags"]
+  TeamMembers:
+    methods:
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DestroyTeamMemberResponse, error)"}
+      PostTeamMembers: {signature: "(context.Context, operations.PostTeamMembersTeamMembersRequestBody, ...operations.Option) (*operations.PostTeamMembersResponse, error)"}
+    models:
+      components.Membership:
+        fields:
+          - {name: "Data", wire: "data", type: "*MembershipData", optional: true}
+      components.MembershipAttributes:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*time.Time", optional: true}
+          - {name: "Email", wire: "email", type: "*string", optional: true}
+          - {name: "FirstName", wire: "first_name", type: "*string", optional: true}
+          - {name: "LastLoginAt", wire: "last_login_at", type: "*time.Time", optional: true}
+          - {name: "LastName", wire: "last_name", type: "*string", optional: true}
+          - {name: "MfaEnabled", wire: "mfa_enabled", type: "*bool", optional: true}
+          - {name: "Role", wire: "role", type: "*MembershipRole", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*time.Time", optional: true}
+      components.MembershipData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*MembershipAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+      components.MembershipRole:
+        enum: ["administrator", "billing", "collaborator", "owner"]
+      operations.DestroyTeamMemberResponse:
+      operations.PostTeamMembersResponse:
+        fields:
+          - {name: "Membership", type: "*components.Membership", optional: true, doc: "09de135b"}
+      operations.PostTeamMembersRole:
+        enum: ["administrator", "billing", "collaborator", "owner"]
+      operations.PostTeamMembersTeamMembersAttributes:
+        fields:
+          - {name: "Email", wire: "email", type: "string"}
+          - {name: "FirstName", wire: "first_name", type: "*string", optional: true}
+          - {name: "LastName", wire: "last_name", type: "*string", optional: true}
+          - {name: "Role", wire: "role", type: "PostTeamMembersRole"}
+      operations.PostTeamMembersTeamMembersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PostTeamMembersTeamMembersAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "PostTeamMembersTeamMembersType"}
+      operations.PostTeamMembersTeamMembersRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PostTeamMembersTeamMembersData"}
+      operations.PostTeamMembersTeamMembersType:
+        enum: ["memberships"]
+  Teams.Members:
+    methods:
+      GetTeamMembers: {signature: "(context.Context, *int64, *int64, *string, ...operations.Option) (*operations.GetTeamMembersResponse, error)"}
+    models:
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.TeamMembers:
+        fields:
+          - {name: "Data", wire: "data", type: "[]TeamMembersData", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.TeamMembersAttributes:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*time.Time", optional: true}
+          - {name: "Email", wire: "email", type: "*string", optional: true}
+          - {name: "FirstName", wire: "first_name", type: "*string", optional: true}
+          - {name: "LastLoginAt", wire: "last_login_at", type: "*time.Time", optional: true}
+          - {name: "LastName", wire: "last_name", type: "*string", optional: true}
+          - {name: "MfaEnabled", wire: "mfa_enabled", type: "*bool", optional: true}
+          - {name: "Role", wire: "role", type: "*TeamMembersRole", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*time.Time", optional: true}
+      components.TeamMembersData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*TeamMembersAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.TeamMembersRole:
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      operations.GetTeamMembersResponse:
+        fields:
+          - {name: "TeamMembers", type: "*components.TeamMembers", optional: true, doc: "6d8303b0"}
+  UserData:
+    methods:
+      Create: {signature: "(context.Context, string, operations.PostProjectUserDataUserDataRequestBody, ...operations.Option) (*operations.PostProjectUserDataResponse, error)", deprecated: true}
+      CreateNew: {signature: "(context.Context, operations.PostUserDataUserDataRequestBody, ...operations.Option) (*operations.PostUserDataResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DeleteUserDataResponse, error)"}
+      DeleteProjectUserData: {signature: "(context.Context, string, string, ...operations.Option) (*operations.DeleteProjectUserDataResponse, error)", deprecated: true}
+      GetProjectUserData: {signature: "(context.Context, string, string, *string, ...operations.Option) (*operations.GetProjectUserDataResponse, error)", deprecated: true}
+      GetProjectUsersData: {signature: "(context.Context, string, *string, ...operations.Option) (*operations.GetProjectUsersDataResponse, error)", deprecated: true}
+      List: {signature: "(context.Context, operations.GetUsersDataRequest, ...operations.Option) (*operations.GetUsersDataResponse, error)"}
+      Retrieve: {signature: "(context.Context, string, *string, ...operations.Option) (*operations.GetUserDataResponse, error)"}
+      Update: {signature: "(context.Context, string, *operations.PatchUserDataUserDataRequestBody, ...operations.Option) (*operations.PatchUserDataResponse, error)"}
+      UpdateForProject: {signature: "(context.Context, string, string, *operations.PutProjectUserDataUserDataRequestBody, ...operations.Option) (*operations.PutProjectUserDataResponse, error)", deprecated: true}
+    models:
+      components.Billing:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.ProjectInclude:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Billing", wire: "billing", type: "*Billing", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*string", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Stats", wire: "stats", type: "*ProjectIncludeStats", optional: true}
+      components.ProjectIncludeStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*int64", optional: true}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*int64", optional: true}
+          - {name: "Prefixes", wire: "prefixes", type: "*int64", optional: true}
+          - {name: "Servers", wire: "servers", type: "*int64", optional: true}
+          - {name: "Storages", wire: "storages", type: "*int64", optional: true}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*int64", optional: true}
+          - {name: "Vlans", wire: "vlans", type: "*int64", optional: true}
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      components.UserData:
+        fields:
+          - {name: "Data", wire: "data", type: "[]UserDataProperties", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      components.UserDataObject:
+        fields:
+          - {name: "Data", wire: "data", type: "*UserDataProperties", optional: true}
+          - {name: "Meta", wire: "meta", type: "*UserDataObjectMeta", optional: true}
+      components.UserDataObjectMeta:
+      components.UserDataProperties:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*UserDataPropertiesAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "UserDataPropertiesType"}
+      components.UserDataPropertiesAttributes:
+        fields:
+          - {name: "Content", wire: "content", type: "*string", optional: true, doc: "ced14265"}
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "DecodedContent", wire: "decoded_content", type: "*string", optional: true, doc: "1bb07bd3"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "beda2ad0"}
+          - {name: "Project", wire: "project", type: "*ProjectInclude", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+      components.UserDataPropertiesType:
+        enum: ["user_data"]
+      operations.DeleteProjectUserDataResponse:
+      operations.DeleteUserDataResponse:
+      operations.GetProjectUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "6d8303b0"}
+      operations.GetProjectUsersDataResponse:
+        fields:
+          - {name: "UserData", type: "*components.UserData", optional: true, doc: "6d8303b0"}
+      operations.GetUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "6d8303b0"}
+      operations.GetUsersDataRequest:
+        fields:
+          - {name: "ExtraFieldsUserData", wire: "extra_fields[user_data]", type: "*string", optional: true, default: "decoded_content", doc: "2fc6c47d"}
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "b2158adf"}
+          - {name: "FilterScope", wire: "filter[scope]", type: "*string", optional: true, doc: "ab095311"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.GetUsersDataResponse:
+        fields:
+          - {name: "UserData", type: "*components.UserData", optional: true, doc: "6d8303b0"}
+      operations.PatchUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "6d8303b0"}
+      operations.PatchUserDataUserDataAttributes:
+        fields:
+          - {name: "Content", wire: "content", type: "*string", optional: true, doc: "d5aa3b1b"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "e5cf3734"}
+      operations.PatchUserDataUserDataData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PatchUserDataUserDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "PatchUserDataUserDataType"}
+      operations.PatchUserDataUserDataRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PatchUserDataUserDataData"}
+      operations.PatchUserDataUserDataType:
+        enum: ["user_data"]
+      operations.PostProjectUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "09de135b"}
+      operations.PostProjectUserDataUserDataAttributes:
+        fields:
+          - {name: "Content", wire: "content", type: "string", doc: "d662b28c"}
+          - {name: "Description", wire: "description", type: "string", doc: "beda2ad0"}
+      operations.PostProjectUserDataUserDataData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PostProjectUserDataUserDataAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "PostProjectUserDataUserDataType"}
+      operations.PostProjectUserDataUserDataRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PostProjectUserDataUserDataData"}
+      operations.PostProjectUserDataUserDataType:
+        enum: ["user_data"]
+      operations.PostUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "09de135b"}
+      operations.PostUserDataUserDataAttributes:
+        fields:
+          - {name: "Content", wire: "content", type: "string", doc: "d662b28c"}
+          - {name: "Description", wire: "description", type: "string", doc: "beda2ad0"}
+          - {name: "Project", wire: "project", type: "*string", optional: true, doc: "b2158adf"}
+      operations.PostUserDataUserDataData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PostUserDataUserDataAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "PostUserDataUserDataType"}
+      operations.PostUserDataUserDataRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PostUserDataUserDataData"}
+      operations.PostUserDataUserDataType:
+        enum: ["user_data"]
+      operations.PutProjectUserDataResponse:
+        fields:
+          - {name: "UserDataObject", type: "*components.UserDataObject", optional: true, doc: "6d8303b0"}
+      operations.PutProjectUserDataUserDataAttributes:
+        fields:
+          - {name: "Content", wire: "content", type: "*string", optional: true, doc: "d5aa3b1b"}
+          - {name: "Description", wire: "description", type: "*string", optional: true, doc: "e5cf3734"}
+      operations.PutProjectUserDataUserDataData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*PutProjectUserDataUserDataAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "PutProjectUserDataUserDataType"}
+      operations.PutProjectUserDataUserDataRequestBody:
+        fields:
+          - {name: "Data", wire: "data", type: "PutProjectUserDataUserDataData"}
+      operations.PutProjectUserDataUserDataType:
+        enum: ["user_data"]
+  VirtualMachines:
+    methods:
+      Create: {signature: "(context.Context, components.VirtualMachinePayload, ...operations.Option) (*operations.CreateVirtualMachineResponse, error)"}
+      CreateVirtualMachineAction: {signature: "(context.Context, string, operations.CreateVirtualMachineActionVirtualMachinesRequestBody, ...operations.Option) (*operations.CreateVirtualMachineActionResponse, error)"}
+      CreateVirtualMachineNetworkAttachment: {signature: "(context.Context, string, components.VirtualMachineNetworkAttachmentCreatePayload, ...operations.Option) (*operations.CreateVirtualMachineNetworkAttachmentResponse, error)"}
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DestroyVirtualMachineResponse, error)"}
+      DestroyVirtualMachineNetworkAttachment: {signature: "(context.Context, string, string, ...operations.Option) (*operations.DestroyVirtualMachineNetworkAttachmentResponse, error)"}
+      Get: {signature: "(context.Context, string, *string, ...operations.Option) (*operations.ShowVirtualMachineResponse, error)"}
+      List: {signature: "(context.Context, operations.IndexVirtualMachineRequest, ...operations.Option) (*operations.IndexVirtualMachineResponse, error)"}
+      ListVirtualMachineNetworkAttachments: {signature: "(context.Context, string, ...operations.Option) (*operations.ListVirtualMachineNetworkAttachmentsResponse, error)"}
+      ShowVirtualMachineMetrics: {signature: "(context.Context, string, operations.Metric, *operations.Range, *bool, ...operations.Option) (*operations.ShowVirtualMachineMetricsResponse, error)"}
+      UpdateVirtualMachine: {signature: "(context.Context, string, components.VirtualMachineUpdatePayload, ...operations.Option) (*operations.UpdateVirtualMachineResponse, error)"}
+    models:
+      components.Billing:
+        fields:
+          - {name: "Method", wire: "method", type: "*string", optional: true}
+          - {name: "SubscriptionID", wire: "subscription_id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*string", optional: true}
+      components.Currency:
+        fields:
+          - {name: "Code", wire: "code", type: "*string", optional: true}
+          - {name: "CurrencyID", wire: "currency_id", type: "*int64", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.Limits:
+        fields:
+          - {name: "BareMetal", wire: "bare_metal", type: "*int64", optional: true}
+          - {name: "BareMetalGpu", wire: "bare_metal_gpu", type: "*int64", optional: true}
+          - {name: "BgpSessionPerIP", wire: "bgp_session_per_ip", type: "*int64", optional: true}
+          - {name: "BlockStorage", wire: "block_storage", type: "*int64", optional: true}
+          - {name: "Database", wire: "database", type: "*int64", optional: true}
+          - {name: "ElasticIP", wire: "elastic_ip", type: "*int64", optional: true}
+          - {name: "Filesystem", wire: "filesystem", type: "*int64", optional: true}
+          - {name: "PublicNetwork", wire: "public_network", type: "*int64", optional: true}
+          - {name: "VirtualMachine", wire: "virtual_machine", type: "*int64", optional: true}
+          - {name: "VirtualMachineGpu", wire: "virtual_machine_gpu", type: "*int64", optional: true}
+          - {name: "VirtualNetwork", wire: "virtual_network", type: "*int64", optional: true}
+      components.Metric:
+        enum: ["cpu", "disk", "memory", "network"]
+      components.PaginationMeta:
+        fields:
+          - {name: "Stats", wire: "stats", type: "*Stats", optional: true}
+      components.Points:
+        fields:
+          - {name: "Timestamp", wire: "timestamp", type: "*time.Time", optional: true, doc: "3eca287d"}
+          - {name: "Value", wire: "value", type: "*float64", optional: true, doc: "bce86d79"}
+      components.ProjectInclude:
+        fields:
+          - {name: "BandwidthAlert", wire: "bandwidth_alert", type: "*bool", optional: true}
+          - {name: "Billing", wire: "billing", type: "*Billing", optional: true}
+          - {name: "BillingMethod", wire: "billing_method", type: "*string", optional: true}
+          - {name: "BillingType", wire: "billing_type", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "Environment", wire: "environment", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "ProvisioningType", wire: "provisioning_type", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Stats", wire: "stats", type: "*ProjectIncludeStats", optional: true}
+      components.ProjectIncludeStats:
+        fields:
+          - {name: "Databases", wire: "databases", type: "*int64", optional: true}
+          - {name: "IPAddresses", wire: "ip_addresses", type: "*int64", optional: true}
+          - {name: "Prefixes", wire: "prefixes", type: "*int64", optional: true}
+          - {name: "Servers", wire: "servers", type: "*int64", optional: true}
+          - {name: "Storages", wire: "storages", type: "*int64", optional: true}
+          - {name: "VirtualMachines", wire: "virtual_machines", type: "*int64", optional: true}
+          - {name: "Vlans", wire: "vlans", type: "*int64", optional: true}
+      components.Range:
+        enum: ["15m", "1h", "24h", "5m"]
+      components.Stats:
+        fields:
+          - {name: "Total", wire: "total", type: "*Total", optional: true}
+      components.TeamInclude:
+        fields:
+          - {name: "Address", wire: "address", type: "*string", optional: true}
+          - {name: "Currency", wire: "currency", type: "*Currency", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "FeatureFlags", wire: "feature_flags", type: "[]string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Limits", wire: "limits", type: "*Limits", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      components.Total:
+        fields:
+          - {name: "Count", wire: "count", type: "*int64", optional: true, doc: "892c1421"}
+      components.Unit:
+        doc: "e5f59b43"
+        enum: ["bytes_per_second", "percent"]
+      components.VirtualMachine:
+        fields:
+          - {name: "Data", wire: "data", type: "*VirtualMachineAttributes", optional: true}
+          - {name: "Meta", wire: "meta", type: "*VirtualMachineMeta", optional: true}
+      components.VirtualMachineAttributes:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*VirtualMachineAttributesAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "*VirtualMachineAttributesType", optional: true}
+      components.VirtualMachineAttributesAttributes:
+        fields:
+          - {name: "Billing", wire: "billing", type: "*string", optional: true}
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Credentials", wire: "credentials", type: "*VirtualMachineAttributesCredentials", optional: true, doc: "79270dd3"}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*VirtualMachineAttributesOperatingSystem", optional: true, doc: "b7f3fa66"}
+          - {name: "PendingRestart", wire: "pending_restart", type: "*bool", optional: true, doc: "3dd4819b"}
+          - {name: "Plan", wire: "plan", type: "*VirtualMachineAttributesPlan", optional: true}
+          - {name: "PrimaryIpv4", wire: "primary_ipv4", type: "*string", optional: true}
+          - {name: "Project", wire: "project", type: "*ProjectInclude", optional: true}
+          - {name: "Site", wire: "site", type: "*string", optional: true}
+          - {name: "Specs", wire: "specs", type: "*VirtualMachineAttributesSpecs", optional: true}
+          - {name: "Status", wire: "status", type: "*string", optional: true, doc: "e05e6061"}
+          - {name: "Tags", wire: "tags", type: "[]VirtualMachineAttributesTags", optional: true}
+          - {name: "Team", wire: "team", type: "*TeamInclude", optional: true}
+          - {name: "UserData", wire: "user_data", type: "*string", optional: true, doc: "60030e58"}
+      components.VirtualMachineAttributesCredentials:
+        doc: "e1f6e6f1"
+        fields:
+          - {name: "Host", wire: "host", type: "*string", optional: true}
+          - {name: "Password", wire: "password", type: "*string", optional: true}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]VirtualMachineAttributesSSHKeys", optional: true}
+          - {name: "Username", wire: "username", type: "*string", optional: true, doc: "ff3ea41a"}
+      components.VirtualMachineAttributesDistro:
+        doc: "d1281074"
+        fields:
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "1e58f405"}
+          - {name: "Series", wire: "series", type: "*string", optional: true, doc: "c9fce3eb"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "914acbad"}
+      components.VirtualMachineAttributesFeatures:
+        doc: "c0abe792"
+        fields:
+          - {name: "Raid", wire: "raid", type: "*bool", optional: true, doc: "cb4c3f4c"}
+          - {name: "Rescue", wire: "rescue", type: "*bool", optional: true, doc: "43dbb840"}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "*bool", optional: true, doc: "2ac4f8f4"}
+          - {name: "UserData", wire: "user_data", type: "*bool", optional: true, doc: "04385407"}
+          - {name: "Workflow", wire: "workflow", type: "*bool", optional: true, doc: "d6f6f7fb"}
+      components.VirtualMachineAttributesOperatingSystem:
+        doc: "cff6909c"
+        fields:
+          - {name: "Distro", wire: "distro", type: "*VirtualMachineAttributesDistro", optional: true, doc: "6a864e11"}
+          - {name: "Features", wire: "features", type: "*VirtualMachineAttributesFeatures", optional: true, doc: "cb7e42fd"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "e251d0fe"}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true, doc: "1773c983"}
+          - {name: "Version", wire: "version", type: "*string", optional: true, doc: "c2068596"}
+      components.VirtualMachineAttributesPlan:
+        fields:
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "Slug", wire: "slug", type: "*string", optional: true}
+      components.VirtualMachineAttributesSSHKeys:
+        fields:
+          - {name: "CreatedAt", wire: "created_at", type: "*string", optional: true}
+          - {name: "Fingerprint", wire: "fingerprint", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+          - {name: "PublicKey", wire: "public_key", type: "*string", optional: true}
+          - {name: "UpdatedAt", wire: "updated_at", type: "*string", optional: true}
+      components.VirtualMachineAttributesSpecs:
+        fields:
+          - {name: "Gpu", wire: "gpu", type: "*string", optional: true}
+          - {name: "Nic", wire: "nic", type: "*string", optional: true}
+          - {name: "RAM", wire: "ram", type: "*string", optional: true}
+          - {name: "Storage", wire: "storage", type: "*string", optional: true}
+          - {name: "Vcpu", wire: "vcpu", type: "*int64", optional: true}
+      components.VirtualMachineAttributesTags:
+        fields:
+          - {name: "Color", wire: "color", type: "*string", optional: true}
+          - {name: "Description", wire: "description", type: "*string", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Name", wire: "name", type: "*string", optional: true}
+      components.VirtualMachineAttributesType:
+        enum: ["virtual_machines"]
+      components.VirtualMachineMeta:
+      components.VirtualMachineMetrics:
+        fields:
+          - {name: "Metric", wire: "metric", type: "*Metric", optional: true}
+          - {name: "Points", wire: "points", type: "[]Points", optional: true}
+          - {name: "Range", wire: "range", type: "*Range", optional: true}
+          - {name: "Step", wire: "step", type: "*string", optional: true, doc: "d5c0a0d8"}
+          - {name: "Unit", wire: "unit", type: "*Unit", optional: true, doc: "e5f59b43"}
+      components.VirtualMachineNetworkAttachmentCreatePayload:
+        fields:
+          - {name: "Data", wire: "data", type: "VirtualMachineNetworkAttachmentCreatePayloadData"}
+      components.VirtualMachineNetworkAttachmentCreatePayloadAttributes:
+        fields:
+          - {name: "VirtualNetworkID", wire: "virtual_network_id", type: "string", doc: "a3f3477b"}
+      components.VirtualMachineNetworkAttachmentCreatePayloadData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "VirtualMachineNetworkAttachmentCreatePayloadAttributes"}
+          - {name: "Type", wire: "type", type: "VirtualMachineNetworkAttachmentCreatePayloadType"}
+      components.VirtualMachineNetworkAttachmentCreatePayloadType:
+        enum: ["virtual_machine_network_attachments"]
+      components.VirtualMachineNetworkAttachmentResource:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*VirtualMachineNetworkAttachmentResourceAttributes", optional: true}
+          - {name: "ID", wire: "id", type: "*string", optional: true, doc: "fcd87e30"}
+          - {name: "Type", wire: "type", type: "*VirtualMachineNetworkAttachmentResourceType", optional: true}
+      components.VirtualMachineNetworkAttachmentResourceAttributes:
+        fields:
+          - {name: "PendingRestart", wire: "pending_restart", type: "*bool", optional: true, doc: "32f18754"}
+          - {name: "Vid", wire: "vid", type: "*int64", optional: true, doc: "138fb34c"}
+          - {name: "VirtualNetworkID", wire: "virtual_network_id", type: "*string", optional: true, doc: "11508689"}
+      components.VirtualMachineNetworkAttachmentResourceType:
+        enum: ["virtual_machine_network_attachments"]
+      components.VirtualMachineNetworkAttachments:
+        fields:
+          - {name: "Data", wire: "data", type: "[]VirtualMachineNetworkAttachmentResource", optional: true}
+      components.VirtualMachinePayload:
+        fields:
+          - {name: "Data", wire: "data", type: "*VirtualMachinePayloadData", optional: true}
+      components.VirtualMachinePayloadAttributes:
+        fields:
+          - {name: "Billing", wire: "billing", type: "*VirtualMachinePayloadBilling", optional: true, doc: "866f42bf"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, default: "my-vm"}
+          - {name: "OperatingSystem", wire: "operating_system", type: "*string", optional: true, doc: "a693e30e"}
+          - {name: "Plan", wire: "plan", type: "*string", optional: true, doc: "668b675e"}
+          - {name: "Project", wire: "project", type: "*string", optional: true, default: "my-project"}
+          - {name: "SSHKeys", wire: "ssh_keys", type: "[]string", optional: true}
+          - {name: "Site", wire: "site", type: "*string", optional: true, default: "DAL", doc: "ec37f334"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true, doc: "09b8f04a"}
+          - {name: "UserData", wire: "user_data", type: "*VirtualMachinePayloadUserData", optional: true, doc: "3733d195"}
+      components.VirtualMachinePayloadBilling:
+        doc: "aea1ae2f"
+        enum: ["hourly", "monthly", "yearly"]
+      components.VirtualMachinePayloadData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "*VirtualMachinePayloadAttributes", optional: true}
+          - {name: "Type", wire: "type", type: "*VirtualMachinePayloadType", optional: true}
+      components.VirtualMachinePayloadType:
+        enum: ["virtual_machines"]
+      components.VirtualMachinePayloadUserData:
+        doc: "f9a5658b"
+        fields:
+          - {name: "Integer", type: "*int64", optional: true}
+          - {name: "Str", type: "*string", optional: true}
+          - {name: "Type", type: "VirtualMachinePayloadUserDataType"}
+      components.VirtualMachinePayloadUserDataType:
+        enum: ["integer", "str"]
+      components.VirtualMachineUpdatePayload:
+        fields:
+          - {name: "Data", wire: "data", type: "VirtualMachineUpdatePayloadData"}
+      components.VirtualMachineUpdatePayloadAttributes:
+        fields:
+          - {name: "Billing", wire: "billing", type: "*VirtualMachineUpdatePayloadBilling", optional: true, doc: "e287eff8"}
+          - {name: "Name", wire: "name", type: "*string", optional: true, doc: "51ced643"}
+          - {name: "Plan", wire: "plan", type: "*string", optional: true, doc: "2b084285"}
+          - {name: "Tags", wire: "tags", type: "[]string", optional: true, doc: "0fb5cc8c"}
+      components.VirtualMachineUpdatePayloadBilling:
+        doc: "5113d24f"
+        enum: ["hourly", "monthly", "yearly"]
+      components.VirtualMachineUpdatePayloadData:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "VirtualMachineUpdatePayloadAttributes"}
+          - {name: "ID", wire: "id", type: "*string", optional: true}
+          - {name: "Type", wire: "type", type: "VirtualMachineUpdatePayloadType"}
+      components.VirtualMachineUpdatePayloadType:
+        enum: ["virtual_machines"]
+      components.VirtualMachines:
+        fields:
+          - {name: "Data", wire: "data", type: "[]VirtualMachineAttributes", optional: true}
+          - {name: "Meta", wire: "meta", type: "*PaginationMeta", optional: true}
+      operations.CreateVirtualMachineActionResponse:
+      operations.CreateVirtualMachineActionVirtualMachinesAction:
+        doc: "d23f2ee8"
+        enum: ["power_off", "power_on", "reboot"]
+      operations.CreateVirtualMachineActionVirtualMachinesAttributes:
+        fields:
+          - {name: "Action", wire: "action", type: "CreateVirtualMachineActionVirtualMachinesAction", doc: "91189ef6"}
+      operations.CreateVirtualMachineActionVirtualMachinesRequestBody:
+        fields:
+          - {name: "Attributes", wire: "attributes", type: "CreateVirtualMachineActionVirtualMachinesAttributes"}
+          - {name: "ID", wire: "id", type: "string"}
+          - {name: "Type", wire: "type", type: "CreateVirtualMachineActionVirtualMachinesType"}
+      operations.CreateVirtualMachineActionVirtualMachinesType:
+        enum: ["virtual_machines"]
+      operations.CreateVirtualMachineNetworkAttachmentMeta:
+        fields:
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      operations.CreateVirtualMachineNetworkAttachmentResponse:
+        fields:
+          - {name: "Object", type: "*CreateVirtualMachineNetworkAttachmentResponseBody", optional: true, doc: "41d09a60"}
+      operations.CreateVirtualMachineNetworkAttachmentResponseBody:
+        doc: "5d30f68d"
+        fields:
+          - {name: "Meta", wire: "meta", type: "*CreateVirtualMachineNetworkAttachmentMeta", optional: true}
+      operations.CreateVirtualMachineResponse:
+        fields:
+          - {name: "VirtualMachine", type: "*components.VirtualMachine", optional: true, doc: "09de135b"}
+      operations.DestroyVirtualMachineNetworkAttachmentMeta:
+        fields:
+          - {name: "Status", wire: "status", type: "*string", optional: true}
+      operations.DestroyVirtualMachineNetworkAttachmentResponse:
+        fields:
+          - {name: "Object", type: "*DestroyVirtualMachineNetworkAttachmentResponseBody", optional: true, doc: "41d09a60"}
+      operations.DestroyVirtualMachineNetworkAttachmentResponseBody:
+        doc: "a3715145"
+        fields:
+          - {name: "Meta", wire: "meta", type: "*DestroyVirtualMachineNetworkAttachmentMeta", optional: true}
+      operations.DestroyVirtualMachineResponse:
+      operations.IndexVirtualMachineRequest:
+        fields:
+          - {name: "ExtraFieldsVirtualMachines", wire: "extra_fields[virtual_machines]", type: "*string", optional: true, doc: "202e8713"}
+          - {name: "FilterProject", wire: "filter[project]", type: "*string", optional: true, doc: "42805174"}
+          - {name: "FilterTags", wire: "filter[tags]", type: "*string", optional: true, doc: "b48e5c50"}
+          - {name: "PageNumber", wire: "page[number]", type: "*int64", optional: true, default: "1", doc: "52d4faa2"}
+          - {name: "PageSize", wire: "page[size]", type: "*int64", optional: true, default: "20", doc: "5cd3806e"}
+          - {name: "Sort", wire: "sort", type: "*string", optional: true, doc: "86abf616"}
+          - {name: "StatsTotal", wire: "stats[total]", type: "*string", optional: true, doc: "186835ea"}
+      operations.IndexVirtualMachineResponse:
+        fields:
+          - {name: "VirtualMachines", type: "*components.VirtualMachines", optional: true, doc: "6d8303b0"}
+      operations.ListVirtualMachineNetworkAttachmentsResponse:
+        fields:
+          - {name: "VirtualMachineNetworkAttachments", type: "*components.VirtualMachineNetworkAttachments", optional: true, doc: "6d8303b0"}
+      operations.Metric:
+        enum: ["cpu", "disk", "memory", "network"]
+      operations.Range:
+        enum: ["15m", "1h", "24h", "5m"]
+      operations.ShowVirtualMachineMetricsResponse:
+        fields:
+          - {name: "VirtualMachineMetrics", type: "*components.VirtualMachineMetrics", optional: true, doc: "6d8303b0"}
+      operations.ShowVirtualMachineResponse:
+        fields:
+          - {name: "VirtualMachine", type: "*components.VirtualMachine", optional: true, doc: "6d8303b0"}
+      operations.UpdateVirtualMachineResponse:
+        fields:
+          - {name: "VirtualMachine", type: "*components.VirtualMachine", optional: true, doc: "6d8303b0"}
+  VirtualNetworks:
+    methods:
+      Delete: {signature: "(context.Context, string, ...operations.Option) (*operations.DestroyVirtualNetworkResponse, error)"}
+    models:
+      operations.DestroyVirtualNetworkResponse:


### PR DESCRIPTION
### Summary

Closes DX-130.

The coverage system (sdk-coverage.yaml + `TestProviderSDKCoverage` + the sdk-watch pipeline) works at group + method granularity and was documented as blind to changes *inside* a covered group — "a new field on an existing resource is invisible here". This closes that gap end to end:

- **Detection** — `internal/sdkcoverage` gains a field-level parser (same go/ast, offline, module-cache approach as the group walk): fields with types, wire names, optionality, `default:` tags, doc hashes, enum values, and method signatures for every covered group. `sdk-fields.lock.yaml` is the committed, byte-stable, go.sum-style baseline (seeded from the pinned v1.19.12); `sdkcoverage drift` diffs any SDK tree against it.
- **Gate** — `TestProviderSDKFieldDrift` runs on every PR and fails **only on breaking drift** (field removed/retyped, required↔optional flip, enum value removed, method removed/re-signed). Additive drift is informational, mirroring the pending-groups philosophy. `sdkcoverage check` agrees.
- **Watch** — the weekly detect job emits `drift.json` (latest SDK vs lock); the tracking issue gains a "Field drift on covered groups" section with suggested attribute names; the issue's close condition accounts for drift and for a crashed drift report.
- **Drift-fix agent** — a scaffold-style job turns drift into draft PRs for **all** drift kinds, with a `[!WARNING]` block when rows are breaking. All breaking groups ride in one PR (the gate checks the whole surface, so one-at-a-time could never go green). The lock is only ever synced surgically (`fields -write -group`), and the gate verifies the lock diff stays scoped to the target groups; the scaffold job now seeds the lock entry for each newly covered group.

Validated against the real v1.19.17 SDK: 51 drift rows, 10 breaking — including the known `FirewallServerType` enum rename and previously uncatalogued breaking changes (Server `status` enum→`*string`, `xfs` removed from the filesystem enums, the `UpdateServerDeployConfig` envelope restructure). Those will fail the first SDK bump until reconciled — that is the point.

Deferred, tracked in DX-130: an eval case for the drift prompt (`eval/cases/field_drift/`) and the `SchemaByKind` "appears mapped" annotation.

### Testing

```bash
go test ./...
make drift-report      # zero drift against the pinned SDK
make coverage-check
```

Real drift against a newer SDK (expect 51 rows, 10 breaking):

```bash
dir=$(go mod download -json github.com/latitudesh/latitudesh-go-sdk@v1.19.17 | jq -r '.Dir')
go run ./cmd/sdkcoverage drift -sdk-dir "$dir" -format text
```

Acceptance-cycle simulation (drift appears, per-group sync restores byte-identically):

```bash
perl -i -ne 'print unless /"bgp_ready"/' sdk-fields.lock.yaml
make drift-report                                      # 1 informational row
go run ./cmd/sdkcoverage fields -write -group Servers  # accept just that group
git diff sdk-fields.lock.yaml                          # empty
```

After merge, the sdk-watch changes can be exercised with `gh workflow run sdk-watch.yml -f dry_run=true` (renders the tracking issue to the run summary without writing).










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds field-level SDK coverage locking, drift detection, reporting, validation, and automated reconciliation for already-covered SDK groups.
- Parses SDK fields, methods, documentation, defaults, and enum values into a stable lock file.
- Distinguishes breaking drift from informational additions in tests and CLI checks.
- Extends the weekly SDK-watch workflow to report drift and generate reconciliation pull requests.
- Hardens agent finalization by resetting Git metadata before minting the write token and preventing token-bearing execution of repository code.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  SDK[Latest SDK] --> DETECT[Parse covered groups and fields]
  LOCK[sdk-fields.lock.yaml] --> DIFF[Compare SDK surface with lock]
  DETECT --> DIFF
  DIFF -->|No drift| CLEAN[Coverage check passes]
  DIFF -->|Informational drift| ISSUE[Update tracking issue]
  DIFF -->|Breaking drift| GATE[Fail pinned-SDK field-drift gate]
  ISSUE --> FIX[Drift-fix agent]
  GATE --> FIX
  FIX --> VALIDATE[Validate scoped mapping and lock changes]
  VALIDATE --> RESET[Reset Git hooks and configuration]
  RESET --> TOKEN[Mint installation token]
  TOKEN --> PR[Push branch and open reconciliation PR]
```

<sub>Reviews (5): Last reviewed commit: ["fix(ci): regenerate git config from scra..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/03c92c1edee74e99d9005c4fdece5a1d17900a3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58037115)</sub>

<!-- /greptile_comment -->