### PR TITLE
fix(gate): drift mode checks docs generation idempotence, not index cleanliness

### DIFF
--- a/.github/prompts/fix-field-drift.md
+++ b/.github/prompts/fix-field-drift.md
@@ -1,5 +1,5 @@
 ---
-prompt-version: 1
+prompt-version: 2
 ---
 
 # Map field drift on covered latitudesh-go-sdk service group(s)
@@ -114,8 +114,9 @@ resource — name it in the handoff and in `notes:` under `{{GROUP}}` in
   `*_test.go` (offline tier at minimum — plain `go test ./latitudesh` must stay
   green, no TF_ACC, no token).
 - Never add a `go:generate` directive, never reach the network, never write a
-  token or key anywhere, never hand-edit `docs/` — edit the template and let the
-  gate regenerate.
+  token or key anywhere, never hand-edit `docs/` — schema and template changes
+  reach `docs/` only through `go generate ./...`, which you run yourself (see
+  Finish).
 
 ## Finish: lock, handoff, gate
 
@@ -124,9 +125,13 @@ resource — name it in the handoff and in `notes:` under `{{GROUP}}` in
    The lock's git diff is the record of what this PR accepted — every deliberate
    omission must also be explained in `notes:` under its group in
    `sdk-coverage.yaml`. The gate verifies the lock changed nowhere else.
-2. **Write the handoff block below to `/tmp/drift-handoff.md` as soon as your
+2. Regenerate the docs after any schema or template change:
+   `go generate ./...`. Changed schema descriptions rewrite tracked files under
+   `docs/` — those regenerated files belong in your change, and the gate fails
+   if generation still produces something you did not keep.
+3. **Write the handoff block below to `/tmp/drift-handoff.md` as soon as your
    first edit builds, and keep it current.**
-3. Run the gate and fix what it reports:
+4. Run the gate and fix what it reports:
 
 ```
 scripts/scaffold-validate.sh --mode drift --group {{GROUP}}

--- a/scripts/scaffold-validate.sh
+++ b/scripts/scaffold-validate.sh
@@ -268,9 +268,18 @@ fi
 
 # ------------------------------------------------------------ 8. docs reproduce --
 # docs/ is generated from templates/ plus the schema. A hand-edit to docs/ is
-# silently lost on the next generate, so the committed docs must be exactly what
-# generation produces.
+# silently lost on the next generate, so the docs in the change must be exactly
+# what generation produces.
 step "8/9 docs reproduce"
+
+# docsState fingerprints the full content of docs/, tracked or not — git diff
+# alone cannot express "generation changed nothing", because it compares
+# against the index, not against the tree generation just ran on.
+docsState() {
+	find docs -type f | LC_ALL=C sort | xargs git hash-object | git hash-object --stdin
+}
+
+docs_before=$(docsState)
 # Capture output and replay it on failure: tfplugindocs fails loudly for real
 # reasons (a missing example file, a bad template) and swallowing that turns an
 # actionable error into a bare "go generate failed".
@@ -278,9 +287,23 @@ if ! generate_out=$(go generate ./... 2>&1); then
 	printf '%s\n' "$generate_out" >&2
 	fail "go generate failed"
 fi
-if ! git diff --quiet -- docs/; then
-	git --no-pager diff --stat -- docs/ >&2
-	fail "docs/ is out of sync with templates/ — edit the template, not the rendered doc, then regenerate"
+if [ "$MODE" = "drift" ]; then
+	# A drift change edits an EXISTING resource's schema, which legitimately
+	# rewrites tracked docs — so comparing docs/ against the committed state
+	# (the scaffold branch below) could never pass here, no matter how correct
+	# the change. What must hold instead is IDEMPOTENCE: the gate's own
+	# generate run changes nothing further. Stale docs (schema changed, docs
+	# never regenerated) and hand-edited docs both fail — and both are fixed by
+	# running `go generate ./...` and re-running this gate.
+	if [ "$docs_before" != "$(docsState)" ]; then
+		git --no-pager diff --stat -- docs/ >&2
+		fail "docs/ was not regenerated after the mapping change — run 'go generate ./...' and keep the updated docs in the change"
+	fi
+else
+	if ! git diff --quiet -- docs/; then
+		git --no-pager diff --stat -- docs/ >&2
+		fail "docs/ is out of sync with templates/ — edit the template, not the rendered doc, then regenerate"
+	fi
 fi
 echo "ok: docs regenerate with no drift"
 


### PR DESCRIPTION
### Summary

Related to DX-130. Fixes the failure observed in [sdk-watch run #8](https://github.com/latitudesh/terraform-provider-latitudesh/actions/runs/33208959259): the first real drift-fix run reconciled `Firewalls.Assignments,Servers` against v1.19.17 and passed gate steps 1–7, then died on step 8.

Step 8's check (`go generate` + `git diff --quiet -- docs/`) compares the tree against the index. That works for scaffolding — new docs are untracked and invisible to the diff — but is structurally impossible to satisfy in drift mode: editing an existing resource's schema legitimately rewrites a tracked doc, and that diff never goes quiet, even for a perfect change.

- `scripts/scaffold-validate.sh` — in drift mode, step 8 now checks generation **idempotence**: the docs content is fingerprinted before and after the gate's own `go generate`; if generation still changes anything, the docs were not regenerated (or were hand-edited) and the gate fails with the actionable message. Scaffold mode keeps the original committed-state check.
- `.github/prompts/fix-field-drift.md` (v2) — the Finish sequence now explicitly instructs the agent to run `go generate ./...` after schema/template changes and keep the regenerated docs in the change; the misleading "let the gate regenerate" wording is gone.

### Testing

```bash
bash -n scripts/scaffold-validate.sh
go test ./...
```

The three drift-mode scenarios, exercised locally:

```bash
docsState() { find docs -type f | LC_ALL=C sort | xargs git hash-object | git hash-object --stdin; }

