### PR TITLE
fix(sdk-watch): give the scaffold agent a scoped delete to recover from mis-named files

### DIFF
--- a/.github/prompts/fix-field-drift.md
+++ b/.github/prompts/fix-field-drift.md
@@ -116,6 +116,11 @@ resource — name it in the handoff and in `notes:` under `{{GROUP}}` in
   `examples/**`, `docs/**` — plus `/tmp/drift-handoff.md`, the one write allowed
   outside the repository. Not `go.mod`, not `cmd/`, not `internal/`, not
   `.github/`.
+- If you `Write` a Go file to the wrong path — a mis-named or stray
+  `latitudesh/*.go` not matching the list above — delete it with
+  `scripts/scaffold-rm.sh latitudesh/<name>.go`. That is the **only** way to
+  remove a file: `Write`/`Edit`/`MultiEdit` cannot, and a leftover out-of-scope
+  file fails the gate. Never leave a "delete before merge" stub behind.
 - Sync the lock **only** with
   `go run ./cmd/sdkcoverage fields -write -group {{GROUP}}` — never hand-edit
   it, and never a full `fields -write`: that would silently accept every other

--- a/.github/prompts/scaffold-resource.md
+++ b/.github/prompts/scaffold-resource.md
@@ -189,6 +189,12 @@ Do not run acceptance tests and do not record cassettes. Cassettes live in
   `latitudesh/provider.go`, `sdk-coverage.yaml`, `templates/**`, `examples/**`, `docs/**` —
   plus the handoff file `/tmp/scaffold-handoff.md`, which is the one write allowed
   outside the repository. Not `go.mod`, not `cmd/`, not `internal/`, not `.github/`.
+- If you `Write` a Go file to the wrong path — a mis-named or stray
+  `latitudesh/*.go` not matching the list above (e.g. `latitudesh/foo_mapping.go`
+  instead of `latitudesh/resource_foo_mapping.go`) — delete it with
+  `scripts/scaffold-rm.sh latitudesh/<name>.go`. That is the **only** way to remove
+  a file: `Write`/`Edit`/`MultiEdit` cannot, and a leftover out-of-scope file fails
+  the gate's first check. Never leave a "delete before merge" stub behind — fix it.
 - Never add a `go:generate` directive.
 - Never reach the network, provision infrastructure, run acceptance tests, or record cassettes.
 - Never write a token, key, or secret anywhere.

--- a/.github/workflows/sdk-watch.yml
+++ b/.github/workflows/sdk-watch.yml
@@ -696,11 +696,12 @@ jobs:
           github_token: ${{ github.token }}
           prompt: ${{ steps.render.outputs.prompt }}
           # Identical allowlist to scaffold: no gh, no git writes, no network,
-          # no free shell.
+          # no free shell — the one delete capability is the scoped
+          # scripts/scaffold-rm.sh, never a raw rm.
           claude_args: >-
             --model ${{ env.DRIFT_MODEL }}
             --max-turns ${{ env.DRIFT_MAX_TURNS }}
-            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*),Bash(scripts/scaffold-rm.sh:*)"
 
       - name: Report agent cost and stats
         id: cost
@@ -1328,11 +1329,14 @@ jobs:
           # The allowlist mirrors scripts/eval-scaffold.sh exactly — the eval is
           # only evidence about production if both grant the same tools. No gh,
           # no git writes, no network, no free shell: commits and the PR are made
-          # by the deterministic steps below, never by the agent.
+          # by the deterministic steps below, never by the agent. The one delete
+          # capability, scripts/scaffold-rm.sh, is a committed script that removes
+          # a single flat latitudesh/*.go file and nothing else — the recovery
+          # path when the agent Writes a file to the wrong name.
           claude_args: >-
             --model ${{ env.SCAFFOLD_MODEL }}
             --max-turns ${{ env.SCAFFOLD_MAX_TURNS }}
-            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*),Bash(scripts/scaffold-rm.sh:*)"
 
       # Cost and agent stats live HERE, in the run summary — deliberately not in
       # the PR body, which is the reviewer's surface, not the operator's.

