### PR TITLE
feat(region): expose location features on the region data source

### DIFF
--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -31,3 +31,4 @@ data "latitudesh_region" "region" {
 - `city` (String) City name
 - `country` (String) Country name
 - `country_code` (String) Country code
+- `features` (List of String) Location capabilities available at this region (e.g. `public_network`, `elastic_ip_bgp`).

--- a/latitudesh/datasource_region.go
+++ b/latitudesh/datasource_region.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
@@ -30,6 +32,7 @@ type RegionDataSourceModel struct {
 	Country     types.String `tfsdk:"country"`
 	CountryCode types.String `tfsdk:"country_code"`
 	City        types.String `tfsdk:"city"`
+	Features    types.List   `tfsdk:"features"`
 }
 
 func (d *RegionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -65,6 +68,11 @@ func (d *RegionDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			},
 			"city": schema.StringAttribute{
 				MarkdownDescription: "City name",
+				Computed:            true,
+			},
+			"features": schema.ListAttribute{
+				MarkdownDescription: "Location capabilities available at this region (e.g. `public_network`, `elastic_ip_bgp`).",
+				ElementType:         types.StringType,
 				Computed:            true,
 			},
 		},
@@ -131,9 +139,10 @@ func (d *RegionDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 						region = &components.RegionData{
 							ID: r.ID,
 							Attributes: &components.RegionAttributes{
-								Name:    r.Attributes.Name,
-								Slug:    r.Attributes.Slug,
-								Country: regionCountry,
+								Name:     r.Attributes.Name,
+								Slug:     r.Attributes.Slug,
+								Country:  regionCountry,
+								Features: r.Attributes.Features,
 							},
 						}
 						break
@@ -156,15 +165,24 @@ func (d *RegionDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	d.mapRegionDataToModel(region, &data)
+	resp.Diagnostics.Append(d.mapRegionDataToModel(ctx, region, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (d *RegionDataSource) mapRegionDataToModel(region *components.RegionData, data *RegionDataSourceModel) {
+func (d *RegionDataSource) mapRegionDataToModel(ctx context.Context, region *components.RegionData, data *RegionDataSourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	if region.ID != nil {
 		data.ID = types.StringValue(*region.ID)
 	}
+
+	// Always expose a known list so consumers can index features even when the
+	// region reports no capabilities.
+	data.Features = types.ListValueMust(types.StringType, []attr.Value{})
 
 	if region.Attributes != nil {
 		if region.Attributes.Name != nil {
@@ -183,5 +201,15 @@ func (d *RegionDataSource) mapRegionDataToModel(region *components.RegionData, d
 				data.CountryCode = types.StringValue(*region.Attributes.Country.Slug)
 			}
 		}
+
+		if region.Attributes.Features != nil {
+			list, d := types.ListValueFrom(ctx, types.StringType, region.Attributes.Features)
+			diags.Append(d...)
+			if !diags.HasError() {
+				data.Features = list
+			}
+		}
 	}
+
+	return diags
 }

--- a/latitudesh/datasource_region_test.go
+++ b/latitudesh/datasource_region_test.go
@@ -27,6 +27,8 @@ func TestAccRegion_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.latitudesh_region.test", "slug", testRegionSlug),
+					resource.TestCheckResourceAttrSet(
+						"data.latitudesh_region.test", "features.#"),
 				),
 			},
 			{

--- a/latitudesh/datasource_region_test.go
+++ b/latitudesh/datasource_region_test.go
@@ -23,19 +23,44 @@ func TestAccRegion_Basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVCR(recorder),
 		Steps: []resource.TestStep{
 			{
+				// Slug lookup for a region that reports capabilities: exercises
+				// the paginated list path and the features conversion.
 				Config: testAccCheckRegionBasic(testRegionSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.latitudesh_region.test", "slug", testRegionSlug),
-					resource.TestCheckResourceAttrSet(
-						"data.latitudesh_region.test", "features.#"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.0", "public_network"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.1", "elastic_ip_bgp"),
 				),
 			},
 			{
+				// Slug lookup for a region with no capabilities: features must
+				// resolve to a known empty list rather than null.
 				Config: testAccCheckRegionBasic("NYC"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.latitudesh_region.test", "slug", "NYC"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.#", "0"),
+				),
+			},
+			{
+				// ID lookup: exercises the Fetch path and confirms features are
+				// mapped there too.
+				Config: testAccCheckRegionByID("reg_ash_001"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "slug", testRegionSlug),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.0", "public_network"),
+					resource.TestCheckResourceAttr(
+						"data.latitudesh_region.test", "features.1", "elastic_ip_bgp"),
 				),
 			},
 		},
@@ -49,5 +74,15 @@ data "latitudesh_region" "test" {
 }
 `,
 		slug,
+	)
+}
+
+func testAccCheckRegionByID(id string) string {
+	return fmt.Sprintf(`
+data "latitudesh_region" "test" {
+	id = "%s"
+}
+`,
+		id,
 	)
 }

--- a/latitudesh/fixtures/TestAccRegion_Basic.yaml
+++ b/latitudesh/fixtures/TestAccRegion_Basic.yaml
@@ -33,7 +33,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -72,7 +72,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -111,7 +111,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -150,7 +150,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -189,7 +189,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -228,7 +228,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -267,7 +267,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -306,7 +306,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -345,7 +345,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -384,7 +384,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        body: '{"data":[{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}],"meta":{}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8
@@ -775,6 +775,396 @@ interactions:
         content_length: -1
         uncompressed: true
         body: '{"data":[{"id":"reg_nyc_001","type":"regions","attributes":{"slug":"NYC","name":"New York City","country":{"slug":"US","name":"United States"}}}],"meta":{}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
+        headers:
+            Content-Type:
+                - application/vnd.api+json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 150ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.latitude.sh
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.api+json
+            Api-Version:
+                - "2023-06-01"
+            Authorization:
+                - '[REDACTED]'
+            User-Agent:
+                - Latitude-Terraform-Provider/dev
+        url: https://api.latitude.sh/regions/reg_ash_001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"data":{"id":"reg_ash_001","type":"regions","attributes":{"slug":"ASH","name":"Ashburn","country":{"slug":"US","name":"United States"},"features":["public_network","elastic_ip_bgp"]}}}'
         headers:
             Content-Type:
                 - application/vnd.api+json; charset=utf-8


### PR DESCRIPTION
### Summary

Expose a new `features` attribute (list of strings) on the `latitudesh_region` data source. It surfaces the location capabilities the API reports per region — e.g. `public_network`, `elastic_ip_bgp` — so a configuration can gate resources like `latitudesh_public_network` on whether the target region actually supports them.

- Populated on both lookup paths (`id` via `Regions.Fetch`, `slug` via the paginated `Regions.Get`). The slug path rebuilds the region object manually, so `features` is copied there too.
- Always resolves to a known list: a region with no capabilities yields `[]` (indexable) rather than `null`.
- Docs regenerated via `go generate ./...`.

Scope is intentionally limited to `features`; `network_group` (also newly emitted by the API) is deferred.

### Testing

```bash
go build ./...
go vet ./latitudesh/
TF_ACC=1 LATITUDESH_AUTH_TOKEN=dummy LATITUDE_TEST_RECORDER=play go test ./latitudesh -run TestAccRegion_Basic -v
```

The acceptance test replays the existing VCR cassette and passes; the empty-list default keeps it green even though the recorded fixture predates the `features` field.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63089946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable new defects or outstanding findings remain.

<details><summary><h3>Summary</h3></summary>

- Maps features from paginated slug lookups and direct ID lookups.
- Returns a known empty list when the API omits capabilities.
- Updates generated documentation and replay fixtures.
- Adds assertions for non-empty, empty, slug-based, and ID-based feature mapping.
</details>

<h3>Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Region data source] --> B{Lookup selector}
    B -->|slug| C[Regions.Get]
    B -->|id| D[Regions.Fetch]
    C --> E[RegionAttributes.Features]
    D --> E
    E --> F[Terraform list of strings]
    E -->|missing or nil| G[Known empty list]
```

<sub>Reviews (2) · Last reviewed commit: ["test(region): cover features mapping on ..."](https://github.com/latitudesh/terraform-provider-latitudesh/commit/62c860c0833194ca22754ef34ba8e30c8a36062f)</sub>

<!-- /greptile_comment -->