# clean tree: generation is idempotent (gate passes)
b=$(docsState); go generate ./...; [ "$b" = "$(docsState)" ] && echo pass

# stale docs (template/schema edited, docs not regenerated): first run detects it (gate fails)
echo '<!-- sim -->' >> templates/resources/server.md.tmpl
b=$(docsState); go generate ./...; [ "$b" != "$(docsState)" ] && echo detected

# regenerated docs kept: second run is stable (gate passes)
b=$(docsState); go generate ./...; [ "$b" = "$(docsState)" ] && echo stable
git checkout templates docs
```

After merge, re-dispatch `sdk-watch.yml` with no inputs: the drift-fix job re-runs the reconciliation and the gate now lets the PR open.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes drift-mode documentation validation from index cleanliness to generation idempotence and updates the drift-fix prompt to require agents to regenerate and retain documentation.

- Fingerprints the complete docs tree before and after `go generate ./...` in drift mode.
- Preserves the existing committed-state check for scaffold mode.
- Clarifies that schema and template changes must be followed by explicit documentation generation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code failure remains.

Drift mode now tests whether documentation generation is stable without rejecting legitimate tracked documentation changes, while scaffold mode retains its original index-based check and the workflow stages generated docs for the resulting PR.
</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start validation step 8] --> B[Fingerprint docs tree]
    B --> C[Run go generate ./...]
    C --> D{Generation succeeded?}
    D -- No --> E[Fail with generator output]
    D -- Yes --> F{Drift mode?}
    F -- Yes --> G{Before and after fingerprints equal?}
    G -- No --> H[Fail: regenerated docs were not retained]
    G -- Yes --> I[Pass docs reproduction]
    F -- No --> J{docs differs from index?}
    J -- Yes --> K[Fail: docs out of sync]
    J -- No --> I
```

<sub>Reviews (1): Last reviewed commit: ["fix(gate): drift mode checks docs genera..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/90352ed19c16bc626960efa5558ba217602b8f6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58063300)</sub>

<!-- /greptile_comment -->