--- a/scripts/eval-scaffold.sh
+++ b/scripts/eval-scaffold.sh
@@ -165,11 +165,11 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 # The tool allowlist mirrors what the scaffold job will grant: read/edit the tree,
-# and only the go/gofmt/jq/validation commands — no gh, no git writes, no arbitrary
-# shell. jq is needed by the prompt's step 0 (premise check pipes the JSON report
-# through it). The exact flag spellings track the installed claude CLI; adjust here
-# if your version differs.
-ALLOWED_TOOLS="Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*)"
+# and only the go/gofmt/jq/validation commands plus the scoped scaffold-rm.sh
+# delete helper — no gh, no git writes, no arbitrary shell. jq is needed by the
+# prompt's step 0 (premise check pipes the JSON report through it). The exact flag
+# spellings track the installed claude CLI; adjust here if your version differs.
+ALLOWED_TOOLS="Read,Glob,Grep,Edit,Write,MultiEdit,Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(go generate:*),Bash(go run ./cmd/sdkcoverage:*),Bash(jq:*),Bash(scripts/scaffold-validate.sh:*),Bash(scripts/scaffold-rm.sh:*)"
 
 echo
 echo "== running the agent (model=$MODEL, max-turns=$MAX_TURNS) =="

--- a/scripts/scaffold-rm.sh
+++ b/scripts/scaffold-rm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# scaffold-rm.sh — the ONLY delete capability the scaffolding agent is given.
+#
+# The agent writes files with Write/MultiEdit, which cannot delete. When it
+# writes a Go file to the wrong path (e.g. latitudesh/public_network_mapping.go,
+# missing the resource_ prefix) it has no way to undo the mistake: the failed
+# 2026-09-07 PublicNetworks run left a stray out-of-scope file that the diff-scope
+# gate then hard-rejected, after the agent burned turns fighting a sandbox with no
+# rm/mv/git rm. This script closes that trap with a single, tightly-scoped delete.
+#
+# It is exposed to the agent as `Bash(scripts/scaffold-rm.sh:*)`. That allowlist
+# entry is a loose string prefix and cannot confine a path on its own — a bare
+# `Bash(rm:*)` (or even `Bash(rm latitudesh/:*)`) would admit `rm latitudesh/../go.mod`,
+# `rm latitudesh/*`, or chained commands. Real path confinement has to be a
+# validation, so this script IS that validation: it accepts exactly one argument,
+# requires it to match an anchored allowlist, and refuses everything else. The
+# delete scope is deliberately the SAME shape the diff-scope gate accepts, so the
+# agent can only remove a file it would have been allowed to create.
+#
+# Usage:
+#   scripts/scaffold-rm.sh <latitudesh/NAME.go>
+#
+# Exit codes: 0 removed · 1 refused (out of scope / missing) · 2 usage error.
+#
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: scaffold-rm.sh <latitudesh/NAME.go>" >&2
+	exit 2
+fi
+p=$1
+
+# Reject nested paths before the regex: in a case pattern '*' spans '/', so this
+# catches latitudesh/sub/x.go (and thus any '../' escape) explicitly first.
+case "$p" in
+latitudesh/*/*)
+	echo "refused: nested path '$p' — only flat latitudesh/*.go files may be removed" >&2
+	exit 1
+	;;
+esac
+
+# Anchored allowlist: 'latitudesh/' + one or more [A-Za-z0-9_] + '.go'. The
+# character class admits no '.', '/', or whitespace, so '..', absolute paths,
+# subdirectories, globs (* ? [ ]), and command-chaining metacharacters are all
+# structurally impossible — the string is either a single flat Go file or it is
+# rejected.
+if ! printf '%s' "$p" | grep -Eq '^latitudesh/[A-Za-z0-9_]+\.go$'; then
+	echo "refused: '$p' is not a flat latitudesh/*.go file" >&2
+	exit 1
+fi
+
+# Must be a real regular file (not a symlink, dir, or already-gone path). The
+# stray file is untracked during the agent run — created by Write, never added —
+# so plain rm is correct here; git rm would fail on an untracked path. The '--'
+# stops the validated name from ever being read as an option.
+if [ ! -f "$p" ] || [ -L "$p" ]; then
+	echo "refused: '$p' is not an existing regular file" >&2
+	exit 1
+fi
+
+rm -f -- "$p"
+echo "removed $p"

--- a/scripts/scaffold-rm.sh
+++ b/scripts/scaffold-rm.sh
@@ -59,5 +59,17 @@ if [ ! -f "$p" ] || [ -L "$p" ]; then
 	exit 1
 fi
 
+# Only ever remove a file git does NOT track. The stray file is always untracked
+# — the agent just created it with Write and never committed it — so this costs
+# the real use case nothing, while it makes an erroneous call structurally unable
+# to delete a committed file. That matters because the pathname shape alone would
+# also admit an existing latitudesh/resource_*_test.go, whose deletion neither the
+# build nor `go test` would catch and the diff-scope gate (which accepts in-scope
+# deletions) would pass straight into the PR.
+if git ls-files --error-unmatch -- "$p" >/dev/null 2>&1; then
+	echo "refused: '$p' is tracked by git — this helper only removes stray untracked files" >&2
+	exit 1
+fi
+
 rm -f -- "$p"
 echo "removed $p"


### PR DESCRIPTION
### Summary

The scaffolding agent runs with an explicit tool allowlist that grants no way to
delete a file — `Write`/`Edit`/`MultiEdit` can only create or overwrite. When the
agent `Write`s a Go file to the wrong path, it cannot undo the mistake, and the
diff-scope gate (`scaffold-validate.sh`, step `1/9`) hard-rejects any out-of-scope
file, so the whole run fails before opening a PR.

This is exactly what killed the 2026-09-07 scheduled run (group `PublicNetworks`,
[run 34104443427](https://github.com/latitudesh/terraform-provider-latitudesh/actions/runs/34104443427)):
the agent wrote its helper as `latitudesh/public_network_mapping.go` (missing the
`resource_` prefix), re-created it correctly, then burned turns ($7.43, over the
$6 thrash watermark) fighting a sandbox with no `rm`/`git rm`/`git mv`, and finally
left a `STRAY FILE — DELETE BEFORE MERGE` stub the gate refused.

This PR gives the agent one tightly-scoped recovery path:

- **`scripts/scaffold-rm.sh`** — removes exactly one flat `latitudesh/*.go` file.
  An anchored regex (`^latitudesh/[A-Za-z0-9_]+\.go$`) makes path traversal, globs,
  absolute paths, subdirectories, and command chaining structurally impossible; it
  also refuses symlinks, missing files, and multi-arg calls. A raw `Bash(rm:*)`
  couldn't confine a path (prefix matching still admits `rm latitudesh/../go.mod`),
  which is why this is a committed script — the same idiom as `scaffold-validate.sh`.
- Wired into all **three** allowlists that must stay identical (`sdk-watch.yml`
  scaffold + drift steps, and `scripts/eval-scaffold.sh`, so the eval keeps
  reflecting production).
- Both prompt templates now instruct the agent to use it instead of leaving a stub.

The gate itself is unchanged: the stray file is deleted before it ever reaches the
diff.

### Testing

`scaffold-rm.sh` was exercised manually — all out-of-scope inputs (traversal, glob,
absolute path, subdir, symlink, multi-arg, command chaining, missing file) are
refused with a non-zero exit and nothing is deleted; a real
`latitudesh/*_mapping.go` file is removed on the happy path.

```bash
bash -n scripts/scaffold-rm.sh          # syntax
ruby -ryaml -e "YAML.load_file('.github/workflows/sdk-watch.yml')"  # workflow parses
```




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR gives the SDK scaffolding and drift agents a narrowly scoped recovery mechanism for deleting mistakenly named, untracked Go files.
- Adds `scripts/scaffold-rm.sh` with path, file-type, symlink, and tracked-file checks.
- Adds the helper to all three corresponding agent allowlists.
- Updates both agent prompts to direct recovery through the helper rather than leaving stray-file stubs.
- The change since the previous review prevents the helper from deleting files tracked by Git.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the tracked-file deletion issue from the previous review is fully fixed and no new actionable failures remain.

The helper validates a single flat Go-file path, rejects symlinks and non-files, and now checks that the target is untracked before deleting it. The earlier shell-chaining concern was correctly disputed and withdrawn, while the tracked-file concern is fully addressed by the new guard.
</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Agent creates misnamed Go file] --> B[Invoke scaffold-rm.sh]
  B --> C{Exactly one flat latitudesh/*.go path?}
  C -->|No| R[Refuse deletion]
  C -->|Yes| D{Regular file and not a symlink?}
  D -->|No| R
  D -->|Yes| E{Tracked by Git?}
  E -->|Yes| R
  E -->|No| F[Delete untracked stray file]
  F --> G[Diff-scope validation proceeds]
```

<sub>Reviews (2): Last reviewed commit: ["fix(sdk-watch): restrict scaffold-rm.sh ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/935adb6060f038d5a20a3d9272c1fa6f986cd4ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61649947)</sub>

<!-- /greptile_comment -->