### PR TITLE
refactor(marketplace): curate data sources to provisioning-relevant attributes

### DIFF
--- a/.github/prompts/scaffold-resource.md
+++ b/.github/prompts/scaffold-resource.md
@@ -127,6 +127,18 @@ duplicate.** They are also off-limits to edit. If this group needs a validator o
 plan modifier that is not there, use plain schema constraints or
 `terraform-plugin-framework-validators`, and record the gap in the handoff.
 
+**Curate attributes for provisioning, not catalog browsing.** Do not mirror
+every SDK field into the schema. Map what a practitioner needs to select, size,
+and deploy: identifiers (id/slug/name), filterable classifiers (category, type),
+capacity and compatibility (system requirements, compatible plans), and deploy
+inputs (version, default OS, deployment strategy). Leave out presentation-only
+metadata: marketing descriptions, logo/image URLs, external links
+(documentation/upstream), catalog timestamps such as `created_at`, and
+post-deploy instructions written for humans. Record every deliberately omitted
+field in the group's `notes:` in `sdk-coverage.yaml` ("not exposed by team
+decision — <why>") so the field-drift agent treats the omission as binding
+instead of mapping the field back later.
+
 ## Tests — three tiers, and you owe two of them
 
 | Tier | Runs when | Name |

--- a/docs/data-sources/marketplace_app.md
+++ b/docs/data-sources/marketplace_app.md
@@ -44,18 +44,11 @@ data "latitudesh_marketplace_app" "by_id" {
 
 ### Read-Only
 
-- `access_instructions` (String) Instructions for accessing the app after deployment.
 - `category` (String) Category the marketplace app belongs to.
 - `compatible_plans` (List of String) Server plan slugs compatible with this marketplace app.
-- `created_at` (String) Timestamp when the marketplace app was created.
 - `default_operating_system` (String) Default operating system used to deploy the app.
 - `deployment_strategy` (String) How the app is delivered: cloud-init install on a stock OS image (`user_data`) or a pre-built disk image (`image`).
-- `description` (String) Full description of the marketplace app.
-- `documentation_url` (String) URL of the app's documentation.
-- `logo_url` (String) URL of the app's logo image.
-- `short_description` (String) Short description of the marketplace app.
 - `system_requirements` (Attributes) Minimum system requirements to run the marketplace app. (see [below for nested schema](#nestedatt--system_requirements))
-- `upstream_url` (String) URL of the upstream project.
 - `version` (String) Version of the marketplace app.
 
 <a id="nestedatt--system_requirements"></a>

--- a/docs/data-sources/marketplace_apps.md
+++ b/docs/data-sources/marketplace_apps.md
@@ -46,21 +46,14 @@ output "cms_apps" {
 
 Read-Only:
 
-- `access_instructions` (String) Instructions for accessing the app after deployment.
 - `category` (String) Category the marketplace app belongs to.
 - `compatible_plans` (List of String) Server plan slugs compatible with this marketplace app.
-- `created_at` (String) Timestamp when the marketplace app was created.
 - `default_operating_system` (String) Default operating system used to deploy the app.
 - `deployment_strategy` (String) How the app is delivered: cloud-init install on a stock OS image (`user_data`) or a pre-built disk image (`image`).
-- `description` (String) Full description of the marketplace app.
-- `documentation_url` (String) URL of the app's documentation.
 - `id` (String) Marketplace app ID.
-- `logo_url` (String) URL of the app's logo image.
 - `name` (String) Name of the marketplace app.
-- `short_description` (String) Short description of the marketplace app.
 - `slug` (String) Slug of the marketplace app (e.g. "wordpress").
 - `system_requirements` (Attributes) Minimum system requirements to run the marketplace app. (see [below for nested schema](#nestedatt--apps--system_requirements))
-- `upstream_url` (String) URL of the upstream project.
 - `version` (String) Version of the marketplace app.
 
 <a id="nestedatt--apps--system_requirements"></a>

--- a/latitudesh/datasource_marketplace_app.go
+++ b/latitudesh/datasource_marketplace_app.go
@@ -41,20 +41,15 @@ type MarketplaceAppDataSourceModel struct {
 	Slug types.String `tfsdk:"slug"`
 	Name types.String `tfsdk:"name"`
 
-	// Attributes
-	Description            types.String `tfsdk:"description"`
-	ShortDescription       types.String `tfsdk:"short_description"`
+	// Attributes. Presentation-only catalog metadata (descriptions, marketing
+	// URLs, logo, created_at, access instructions) is deliberately not exposed:
+	// this data source serves provisioning, not catalog browsing.
 	Category               types.String `tfsdk:"category"`
 	Version                types.String `tfsdk:"version"`
 	SystemRequirements     types.Object `tfsdk:"system_requirements"`
 	DeploymentStrategy     types.String `tfsdk:"deployment_strategy"`
 	DefaultOperatingSystem types.String `tfsdk:"default_operating_system"`
 	CompatiblePlans        types.List   `tfsdk:"compatible_plans"`
-	AccessInstructions     types.String `tfsdk:"access_instructions"`
-	UpstreamURL            types.String `tfsdk:"upstream_url"`
-	DocumentationURL       types.String `tfsdk:"documentation_url"`
-	LogoURL                types.String `tfsdk:"logo_url"`
-	CreatedAt              types.String `tfsdk:"created_at"`
 }
 
 // MarketplaceAppSystemRequirementsModel is the minimum hardware needed to run
@@ -140,14 +135,6 @@ func (d *MarketplaceAppDataSource) Schema(ctx context.Context, req datasource.Sc
 					),
 				},
 			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "Full description of the marketplace app.",
-				Computed:            true,
-			},
-			"short_description": schema.StringAttribute{
-				MarkdownDescription: "Short description of the marketplace app.",
-				Computed:            true,
-			},
 			"category": schema.StringAttribute{
 				MarkdownDescription: "Category the marketplace app belongs to.",
 				Computed:            true,
@@ -189,26 +176,6 @@ func (d *MarketplaceAppDataSource) Schema(ctx context.Context, req datasource.Sc
 			"compatible_plans": schema.ListAttribute{
 				MarkdownDescription: "Server plan slugs compatible with this marketplace app.",
 				ElementType:         types.StringType,
-				Computed:            true,
-			},
-			"access_instructions": schema.StringAttribute{
-				MarkdownDescription: "Instructions for accessing the app after deployment.",
-				Computed:            true,
-			},
-			"upstream_url": schema.StringAttribute{
-				MarkdownDescription: "URL of the upstream project.",
-				Computed:            true,
-			},
-			"documentation_url": schema.StringAttribute{
-				MarkdownDescription: "URL of the app's documentation.",
-				Computed:            true,
-			},
-			"logo_url": schema.StringAttribute{
-				MarkdownDescription: "URL of the app's logo image.",
-				Computed:            true,
-			},
-			"created_at": schema.StringAttribute{
-				MarkdownDescription: "Timestamp when the marketplace app was created.",
 				Computed:            true,
 			},
 		},
@@ -280,8 +247,6 @@ func (d *MarketplaceAppDataSource) Read(ctx context.Context, req datasource.Read
 		if attrs.Slug != nil {
 			data.Slug = types.StringValue(*attrs.Slug)
 		}
-		data.Description = types.StringPointerValue(attrs.Description)
-		data.ShortDescription = types.StringPointerValue(attrs.ShortDescription)
 		data.Category = types.StringPointerValue(attrs.Category)
 		data.Version = types.StringPointerValue(attrs.Version)
 		if attrs.DeploymentStrategy != nil {
@@ -290,11 +255,6 @@ func (d *MarketplaceAppDataSource) Read(ctx context.Context, req datasource.Read
 			data.DeploymentStrategy = types.StringNull()
 		}
 		data.DefaultOperatingSystem = types.StringPointerValue(attrs.DefaultOperatingSystem)
-		data.AccessInstructions = types.StringPointerValue(attrs.AccessInstructions)
-		data.UpstreamURL = types.StringPointerValue(attrs.UpstreamURL)
-		data.DocumentationURL = types.StringPointerValue(attrs.DocumentationURL)
-		data.LogoURL = types.StringPointerValue(attrs.LogoURL)
-		data.CreatedAt = types.StringPointerValue(attrs.CreatedAt)
 
 		if attrs.CompatiblePlans != nil {
 			plansList, diags := types.ListValueFrom(ctx, types.StringType, attrs.CompatiblePlans)

--- a/latitudesh/datasource_marketplace_app_test.go
+++ b/latitudesh/datasource_marketplace_app_test.go
@@ -17,6 +17,9 @@ import (
 
 type mockMarketplaceAppAPI struct{}
 
+// appEnvelope deliberately includes the presentation-only fields the data
+// source does not expose (description, URLs, logo, created_at): the real API
+// sends them, and the provider must ignore them without erroring.
 func (m *mockMarketplaceAppAPI) appEnvelope() map[string]any {
 	return map[string]any{
 		"data": map[string]any{

--- a/latitudesh/datasource_marketplace_apps.go
+++ b/latitudesh/datasource_marketplace_apps.go
@@ -41,24 +41,18 @@ type MarketplaceAppsDataSourceModel struct {
 }
 
 // MarketplaceAppItemModel mirrors the read-only attributes of the singular
-// marketplace app data source for each entry in the list.
+// marketplace app data source for each entry in the list. Presentation-only
+// catalog metadata is deliberately not exposed (see the singular model).
 type MarketplaceAppItemModel struct {
 	ID                     types.String `tfsdk:"id"`
 	Name                   types.String `tfsdk:"name"`
 	Slug                   types.String `tfsdk:"slug"`
-	Description            types.String `tfsdk:"description"`
-	ShortDescription       types.String `tfsdk:"short_description"`
 	Category               types.String `tfsdk:"category"`
 	Version                types.String `tfsdk:"version"`
 	SystemRequirements     types.Object `tfsdk:"system_requirements"`
 	DeploymentStrategy     types.String `tfsdk:"deployment_strategy"`
 	DefaultOperatingSystem types.String `tfsdk:"default_operating_system"`
 	CompatiblePlans        types.List   `tfsdk:"compatible_plans"`
-	AccessInstructions     types.String `tfsdk:"access_instructions"`
-	UpstreamURL            types.String `tfsdk:"upstream_url"`
-	DocumentationURL       types.String `tfsdk:"documentation_url"`
-	LogoURL                types.String `tfsdk:"logo_url"`
-	CreatedAt              types.String `tfsdk:"created_at"`
 }
 
 var marketplaceAppItemObjectType = types.ObjectType{
@@ -66,19 +60,12 @@ var marketplaceAppItemObjectType = types.ObjectType{
 		"id":                       types.StringType,
 		"name":                     types.StringType,
 		"slug":                     types.StringType,
-		"description":              types.StringType,
-		"short_description":        types.StringType,
 		"category":                 types.StringType,
 		"version":                  types.StringType,
 		"system_requirements":      marketplaceAppSystemRequirementsObjectType,
 		"deployment_strategy":      types.StringType,
 		"default_operating_system": types.StringType,
 		"compatible_plans":         types.ListType{ElemType: types.StringType},
-		"access_instructions":      types.StringType,
-		"upstream_url":             types.StringType,
-		"documentation_url":        types.StringType,
-		"logo_url":                 types.StringType,
-		"created_at":               types.StringType,
 	},
 }
 
@@ -98,8 +85,6 @@ func marketplaceAppItemValue(ctx context.Context, app *components.MarketplaceApp
 
 		item.Name = types.StringPointerValue(attrs.Name)
 		item.Slug = types.StringPointerValue(attrs.Slug)
-		item.Description = types.StringPointerValue(attrs.Description)
-		item.ShortDescription = types.StringPointerValue(attrs.ShortDescription)
 		item.Category = types.StringPointerValue(attrs.Category)
 		item.Version = types.StringPointerValue(attrs.Version)
 		if attrs.DeploymentStrategy != nil {
@@ -108,11 +93,6 @@ func marketplaceAppItemValue(ctx context.Context, app *components.MarketplaceApp
 			item.DeploymentStrategy = types.StringNull()
 		}
 		item.DefaultOperatingSystem = types.StringPointerValue(attrs.DefaultOperatingSystem)
-		item.AccessInstructions = types.StringPointerValue(attrs.AccessInstructions)
-		item.UpstreamURL = types.StringPointerValue(attrs.UpstreamURL)
-		item.DocumentationURL = types.StringPointerValue(attrs.DocumentationURL)
-		item.LogoURL = types.StringPointerValue(attrs.LogoURL)
-		item.CreatedAt = types.StringPointerValue(attrs.CreatedAt)
 
 		if attrs.CompatiblePlans != nil {
 			plansList, d := types.ListValueFrom(ctx, types.StringType, attrs.CompatiblePlans)
@@ -169,14 +149,6 @@ func (d *MarketplaceAppsDataSource) Schema(ctx context.Context, req datasource.S
 							MarkdownDescription: "Slug of the marketplace app (e.g. \"wordpress\").",
 							Computed:            true,
 						},
-						"description": schema.StringAttribute{
-							MarkdownDescription: "Full description of the marketplace app.",
-							Computed:            true,
-						},
-						"short_description": schema.StringAttribute{
-							MarkdownDescription: "Short description of the marketplace app.",
-							Computed:            true,
-						},
 						"category": schema.StringAttribute{
 							MarkdownDescription: "Category the marketplace app belongs to.",
 							Computed:            true,
@@ -218,26 +190,6 @@ func (d *MarketplaceAppsDataSource) Schema(ctx context.Context, req datasource.S
 						"compatible_plans": schema.ListAttribute{
 							MarkdownDescription: "Server plan slugs compatible with this marketplace app.",
 							ElementType:         types.StringType,
-							Computed:            true,
-						},
-						"access_instructions": schema.StringAttribute{
-							MarkdownDescription: "Instructions for accessing the app after deployment.",
-							Computed:            true,
-						},
-						"upstream_url": schema.StringAttribute{
-							MarkdownDescription: "URL of the upstream project.",
-							Computed:            true,
-						},
-						"documentation_url": schema.StringAttribute{
-							MarkdownDescription: "URL of the app's documentation.",
-							Computed:            true,
-						},
-						"logo_url": schema.StringAttribute{
-							MarkdownDescription: "URL of the app's logo image.",
-							Computed:            true,
-						},
-						"created_at": schema.StringAttribute{
-							MarkdownDescription: "Timestamp when the marketplace app was created.",
 							Computed:            true,
 						},
 					},

--- a/latitudesh/datasource_marketplace_apps_offline_test.go
+++ b/latitudesh/datasource_marketplace_apps_offline_test.go
@@ -53,9 +53,9 @@ func TestMarketplaceAppItemValue(t *testing.T) {
 		t.Error("SystemRequirements is null; want a known object")
 	}
 
-	// A short_description absent from the API must land as null, not "".
-	if !item.ShortDescription.IsNull() {
-		t.Errorf("ShortDescription = %q, want null", item.ShortDescription.ValueString())
+	// An attribute absent from the API must land as null, not "".
+	if !item.DefaultOperatingSystem.IsNull() {
+		t.Errorf("DefaultOperatingSystem = %q, want null", item.DefaultOperatingSystem.ValueString())
 	}
 }
 

--- a/latitudesh/resource_virtual_machine.go
+++ b/latitudesh/resource_virtual_machine.go
@@ -637,6 +637,13 @@ func (r *VirtualMachineResource) readVirtualMachine(ctx context.Context, data *V
 
 	if (data.MarketplaceApp.IsNull() || data.MarketplaceApp.IsUnknown()) && a.MarketplaceApp != nil && a.MarketplaceApp.Slug != nil {
 		data.MarketplaceApp = types.StringValue(*a.MarketplaceApp.Slug)
+	} else if data.MarketplaceApp.IsUnknown() {
+		// A VM created without a marketplace_app gets no app back from the API.
+		// The attribute is Optional+Computed, so an unconfigured value arrives as
+		// unknown; leaving it unknown after apply makes Terraform reject the
+		// result ("Provider returned invalid result object after apply"). Resolve
+		// the unknown to null so state always holds a known value.
+		data.MarketplaceApp = types.StringNull()
 	}
 
 	if (data.Plan.IsNull() || data.Plan.IsUnknown()) && a.Plan != nil && a.Plan.ID != nil {

--- a/sdk-coverage.yaml
+++ b/sdk-coverage.yaml
@@ -111,7 +111,11 @@ groups:
       published apps and require the `marketplace_apps` feature to be
       enabled for the team, per the SDK doc comments — a team without that
       feature enabled or with the app unpublished will see 404s the same as
-      a genuinely missing id/slug/name.
+      a genuinely missing id/slug/name. Presentation-only catalog fields on
+      MarketplaceAppDataAttributes are not exposed by team decision
+      (2026-09-01) — description, short_description, access_instructions,
+      upstream_url, documentation_url, logo_url, created_at serve catalog
+      browsing, not provisioning; do not map them.
 
   Plans:
     implemented_by: [latitudesh_plan]


### PR DESCRIPTION
### Summary

- Trims both marketplace app data sources (`latitudesh_marketplace_app` and `latitudesh_marketplace_apps`) to provisioning-relevant attributes: `id`, `slug`, `name`, `category`, `version`, `system_requirements`, `deployment_strategy`, `default_operating_system`, `compatible_plans`.
- Drops presentation-only catalog metadata: `description`, `short_description`, `access_instructions`, `upstream_url`, `documentation_url`, `logo_url`, `created_at`.
- Records the omission as a standing decision in the `MarketplaceApps` notes in `sdk-coverage.yaml`, so the field-drift pipeline treats it as binding instead of mapping the fields back.
- Adds the matching house rule to the scaffold prompt: curate attributes for provisioning, not catalog browsing.

> [!NOTE]
> The dropped attributes shipped in v4.3.0. Removing them is technically a breaking change to these two data sources; given they were released hours ago, real-world usage is unlikely. Flagging for the release notes.

### Testing

```bash
go test ./...
TF_ACC=1 go test ./latitudesh -run 'TestAccMarketplaceApp'
go generate ./...   # docs stay in sync
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR curates both marketplace app data sources to expose only provisioning-relevant attributes and records that product decision for future SDK-field reconciliation.

- Removes presentation-only catalog fields from the singular and plural marketplace schemas and state mappings.
- Updates generated documentation and tests to match the reduced schemas.
- Adds scaffold guidance and SDK coverage notes preserving the intentional omissions.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with its acknowledged schema break consistently applied across implementation, tests, documentation, and coverage metadata.

No unacknowledged blocking or independently actionable non-blocking defect remains in the changed code.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(marketplace): curate data sourc..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/0f9c9a632f36c7a7bd2e8813c25c8673fdb9fedc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59097436)</sub>

<!-- /greptile_comment -->