### PR TITLE
chore(scaffold): exclude paused/deprecated SDK groups and fix generated-PR example

### DIFF
--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -1624,19 +1624,19 @@ jobs:
           export LATITUDESH_AUTH_TOKEN="<your-api-token>"
           ```
 
-          **2. Test project** (ID or slug; used as the provider-level default — harmless for resources that do not take a project):
+          **2. Test project** (ID or slug; fills the example's `project` variable and the provider-level default):
 
           ```bash
-          export LATITUDESH_PROJECT="<test-project-id-or-slug>"
+          export TF_VAR_project="<test-project-id-or-slug>"
           ```
 
-          **3. Build this branch and apply the example:**
+          **3. Build this branch and apply the example.** `make build` drops the provider binary at the repo root — don't `make install`. `dev_overrides` is active, so there is no `terraform init` and `plan`/`apply` print an overrides warning. The example is inlined below so you can tweak names and values before applying; the gate enforces it self-contained, so any helper resources it declares are created on apply too.
 
           ```bash
           workdir=$(mktemp -d)
           git clone --depth 1 --branch __BRANCH__ \
             https://github.com/__REPO__.git "$workdir/provider"
-          make -C "$workdir/provider" build   # binary lands at the repo root — do NOT `make install`
+          make -C "$workdir/provider" build
 
           cat > "$workdir/dev.tfrc" <<EOF
           provider_installation {
@@ -1657,12 +1657,9 @@ jobs:
           }
 
           provider "latitudesh" {
-            project = "$LATITUDESH_PROJECT"
+            project = "$TF_VAR_project"
           }
           EOF
-          # This PR's example, inlined so you can adjust names and values before
-          # applying. It is gate-enforced to be self-contained; it may declare
-          # helper resources it depends on, and apply creates those too.
           cat > main.tf <<'TF_EXAMPLE_EOF_9f3a'
           MANUAL_EOF
             # The example ships inline in the snippet — the reviewer should see and
@@ -1683,7 +1680,7 @@ jobs:
             cat <<'MANUAL_EOF'
           TF_EXAMPLE_EOF_9f3a
 
-          terraform plan     # dev_overrides active: no init needed; expect the overrides warning
+          terraform plan
           terraform apply
           terraform state show "$(terraform state list | head -1)"
           terraform destroy

--- a/sdk-coverage.yaml
+++ b/sdk-coverage.yaml
@@ -148,6 +148,45 @@ groups:
 
   # --------------------------------------------------------------- excluded ---
 
+  BaselinesPreview:
+    ceiling: none
+    rationale: product_decision
+    notes: >-
+      Baselines is still under active development and its preview API is not
+      stable, so scaffolding against it now would only churn. Revisit once the
+      product ships.
+
+  BlockStorage:
+    ceiling: none
+    rationale: product_decision
+    notes: >-
+      Volume creation is paused on the platform right now, so a scaffolded
+      resource nobody can apply would only add review load. Revisit when creation
+      reopens. Shape context for that day: methods are HTTP-verb prefixed
+      (PostStorageVolumes, DeleteStorageVolumes), DeleteStorageVolumes deletes a
+      single volume despite the plural, and the API has no volume update, so the
+      CR-D shape is real and not a spec gap.
+
+  FilesystemStorage:
+    ceiling: none
+    rationale: product_decision
+    notes: >-
+      Filesystem storage is gated — a customer has to request access before it
+      can be created — so it is not a general Terraform surface yet. Revisit if it
+      becomes generally available. Shape context: the API genuinely has no
+      single-item read (confirmed against the routes), so import support would
+      need thought — an API limitation, not a spec gap.
+
+  KubernetesClusters:
+    ceiling: none
+    rationale: deprecated
+    notes: >-
+      Managed Kubernetes is being deprecated, so we are not adding Terraform
+      support for it. Shape context: kubeconfig retrieval and available-version
+      listing would each likely want their own data source, and
+      GET /kubernetes_clusters/plans exists in the API but is absent from the
+      spec, so the SDK has no method for it.
+
   Projects.SSHKeys:
     ceiling: none
     rationale: deprecated
@@ -182,23 +221,6 @@ groups:
       sub-resource, a metrics endpoint, and a bucket-exists check. Scoped
       previously as PD-6063 and paused pending storage-team spec fixes. Expect the
       generated resource to lack update support it could have had.
-
-  BlockStorage:
-    notes: >-
-      Methods are HTTP-verb prefixed (PostStorageVolumes, DeleteStorageVolumes) and
-      DeleteStorageVolumes deletes a single volume despite the plural. The API has
-      no volume update, so the CR-D shape is real and not a spec gap.
-
-  FilesystemStorage:
-    notes: >-
-      The API genuinely has no single-item read (confirmed against the routes), so
-      import support needs thought — an API limitation, not a spec gap.
-
-  KubernetesClusters:
-    notes: >-
-      Kubeconfig retrieval and available-version listing would likely want data
-      sources of their own. GET /kubernetes_clusters/plans exists in the API but is
-      absent from the spec, so the SDK has no method for it.
 
   VirtualMachineBackups:
     notes: >-


### PR DESCRIPTION
### Summary

Two related maintenance changes to the SDK scaffolding pipeline.

**1. Stop scaffolding four SDK groups.** Move them to the `excluded` section of `sdk-coverage.yaml` with a `ceiling: none` and a rationale, so the sdk-watch workflow no longer opens draft PRs for them:

| Group | rationale | Why |
|---|---|---|
| `BlockStorage` | `product_decision` | Volume creation is paused on the platform — a resource nobody can apply only adds review load. Revisit when it reopens. |
| `FilesystemStorage` | `product_decision` | Gated behind an access request, so not a general Terraform surface yet. |
| `BaselinesPreview` | `product_decision` | Still under active development; the preview API is not stable. |
| `KubernetesClusters` | `deprecated` | Managed Kubernetes is being deprecated. |

`product_decision` (never auto-revisited by the gate) is used for the three temporary pauses, each with a "revisit when…" note; `deprecated` for Kubernetes. The existing shape context was preserved in each note.

**2. Fix the generated-PR "Manual validation" snippet** (`sdk-watch.yml`):
- The exported project never reached the applied config: the snippet exported `LATITUDESH_PROJECT` (only the provider default), but the inlined example declares `variable "project" { default = "proj_..." }` and uses `project = var.project`, which shadowed it. Switched to `export TF_VAR_project=...` so Terraform populates the example's `project` variable (overriding the placeholder default); the provider block uses the same value.
- Removed inline comments from the copy-paste `bash` block (they cluttered paste) and moved the essential guidance into the step-3 prose.

### Testing

```bash
go test ./latitudesh -run TestProviderSDKCoverage
go run ./cmd/sdkcoverage report   # 4 groups now under "Excluded", none in "pending"
```


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates SDK scaffolding maintenance behavior and its generated manual-validation instructions.
- Excludes four paused, gated, unstable, or deprecated SDK groups from automatic scaffolding.
- Passes the selected test project through `TF_VAR_project` so the inlined Terraform example and provider configuration use the same value.
- Moves explanatory guidance outside the copy-paste shell block.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The workflow now consistently supplies the selected project to both Terraform’s project variable and the provider block, while the four manifest entries use valid exclusion metadata with the intended non-automatic revisit behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk-watch): populate example project..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/fc4d69319fc7a32fad982c2ef511735ec0493d19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58696009)</sub>

<!-- /greptile_comment -->